### PR TITLE
Create publications api

### DIFF
--- a/src/main/java/reciter/engine/analysis/ReCiterFeature.java
+++ b/src/main/java/reciter/engine/analysis/ReCiterFeature.java
@@ -24,9 +24,9 @@ public class ReCiterFeature {
     private Date dateUpdated;
     @DynamoDBTyped(DynamoDBAttributeType.S)
     private UseGoldStandard mode;
-    private double overallAccuracy;
-    private double precision;
-    private double recall;
+    private Double overallAccuracy;
+    private Double precision;
+    private Double recall;
     private List<Long> inGoldStandardButNotRetrieved;
     private int countSuggestedArticles;
     private List<ReCiterArticleFeature> reCiterArticleFeatures;


### PR DESCRIPTION
## Assumption 

We will be running ReCiter feature-generator on a regular basis, with newly_added_publications, for all users' whose publications need to be retrieved.


## Need

Departments, labs, and other third parties with whom we have weak ties need a way to retrieve article records from the API.

Ideally, this would build upon existing code and allow for future changes (e.g., inclusion of ScopsDocID) to be seamlessly integrated.


## Exclude certain data

The following outputs should not be included:
- anything in `evidence.*`
- precision
- recall
- overallAccuracy
- inGoldStandardButNotRetrieved

## Parameters

User should be able to use the following parameters.
```
uid
totalStandardizedArticleScore
filterByFeedback
```

We should set these parameters to the following values.
```
useGoldStandard=AS_EVIDENCE /* Gives more accurate scores. */
analysisRefreshFlag=FALSE /* We should be running all people of interest in a regular basis anyway. */
retrievalRefreshFlag=FALSE /* We should be running all people of interest in a regular basis anyway. */ 
```

There may be a use case for allowing consumers of this API to modify these parameters, but for now, I think we should not allow that. Alternatively, we could allow it, but not disclose their availability. That could require less code modification down the road. Your choice how to handle this.