### PR TITLE
Article Strategy fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
 	    <dependency>
 	    	<groupId>edu.cornell.weill.reciter</groupId>
 	    	<artifactId>reciter-dynamodb-model</artifactId>
-	    	<version>2.0.7</version>
+	    	<version>2.0.8</version>
 	    </dependency>
 	    <dependency>
 	    	<groupId>com.github.bohnman</groupId>

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/articlesize/strategy/ArticleSizeStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/articlesize/strategy/ArticleSizeStrategy.java
@@ -18,8 +18,6 @@
  *******************************************************************************/
 package reciter.algorithm.evidence.targetauthor.articlesize.strategy;
 
-import static org.hamcrest.CoreMatchers.sameInstance;
-
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -28,8 +26,10 @@ import org.slf4j.LoggerFactory;
 import reciter.ApplicationContextHolder;
 import reciter.algorithm.cluster.article.scorer.ReCiterArticleScorer;
 import reciter.algorithm.evidence.targetauthor.AbstractTargetAuthorStrategy;
+import reciter.database.dynamodb.model.ESearchPmid;
 import reciter.database.dynamodb.model.ESearchResult;
 import reciter.database.dynamodb.model.QueryType;
+import reciter.database.dynamodb.model.ESearchPmid.RetrievalRefreshFlag;
 import reciter.engine.Feature;
 import reciter.engine.analysis.evidence.ArticleCountEvidence;
 import reciter.model.article.ReCiterArticle;
@@ -38,6 +38,10 @@ import reciter.model.article.ReCiterAuthor;
 import reciter.model.identity.Identity;
 import reciter.service.ESearchResultService;
 
+/**
+ * @author Sarbajit Dutta
+ * @see <a href= "https://github.com/wcmc-its/ReCiter/issues/228">Article Count Strategy</a>
+ */
 public class ArticleSizeStrategy extends AbstractTargetAuthorStrategy {
 	
 	private static final Logger slf4jLogger = LoggerFactory.getLogger(ArticleSizeStrategy.class);
@@ -97,19 +101,36 @@ public class ArticleSizeStrategy extends AbstractTargetAuthorStrategy {
 
 	@Override
 	public double executeStrategy(List<ReCiterArticle> reCiterArticles, Identity identity) {
-		
+		//Logic was updated to include lookupType in eSearchPmid so as to only count publications when
+		//ALL_PUBLICATIONS flag is being used and excluding GoldStandard Strategy retrieval type for actual candidate publication count
+		//https://github.com/wcmc-its/ReCiter/issues/455 
 		ESearchResultService eSearchResultService = ApplicationContextHolder.getContext().getBean(ESearchResultService.class);
 		ESearchResult eSearchResult = eSearchResultService.findByUid(identity.getUid());
 		reCiterArticles.forEach(reCiterArticle -> {
 		ArticleCountEvidence articleCountEvidence = new ArticleCountEvidence();
 		if(this.numberOfArticles > 0) {
+			int retrievalArticleCountByLookUpType = 0;
 			if(eSearchResult != null
 					&&
 					eSearchResult.getQueryType() != null 
 					&&
 					(eSearchResult.getQueryType() == QueryType.LENIENT_LOOKUP || eSearchResult.getQueryType() == QueryType.STRICT_COMPOUND_NAME_LOOKUP)) {
-				articleCountEvidence.setCountArticlesRetrieved(this.numberOfArticles);
-				articleCountEvidence.setArticleCountScore(-(this.numberOfArticles - ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())/ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
+				if(eSearchResult.getESearchPmids() != null
+						&&
+						!eSearchResult.getESearchPmids().isEmpty()) {
+							retrievalArticleCountByLookUpType = eSearchResult.getESearchPmids().stream()
+							.filter(eSearchPmid -> !eSearchPmid.getRetrievalStrategyName().equalsIgnoreCase("GoldStandardRetrievalStrategy") && eSearchPmid.getLookupType() == RetrievalRefreshFlag.ALL_PUBLICATIONS)
+							.map(ESearchPmid::getPmids)
+							.mapToInt(List::size)
+							.sum();
+							if(retrievalArticleCountByLookUpType > 0) {
+								articleCountEvidence.setCountArticlesRetrieved(retrievalArticleCountByLookUpType);
+								articleCountEvidence.setArticleCountScore(-(retrievalArticleCountByLookUpType - ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())/ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
+							} else {
+								articleCountEvidence.setCountArticlesRetrieved(this.numberOfArticles);
+								articleCountEvidence.setArticleCountScore(-(this.numberOfArticles - ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())/ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
+							}
+						}
 			} else if(eSearchResult != null
 					&&
 					eSearchResult.getQueryType() != null 

--- a/src/main/java/reciter/pubmed/retriever/PubMedQuery.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedQuery.java
@@ -40,9 +40,9 @@ public class PubMedQuery {
             //parts.add(author + " [au]");
         	parts.add(author);
         }
-        //Switched from [DP] to [EDAT] for better capture of pubs : Date of publication - Date added to Entrez
+        //Added both [DP] and [EDAT] for better capture of pubs : Date of publication - Date added to Entrez
         if (start != null && end != null) {
-            parts.add(dt.format(start) + ":" + dt.format(end) + "[EDAT]");
+            parts.add("((" + dt.format(start) + ":" + dt.format(end) + "[EDAT]" + ") OR (" + dt.format(start) + ":" + dt.format(end) + "[DP]))");
         }
         if (strategyQuery != null && !strategyQuery.isEmpty()) {
             parts.add(strategyQuery);


### PR DESCRIPTION
#455 
#454

There was a lookupType attribute introduced in ESearchPmid class which has refreshFlag attributes. For details see https://github.com/wcmc-its/ReCiter-Dynamodb-Model/issues/2

For all articles in ESearchResult only look for articles that have lookupType ALL_PUBLICATIONS and exclude GoldStandardRetrievalStrategy to calculate the count of candidate publications.

This fixes a bug where the articleCount would based on the number of articles in the cluster which was low on incremental name lookup A.K.A ONLY_NEWLY_ADDED_PUBLICATIONS.
 