### PR TITLE
Fix of retrieve articles and retrieve articles for all identities

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -262,15 +262,19 @@ public class ReCiterController {
 	public ResponseEntity retrieveArticles() {
 		long startTime = System.currentTimeMillis();
 		slf4jLogger.info("Start time is: " + startTime);
-		List<Identity> identities = new ArrayList<>();
 		LocalDate initial = LocalDate.now();
+		
 		LocalDate startDate = initial.withDayOfMonth(1);
 		LocalDate endDate = initial.withDayOfMonth(initial.lengthOfMonth());
-		for (String uid : Uids.uids) {
+		/* Commented hard coded uids
+		    List<Identity> identities = new ArrayList<Identity>();
+		 	for (String uid : Uids.uids) {
 			slf4jLogger.info("Retrieving uid {}.", uid);
 			Identity identity = identityService.findByUid(uid);
 			identities.add(identity);
-		}
+		}*/
+		
+		List<Identity> identities =  identityService.findAll();
 		try {
 			aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate));
 		} catch (IOException e) {

--- a/src/main/java/reciter/scopus/retriever/ScopusArticleRetriever.java
+++ b/src/main/java/reciter/scopus/retriever/ScopusArticleRetriever.java
@@ -54,7 +54,7 @@ public class ScopusArticleRetriever<T> {
         if (queryParams.isEmpty()) {
             return Collections.emptyList();
         }
-        String nodeUrl = SCOPUS_SERVICE + "/query/";
+        String nodeUrl = SCOPUS_SERVICE + "/scopus/query/";
         RestTemplate restTemplate = new RestTemplate();
         log.info("Sending web request for query " + queryParams + " modifier:" + queryModifier + ":" + nodeUrl);
         List<Object> pmidList = new ArrayList<>();


### PR DESCRIPTION
This PR addresses two changes -

1.  Fix of retrieve articles which was not working as the scopus retrieval service uri being use was the incorrect one.
2.  The retrieveArticlesByUid api was using hard coded list of identities to import. That was changed to retrieve for identities in identity table in dynamo db.