### PR TITLE
Refactor clustering strategy & fix with name scoring strategy name variants in identity

### DIFF
--- a/src/main/java/reciter/algorithm/cluster/similarity/clusteringstrategy/article/GrantFeatureClusteringStrategy.java
+++ b/src/main/java/reciter/algorithm/cluster/similarity/clusteringstrategy/article/GrantFeatureClusteringStrategy.java
@@ -14,9 +14,12 @@ import reciter.model.article.ReCiterArticle;
 import reciter.model.article.ReCiterArticleGrant;
 
 /**
- * @author szd2013
+ * @author <b>Sarbajit Dutta(szd2013)</b>
+ * 
+ * @description:
  * This class parses NIH grant identifiers for all articles in a standardized logic of Funding Agency-4 to 6 digit grant code. Then matches and form clusters.
- * It also checks for transitive property matches as well.
+ * It also checks for transitive property matches as well. 
+ * For full details refer to https://github.com/wcmc-its/ReCiter/issues/217 section 4. - Feature: grant identifiers.
  */
 public class GrantFeatureClusteringStrategy extends AbstractClusteringStrategy {
 	

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/name/strategy/ScoreByNameStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/name/strategy/ScoreByNameStrategy.java
@@ -829,7 +829,13 @@ public class ScoreByNameStrategy extends AbstractTargetAuthorStrategy {
 				if(i==j) {
 					continue;
 				}
-				if(idenityAuthorNames.get(i) != null && idenityAuthorNames.get(j) != null) {
+				if(idenityAuthorNames.size() > 1 
+						&&
+						idenityAuthorNames.size() -1 >= i
+						&&
+						idenityAuthorNames.size() - 1 >= j
+						&&
+						idenityAuthorNames.get(i) != null && idenityAuthorNames.get(j) != null) {
 					if(StringUtils.equalsIgnoreCase(idenityAuthorNames.get(i).getLastName(), idenityAuthorNames.get(j).getLastName()) && 
 							idenityAuthorNames.get(i).getFirstName().startsWith(idenityAuthorNames.get(j).getFirstName())) {
 						if(idenityAuthorNames.get(j).getMiddleName() == null) {

--- a/src/main/java/reciter/engine/ReCiterEngine.java
+++ b/src/main/java/reciter/engine/ReCiterEngine.java
@@ -71,6 +71,8 @@ public class ReCiterEngine implements Engine {
 	
 	public static double clusterSimilarityThresholdScore;
 	
+	public static double clutseringGrantsThreshold;
+	
 	@Override
 	public List<Feature> generateFeature(EngineParameters parameters) {
 		
@@ -127,6 +129,7 @@ public class ReCiterEngine implements Engine {
 		List<PubMedArticle> pubMedArticles = parameters.getPubMedArticles();
 		List<ScopusArticle> scopusArticles = parameters.getScopusArticles();
 		clusterSimilarityThresholdScore = strategyParameters.getClusterSimilarityThresholdScore();
+		clutseringGrantsThreshold = strategyParameters.getClusteringGrantsThreshold();
 		
 		Map<Long, ScopusArticle> map = new HashMap<>();
 		for (ScopusArticle scopusArticle : scopusArticles) {

--- a/src/main/java/reciter/engine/StrategyParameters.java
+++ b/src/main/java/reciter/engine/StrategyParameters.java
@@ -96,6 +96,9 @@ public class StrategyParameters {
 	@Value("${cluster.similarity.threshold.score}")
 	private double clusterSimilarityThresholdScore;
 	
+	@Value("${clusteringGrants-threshold}")
+	private double clusteringGrantsThreshold;
+	
 	@Value("${nameMatchFirstType.full-exact}")
 	private double nameMatchFirstTypeFullExactScore;
 	
@@ -1074,4 +1077,13 @@ public class StrategyParameters {
 	public void setInstAfflInstitutionStopwords(String instAfflInstitutionStopwords) {
 		this.instAfflInstitutionStopwords = instAfflInstitutionStopwords;
 	}
+
+	public double getClusteringGrantsThreshold() {
+		return clusteringGrantsThreshold;
+	}
+
+	public void setClusteringGrantsThreshold(double clusteringGrantsThreshold) {
+		this.clusteringGrantsThreshold = clusteringGrantsThreshold;
+	}
+	
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,7 @@ strategy.acceptedrejected=true
 strategy.averageclustering=true
 
 cluster.similarity.threshold.score=0.2
+clusteringGrants-threshold=12
 
 use.scopus.articles=true
 use.gold.standard.evidence=false


### PR DESCRIPTION
This PR addresses filters for grant clustering strategy where an article if has grants more than the threshold in application properties should be discarded for clustering. - #254 

Also a name variant fix when middle name is null in identity. e.g. amc2056