### PR TITLE
Add eSearch count storage and informed absence penalties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ reciter.iml
 /.apt_generated_tests/
 .vscode/launch.json
 .vscode/settings.json
+
+# Scoring test artifacts
+*-feedbackIdentityScoringInput.json
+*-identityOnlyScoringInput.json

--- a/src/main/java/reciter/Application.java
+++ b/src/main/java/reciter/Application.java
@@ -58,16 +58,19 @@ import reciter.database.dyanmodb.files.GenderFileImport;
 import reciter.database.dyanmodb.files.IdentityFileImport;
 import reciter.database.dyanmodb.files.InstitutionAfidFileImport;
 import reciter.database.dyanmodb.files.MeshTermFileImport;
+import reciter.database.dyanmodb.files.NameFrequencyFileImport;
 import reciter.database.dyanmodb.files.ScienceMetrixDepartmentCategoryFileImport;
 import reciter.database.dyanmodb.files.ScienceMetrixFileImport;
 import reciter.database.dynamodb.model.Gender;
 import reciter.database.dynamodb.model.InstitutionAfid;
 import reciter.database.dynamodb.model.MeshTerm;
+import reciter.database.dynamodb.model.NameFrequency;
 import reciter.database.dynamodb.model.ScienceMetrix;
 import reciter.database.dynamodb.model.ScienceMetrixDepartmentCategory;
 import reciter.engine.EngineParameters;
 import reciter.security.APIKey;
 import reciter.service.GenderService;
+import reciter.service.NameFrequencyService;
 import reciter.service.ScienceMetrixDepartmentCategoryService;
 import reciter.service.ScienceMetrixService;
 import reciter.service.dynamo.DynamoDbInstitutionAfidService;
@@ -107,18 +110,24 @@ public class Application {
     
     @Autowired
     private GenderService genderService;
-    
+
+    @Autowired
+    private NameFrequencyService nameFrequencyService;
+
     @Value("${use.scopus.articles}")
     private boolean useScopusArticles;
-    
+
     @Value("${spring.security.enabled}")
     private boolean useAPISecurity;
-    
+
     @Value("${aws.dynamodb.settings.file.import}")
     private boolean isFileImport;
-    
+
     @Value("${strategy.gender}")
 	private boolean useGenderStrategy;
+
+    @Value("${strategy.nameFrequency:true}")
+	private boolean useNameFrequencyStrategy;
 	
 	@Value("${strategy.discrepancyDegreeYear.degreeYearDiscrepancyScore}")
 	private String degreeYearDiscrepancyScore;
@@ -315,6 +324,13 @@ public class Application {
 				log.info("Gender strategy use is set to false. Please update strategy.gender to true in application.properties file to use it.\n"
 			+ "Its recommened to use this strategy to get better scores.");
 			}
+
+			if(useNameFrequencyStrategy) {
+				NameFrequencyFileImport nameFrequencyFileImport = ApplicationContextHolder.getContext().getBean(NameFrequencyFileImport.class);
+				nameFrequencyFileImport.importNameFrequency();
+			} else {
+				log.info("NameFrequency strategy use is set to false. Set strategy.nameFrequency=true in application.properties to enable.");
+			}
 			
 			if(useScopusArticles) {
 				InstitutionAfidFileImport institutionAfidFileImport = ApplicationContextHolder.getContext().getBean(InstitutionAfidFileImport.class);
@@ -352,6 +368,19 @@ public class Application {
 	        List<Gender> genders = genderService.findAll();
 	        if(genders != null && !genders.isEmpty()) {
 	        	EngineParameters.setGenders(genders);
+	        }
+        }
+        if(useNameFrequencyStrategy) {
+	        log.info("Loading NameFrequency to Engine Parameters");
+	        List<NameFrequency> nameFrequencies = nameFrequencyService.findAll();
+	        if(nameFrequencies != null && !nameFrequencies.isEmpty()) {
+	        	EngineParameters.setNameFrequencies(nameFrequencies);
+	        	Map<String, NameFrequency> nameFrequencyMap = new HashMap<>();
+	        	for (NameFrequency nf : nameFrequencies) {
+	        		nameFrequencyMap.put(nf.getName(), nf);
+	        	}
+	        	EngineParameters.setNameFrequencyMap(nameFrequencyMap);
+	        	log.info("Loaded {} name frequencies to Engine Parameters", nameFrequencies.size());
 	        }
         }
         

--- a/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
+++ b/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
@@ -30,6 +30,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import reciter.algorithm.article.score.predictor.NeuralNetworkModelArticlesScorer;
 import reciter.algorithm.evidence.StrategyContext;
@@ -338,6 +339,18 @@ public class ReCiterArticleScorer extends AbstractArticleScorer {
     	
     	
     	ObjectMapper objectMapper = new ObjectMapper();
+
+    	// Enrich scores with identity first name for name frequency scoring in Python
+    	String identityFirstName = (identity.getPrimaryName() != null && identity.getPrimaryName().getFirstName() != null)
+    	        ? identity.getPrimaryName().getFirstName() : "";
+    	List<ObjectNode> enrichedScores = articleIdentityScore.stream()
+    	        .map(score -> {
+    	            ObjectNode node = objectMapper.convertValue(score, ObjectNode.class);
+    	            node.put("identityFirstName", identityFirstName);
+    	            return node;
+    	        })
+    	        .collect(Collectors.toList());
+
     	// Define a DateTimeFormatter for safe file name format
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HHmmss");
 
@@ -350,21 +363,21 @@ public class ReCiterArticleScorer extends AbstractArticleScorer {
 		String fileName = StringUtils.join(identity.getUid(), "-identityOnlyScoringInput.json");
 		boolean isS3UploadRequired = isS3UploadRequired();
 		String identityS3BucketName = PropertiesUtils.get("aws.s3.feedback.score.bucketName");
-		
+
         try {
-			NeuralNetworkModelArticlesScorer nnmodel = new NeuralNetworkModelArticlesScorer();																			   
-        	  if(isS3UploadRequired) 
+			NeuralNetworkModelArticlesScorer nnmodel = new NeuralNetworkModelArticlesScorer();
+        	  if(isS3UploadRequired)
         	  {
         		  File jsonFile = new File(fileName);
 
         		// Write the User object to the JSON file
-                  objectMapper.writeValue(jsonFile, articleIdentityScore);
+                  objectMapper.writeValue(jsonFile, enrichedScores);
                   uploadJsonFileIntoS3(fileName, jsonFile);
          	  }
         	  else
-        	  {	  
+        	  {
         		  File jsonFile = new File("src/main/resources/scripts/"+fileName);
-	        	  objectMapper.writeValue(jsonFile,articleIdentityScore);
+	        	  objectMapper.writeValue(jsonFile, enrichedScores);
         	  }
               String isS3UploadRequiredString = Boolean.toString(isS3UploadRequired);
  			  JSONArray articlesIdentityScoreTotal = nnmodel.executeArticleScorePredictor("identity", fileName,identityS3BucketName,isS3UploadRequiredString);

--- a/src/main/java/reciter/algorithm/evidence/feedback/targetauthor/AbstractTargetAuthorFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/feedback/targetauthor/AbstractTargetAuthorFeedbackStrategy.java
@@ -28,9 +28,9 @@ public class AbstractTargetAuthorFeedbackStrategy implements TargetAuthorFeedbac
 	protected DecimalFormat decimalFormat = new DecimalFormat("#.######");
 
 	// Informed absence configuration (set by ReciterFeedbackArticleScorer)
-	protected boolean informedAbsenceEnabled = false;
-	protected double informedAbsenceScale = 10.0;
-	protected double informedAbsenceStrength = 1.0;
+	private boolean informedAbsenceEnabled = false;
+	private double informedAbsenceScale = 10.0;
+	private double informedAbsenceStrength = 1.0;
 
 	public void setInformedAbsenceConfig(boolean enabled, double scale, double strength) {
 		this.informedAbsenceEnabled = enabled;

--- a/src/main/java/reciter/algorithm/evidence/feedback/targetauthor/AbstractTargetAuthorFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/feedback/targetauthor/AbstractTargetAuthorFeedbackStrategy.java
@@ -26,7 +26,18 @@ public class AbstractTargetAuthorFeedbackStrategy implements TargetAuthorFeedbac
 	protected final int ACCEPTED = 1;
 	protected final int REJECTED = -1;
 	protected DecimalFormat decimalFormat = new DecimalFormat("#.######");
-	
+
+	// Informed absence configuration (set by ReciterFeedbackArticleScorer)
+	protected boolean informedAbsenceEnabled = false;
+	protected double informedAbsenceScale = 10.0;
+	protected double informedAbsenceStrength = 1.0;
+
+	public void setInformedAbsenceConfig(boolean enabled, double scale, double strength) {
+		this.informedAbsenceEnabled = enabled;
+		this.informedAbsenceScale = scale;
+		this.informedAbsenceStrength = strength;
+	}
+
 	@Override
 	public double executeFeedbackStrategy(ReCiterArticle reCiterArticle, Identity identity) {
 		return 0;
@@ -36,11 +47,32 @@ public class AbstractTargetAuthorFeedbackStrategy implements TargetAuthorFeedbac
 	public double executeFeedbackStrategy(List<ReCiterArticle> reCiterArticles, Identity identity) {
 		return 0;
 	}
-	
+
 	// Helper method to compute score
 	protected double computeScore(int countAccepted, int countRejected) {
 		return (1 / (1 + Math.exp(-(countAccepted - countRejected) / (Math.sqrt(countAccepted + countRejected) + 1))))
 				- 0.5;
+	}
+
+	/**
+	 * Compute informed absence penalty for a feedback feature.
+	 *
+	 * When a specific attribute value has zero accepted and zero rejected records,
+	 * but the researcher has substantial overall acceptance history, the zero score
+	 * is evidence of absence rather than absence of evidence.
+	 *
+	 * @param totalAccepted total number of accepted articles for this researcher
+	 * @return negative penalty scaled by total accepted count and feature strength,
+	 *         or 0.0 if informed absence is disabled or totalAccepted is 0
+	 */
+	protected double computeInformedAbsencePenalty(int totalAccepted) {
+		if (!informedAbsenceEnabled || totalAccepted == 0) {
+			return 0.0;
+		}
+		// sigmoid(totalAccepted / scale) - 0.5 gives a value in (0, 0.5)
+		// Negate it so penalty is negative; multiply by strength
+		double sigmoidValue = 1.0 / (1.0 + Math.exp(-totalAccepted / informedAbsenceScale));
+		return informedAbsenceStrength * -(sigmoidValue - 0.5);
 	}
 	
 	protected double determineFeedbackScore(int goldStandard, double scoreWithout1Accepted, double scoreWithout1Rejected, double scoreAll) 

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/TargetAuthorSelection.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/TargetAuthorSelection.java
@@ -137,16 +137,71 @@ public class TargetAuthorSelection {
 	            	continue;
 	            }
 	            
-	            if(fullLastNameToIdentityPartialMatchCount == 0) {
-	            	slf4jLogger.info("There was no target author found for " + reciterArticle.getArticleId());
-	            	assignTargetAuthorFalse(authors.getAuthors());
-	            }
-	            else if(fullLastNameToIdentityPartialMatchCount > 1) {
-	            	slf4jLogger.info(fullLastNameToIdentityPartialMatchCount + " authors were marked as target author for article " + reciterArticle.getArticleId());
-	            }
 	            if(fullLastNameToIdentityPartialMatchCount == 1) {
 	            	slf4jLogger.info("Full Last Name match to partial Identity Last Name: " + reciterArticle.getArticleId());
 	            	continue;
+	            }
+
+	            //Step 13: Attempt strict first name and first initial of last name match
+	            int firstNameLastInitialMatchCount = 0;
+	            if(fullLastNameToIdentityPartialMatchCount == 0 || fullLastNameToIdentityPartialMatchCount > 1)
+	            	firstNameLastInitialMatchCount = checkFirstNameAndLastInitialMatch(sanitizedAritcleAuthors, sanitizedIdentityAuthors, fullLastNameToIdentityPartialMatchCount, multipleMarkedTargetAuthor);
+	            if(firstNameLastInitialMatchCount == 1) {
+	            	slf4jLogger.info("First Name and Last Initial Match found for article: " + reciterArticle.getArticleId());
+	            	continue;
+	            }
+
+	            //Step 14: Attempt identity middle name to article last name match
+	            int middleNameToLastNameMatchCount = 0;
+	            if(firstNameLastInitialMatchCount == 0 || firstNameLastInitialMatchCount > 1)
+	            	middleNameToLastNameMatchCount = checkMiddleNameToLastNameMatch(sanitizedAritcleAuthors, sanitizedIdentityAuthors, firstNameLastInitialMatchCount, multipleMarkedTargetAuthor);
+	            if(middleNameToLastNameMatchCount == 1) {
+	            	slf4jLogger.info("Identity Middle Name to Article Last Name Match found for article: " + reciterArticle.getArticleId());
+	            	continue;
+	            }
+
+	            //Step 15: Attempt first-to-last and last-to-first name swap match
+	            int firstLastSwapMatchCount = 0;
+	            if(middleNameToLastNameMatchCount == 0 || middleNameToLastNameMatchCount > 1)
+	            	firstLastSwapMatchCount = checkFirstLastNameSwapMatch(sanitizedAritcleAuthors, sanitizedIdentityAuthors, middleNameToLastNameMatchCount, multipleMarkedTargetAuthor);
+	            if(firstLastSwapMatchCount == 1) {
+	            	slf4jLogger.info("First-Last Name Swap Match found for article: " + reciterArticle.getArticleId());
+	            	continue;
+	            }
+
+	            //Step 17: Attempt identity last name to article first name + identity first initial to article last initial
+	            int lastToFirstAndInitialMatchCount = 0;
+	            if(firstLastSwapMatchCount == 0 || firstLastSwapMatchCount > 1)
+	            	lastToFirstAndInitialMatchCount = checkLastNameToFirstNameAndFirstInitialToLastInitialMatch(sanitizedAritcleAuthors, sanitizedIdentityAuthors, firstLastSwapMatchCount, multipleMarkedTargetAuthor);
+	            if(lastToFirstAndInitialMatchCount == 1) {
+	            	slf4jLogger.info("Identity Last-to-Article First + Initial Match found for article: " + reciterArticle.getArticleId());
+	            	continue;
+	            }
+
+	            //Step 18: Attempt both initials match (first initial to first initial, last initial to last initial)
+	            int bothInitialsMatchCount = 0;
+	            if(lastToFirstAndInitialMatchCount == 0 || lastToFirstAndInitialMatchCount > 1)
+	            	bothInitialsMatchCount = checkBothInitialsMatch(sanitizedAritcleAuthors, sanitizedIdentityAuthors, lastToFirstAndInitialMatchCount, multipleMarkedTargetAuthor);
+	            if(bothInitialsMatchCount == 1) {
+	            	slf4jLogger.info("Both Initials Match found for article: " + reciterArticle.getArticleId());
+	            	continue;
+	            }
+
+	            //Step 19: Attempt fuzzy last name match (Levenshtein distance <= 2) with first name or first initial match
+	            int fuzzyLastNameMatchCount = 0;
+	            if(bothInitialsMatchCount == 0 || bothInitialsMatchCount > 1)
+	            	fuzzyLastNameMatchCount = checkFuzzyLastNameMatch(sanitizedAritcleAuthors, sanitizedIdentityAuthors, bothInitialsMatchCount, multipleMarkedTargetAuthor);
+	            if(fuzzyLastNameMatchCount == 1) {
+	            	slf4jLogger.info("Fuzzy Last Name Match (Levenshtein <= 2) found for article: " + reciterArticle.getArticleId());
+	            	continue;
+	            }
+
+	            if(fuzzyLastNameMatchCount == 0) {
+	            	slf4jLogger.info("There was no target author found for " + reciterArticle.getArticleId());
+	            	assignTargetAuthorFalse(authors.getAuthors());
+	            }
+	            else if(fuzzyLastNameMatchCount > 1) {
+	            	slf4jLogger.info(fuzzyLastNameMatchCount + " authors were marked as target author for article " + reciterArticle.getArticleId());
 	            }
             	
             		
@@ -884,6 +939,420 @@ public class TargetAuthorSelection {
 	}
 	
 	
+	//Step 19: Attempt fuzzy last name match (Levenshtein distance <= 2) with first name or first initial match
+	/**
+	 * Check if last names are within Levenshtein distance 2 (handling typos and
+	 * spelling variants) AND the first name or first initial also matches.
+	 * This is the loosest matching step and only fires when all other steps fail.
+	 * Examples:
+	 *   - "Kovanhkaya" vs "Kovanlikaya" (PubMed typo, distance 2)
+	 *   - "Polanecsky" vs "Polaneczky" (variant spelling, distance 2)
+	 *   - "Seidman" vs "Siedman" (transposition, distance 2)
+	 * Requires last name length >= 4 to avoid false positives on short names.
+	 */
+	public int checkFuzzyLastNameMatch(Set<Entry<ReCiterAuthor, ReCiterAuthor>> authors, List<AuthorName> sanitizedIdentityAuthors, int matchCount, Set<Entry<ReCiterAuthor, ReCiterAuthor>> multipleMarkedTargetAuthor) {
+		int count = 0;
+		if(matchCount > 1) {
+			authors = new HashSet<Entry<ReCiterAuthor, ReCiterAuthor>>(multipleMarkedTargetAuthor);
+		}
+		for (Entry<ReCiterAuthor, ReCiterAuthor> entry : authors) {
+			ReCiterAuthor author = entry.getValue();
+			ReCiterAuthor originalAuthor = entry.getKey();
+			if(author.getAuthorName().getLastName() != null && author.getAuthorName().getLastName().length() >= 4
+					&& author.getAuthorName().getFirstInitial() != null) {
+				if(matchCount > 1 && author.isTargetAuthor()) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() >= 4
+							&&
+							sanitizedIdentityName.getFirstInitial() != null
+							&&
+							ReCiterStringUtil.levenshteinDistance(
+								author.getAuthorName().getLastName().toLowerCase(),
+								sanitizedIdentityName.getLastName().toLowerCase()) <= 2
+							&&
+							ReCiterStringUtil.levenshteinDistance(
+								author.getAuthorName().getLastName().toLowerCase(),
+								sanitizedIdentityName.getLastName().toLowerCase()) > 0
+							&&
+							(author.getAuthorName().getFirstInitial().equalsIgnoreCase(sanitizedIdentityName.getFirstInitial())
+							||
+							(author.getAuthorName().getFirstName() != null && sanitizedIdentityName.getFirstName() != null
+							&& author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getFirstName()))))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+				else if(matchCount == 0) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() >= 4
+							&&
+							sanitizedIdentityName.getFirstInitial() != null
+							&&
+							ReCiterStringUtil.levenshteinDistance(
+								author.getAuthorName().getLastName().toLowerCase(),
+								sanitizedIdentityName.getLastName().toLowerCase()) <= 2
+							&&
+							ReCiterStringUtil.levenshteinDistance(
+								author.getAuthorName().getLastName().toLowerCase(),
+								sanitizedIdentityName.getLastName().toLowerCase()) > 0
+							&&
+							(author.getAuthorName().getFirstInitial().equalsIgnoreCase(sanitizedIdentityName.getFirstInitial())
+							||
+							(author.getAuthorName().getFirstName() != null && sanitizedIdentityName.getFirstName() != null
+							&& author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getFirstName()))))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+			}
+		}
+		if(matchCount > 1 && count == 0) {
+			return matchCount;
+		}
+		return count;
+	}
+
+	//Step 13: Attempt strict first name and first initial of last name match
+	/**
+	 * Check for exact first name match and matching first character of last name.
+	 * Handles cases where the last name is garbled but the first name is intact.
+	 * Example: identity "Mark Polanec" matching article author "M Polanec" where
+	 * last name may be truncated but first name and last initial are correct.
+	 */
+	public int checkFirstNameAndLastInitialMatch(Set<Entry<ReCiterAuthor, ReCiterAuthor>> authors, List<AuthorName> sanitizedIdentityAuthors, int matchCount, Set<Entry<ReCiterAuthor, ReCiterAuthor>> multipleMarkedTargetAuthor) {
+		int count = 0;
+		if(matchCount > 1) {
+			authors = new HashSet<Entry<ReCiterAuthor, ReCiterAuthor>>(multipleMarkedTargetAuthor);
+		}
+		for (Entry<ReCiterAuthor, ReCiterAuthor> entry : authors) {
+			ReCiterAuthor author = entry.getValue();
+			ReCiterAuthor originalAuthor = entry.getKey();
+			if(author.getAuthorName().getFirstName() != null && author.getAuthorName().getLastName() != null
+					&& author.getAuthorName().getFirstName().length() > 1 && author.getAuthorName().getLastName().length() > 0) {
+				if(matchCount > 1 && author.isTargetAuthor()) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getFirstName() != null
+							&& sanitizedIdentityName.getFirstName().length() > 1
+							&&
+							sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() > 0
+							&&
+							author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getFirstName())
+							&&
+							author.getAuthorName().getLastName().substring(0, 1).equalsIgnoreCase(sanitizedIdentityName.getLastName().substring(0, 1)))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+				else if(matchCount == 0) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getFirstName() != null
+							&& sanitizedIdentityName.getFirstName().length() > 1
+							&&
+							sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() > 0
+							&&
+							author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getFirstName())
+							&&
+							author.getAuthorName().getLastName().substring(0, 1).equalsIgnoreCase(sanitizedIdentityName.getLastName().substring(0, 1)))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+			}
+		}
+		if(matchCount > 1 && count == 0) {
+			return matchCount;
+		}
+		return count;
+	}
+
+	//Step 14: Attempt identity middle name to article last name match
+	/**
+	 * Check if identity middle name matches article last name, with first name or
+	 * first initial also matching. Handles cases where PubMed indexed the middle
+	 * name as the last name (common with multi-part names).
+	 * Example: identity "Brian C Edwards" (middle="C") where article has author
+	 * "C Edwards" indexed differently.
+	 */
+	public int checkMiddleNameToLastNameMatch(Set<Entry<ReCiterAuthor, ReCiterAuthor>> authors, List<AuthorName> sanitizedIdentityAuthors, int matchCount, Set<Entry<ReCiterAuthor, ReCiterAuthor>> multipleMarkedTargetAuthor) {
+		int count = 0;
+		if(matchCount > 1) {
+			authors = new HashSet<Entry<ReCiterAuthor, ReCiterAuthor>>(multipleMarkedTargetAuthor);
+		}
+		for (Entry<ReCiterAuthor, ReCiterAuthor> entry : authors) {
+			ReCiterAuthor author = entry.getValue();
+			ReCiterAuthor originalAuthor = entry.getKey();
+			if(author.getAuthorName().getLastName() != null && author.getAuthorName().getFirstInitial() != null) {
+				if(matchCount > 1 && author.isTargetAuthor()) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getMiddleName() != null
+							&& sanitizedIdentityName.getMiddleName().length() > 1
+							&&
+							sanitizedIdentityName.getFirstInitial() != null
+							&&
+							author.getAuthorName().getLastName().equalsIgnoreCase(sanitizedIdentityName.getMiddleName())
+							&&
+							(author.getAuthorName().getFirstInitial().equalsIgnoreCase(sanitizedIdentityName.getFirstInitial())
+							||
+							(author.getAuthorName().getFirstName() != null && sanitizedIdentityName.getFirstName() != null
+							&& author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getFirstName()))))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+				else if(matchCount == 0) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getMiddleName() != null
+							&& sanitizedIdentityName.getMiddleName().length() > 1
+							&&
+							sanitizedIdentityName.getFirstInitial() != null
+							&&
+							author.getAuthorName().getLastName().equalsIgnoreCase(sanitizedIdentityName.getMiddleName())
+							&&
+							(author.getAuthorName().getFirstInitial().equalsIgnoreCase(sanitizedIdentityName.getFirstInitial())
+							||
+							(author.getAuthorName().getFirstName() != null && sanitizedIdentityName.getFirstName() != null
+							&& author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getFirstName()))))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+			}
+		}
+		if(matchCount > 1 && count == 0) {
+			return matchCount;
+		}
+		return count;
+	}
+
+	//Step 15: Attempt first-to-last and last-to-first name swap match
+	/**
+	 * Check if identity first name matches article last name AND identity last name
+	 * matches article first name. Handles cases where PubMed reversed the first
+	 * and last name fields.
+	 * Example: identity "Daniel Li" matching article author "Li Daniel".
+	 */
+	public int checkFirstLastNameSwapMatch(Set<Entry<ReCiterAuthor, ReCiterAuthor>> authors, List<AuthorName> sanitizedIdentityAuthors, int matchCount, Set<Entry<ReCiterAuthor, ReCiterAuthor>> multipleMarkedTargetAuthor) {
+		int count = 0;
+		if(matchCount > 1) {
+			authors = new HashSet<Entry<ReCiterAuthor, ReCiterAuthor>>(multipleMarkedTargetAuthor);
+		}
+		for (Entry<ReCiterAuthor, ReCiterAuthor> entry : authors) {
+			ReCiterAuthor author = entry.getValue();
+			ReCiterAuthor originalAuthor = entry.getKey();
+			if(author.getAuthorName().getFirstName() != null && author.getAuthorName().getFirstName().length() > 1
+					&& author.getAuthorName().getLastName() != null && author.getAuthorName().getLastName().length() > 1) {
+				if(matchCount > 1 && author.isTargetAuthor()) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getFirstName() != null
+							&& sanitizedIdentityName.getFirstName().length() > 1
+							&&
+							sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() > 1
+							&&
+							author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getLastName())
+							&&
+							author.getAuthorName().getLastName().equalsIgnoreCase(sanitizedIdentityName.getFirstName()))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+				else if(matchCount == 0) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getFirstName() != null
+							&& sanitizedIdentityName.getFirstName().length() > 1
+							&&
+							sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() > 1
+							&&
+							author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getLastName())
+							&&
+							author.getAuthorName().getLastName().equalsIgnoreCase(sanitizedIdentityName.getFirstName()))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+			}
+		}
+		if(matchCount > 1 && count == 0) {
+			return matchCount;
+		}
+		return count;
+	}
+
+	//Step 17: Attempt identity last name to article first name + identity first initial to article last name initial
+	/**
+	 * Check if identity last name matches article first name AND identity first
+	 * initial matches the first character of article last name. Handles partial
+	 * name swaps where the last name appears in the first name field.
+	 * Example: identity "Brian Harvey" matching article "Harvey B" where first
+	 * name field has "Harvey" and last name starts with "B".
+	 */
+	public int checkLastNameToFirstNameAndFirstInitialToLastInitialMatch(Set<Entry<ReCiterAuthor, ReCiterAuthor>> authors, List<AuthorName> sanitizedIdentityAuthors, int matchCount, Set<Entry<ReCiterAuthor, ReCiterAuthor>> multipleMarkedTargetAuthor) {
+		int count = 0;
+		if(matchCount > 1) {
+			authors = new HashSet<Entry<ReCiterAuthor, ReCiterAuthor>>(multipleMarkedTargetAuthor);
+		}
+		for (Entry<ReCiterAuthor, ReCiterAuthor> entry : authors) {
+			ReCiterAuthor author = entry.getValue();
+			ReCiterAuthor originalAuthor = entry.getKey();
+			if(author.getAuthorName().getFirstName() != null && author.getAuthorName().getFirstName().length() > 1
+					&& author.getAuthorName().getLastName() != null && author.getAuthorName().getLastName().length() > 0) {
+				if(matchCount > 1 && author.isTargetAuthor()) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() > 1
+							&&
+							sanitizedIdentityName.getFirstInitial() != null
+							&&
+							author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getLastName())
+							&&
+							author.getAuthorName().getLastName().substring(0, 1).equalsIgnoreCase(sanitizedIdentityName.getFirstInitial()))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+				else if(matchCount == 0) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() > 1
+							&&
+							sanitizedIdentityName.getFirstInitial() != null
+							&&
+							author.getAuthorName().getFirstName().equalsIgnoreCase(sanitizedIdentityName.getLastName())
+							&&
+							author.getAuthorName().getLastName().substring(0, 1).equalsIgnoreCase(sanitizedIdentityName.getFirstInitial()))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+			}
+		}
+		if(matchCount > 1 && count == 0) {
+			return matchCount;
+		}
+		return count;
+	}
+
+	//Step 18: Attempt both initials match (first initial to first initial, last initial to last initial)
+	/**
+	 * Check if identity first initial matches article first initial AND identity
+	 * last name initial matches article last name initial. This is the loosest
+	 * matching step and only fires when all other steps have failed.
+	 * Example: identity "Cassie Sied" matching article "CS" where names are
+	 * heavily abbreviated.
+	 */
+	public int checkBothInitialsMatch(Set<Entry<ReCiterAuthor, ReCiterAuthor>> authors, List<AuthorName> sanitizedIdentityAuthors, int matchCount, Set<Entry<ReCiterAuthor, ReCiterAuthor>> multipleMarkedTargetAuthor) {
+		int count = 0;
+		if(matchCount > 1) {
+			authors = new HashSet<Entry<ReCiterAuthor, ReCiterAuthor>>(multipleMarkedTargetAuthor);
+		}
+		for (Entry<ReCiterAuthor, ReCiterAuthor> entry : authors) {
+			ReCiterAuthor author = entry.getValue();
+			ReCiterAuthor originalAuthor = entry.getKey();
+			if(author.getAuthorName().getFirstInitial() != null && author.getAuthorName().getFirstInitial().length() > 0
+					&& author.getAuthorName().getLastName() != null && author.getAuthorName().getLastName().length() > 0) {
+				if(matchCount > 1 && author.isTargetAuthor()) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getFirstInitial() != null
+							&& sanitizedIdentityName.getFirstInitial().length() > 0
+							&&
+							sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() > 0
+							&&
+							author.getAuthorName().getFirstInitial().equalsIgnoreCase(sanitizedIdentityName.getFirstInitial())
+							&&
+							author.getAuthorName().getLastName().substring(0, 1).equalsIgnoreCase(sanitizedIdentityName.getLastName().substring(0, 1)))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+				else if(matchCount == 0) {
+					if(sanitizedIdentityAuthors.stream().anyMatch(sanitizedIdentityName -> sanitizedIdentityName.getFirstInitial() != null
+							&& sanitizedIdentityName.getFirstInitial().length() > 0
+							&&
+							sanitizedIdentityName.getLastName() != null
+							&& sanitizedIdentityName.getLastName().length() > 0
+							&&
+							author.getAuthorName().getFirstInitial().equalsIgnoreCase(sanitizedIdentityName.getFirstInitial())
+							&&
+							author.getAuthorName().getLastName().substring(0, 1).equalsIgnoreCase(sanitizedIdentityName.getLastName().substring(0, 1)))) {
+						author.setTargetAuthor(true);
+						originalAuthor.setTargetAuthor(true);
+						multipleMarkedTargetAuthor.add(entry);
+						count++;
+					}
+					else {
+						author.setTargetAuthor(false);
+						originalAuthor.setTargetAuthor(false);
+					}
+				}
+			}
+		}
+		if(matchCount > 1 && count == 0) {
+			return matchCount;
+		}
+		return count;
+	}
+
 	//Not Used
 	public int checkLastNamePartMatch(List<ReCiterAuthor> authors, Identity identity, int matchCount) {
 		int count = 0;

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/TargetAuthorSelection.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/TargetAuthorSelection.java
@@ -201,7 +201,13 @@ public class TargetAuthorSelection {
 	            	assignTargetAuthorFalse(authors.getAuthors());
 	            }
 	            else if(fuzzyLastNameMatchCount > 1) {
-	            	slf4jLogger.info(fuzzyLastNameMatchCount + " authors were marked as target author for article " + reciterArticle.getArticleId());
+	            	slf4jLogger.info(fuzzyLastNameMatchCount + " authors were marked as target author for article " + reciterArticle.getArticleId() + ". Attempting disambiguation...");
+	            	int disambiguatedCount = disambiguateMultipleMatches(multipleMarkedTargetAuthor, sanitizedIdentityAuthors);
+	            	if(disambiguatedCount == 1) {
+	            		slf4jLogger.info("Disambiguation resolved to 1 target author for article: " + reciterArticle.getArticleId());
+	            	} else {
+	            		slf4jLogger.info("Disambiguation could not resolve: " + disambiguatedCount + " authors remain for article " + reciterArticle.getArticleId());
+	            	}
 	            }
             	
             		
@@ -939,6 +945,102 @@ public class TargetAuthorSelection {
 	}
 	
 	
+	/**
+	 * Disambiguate when multiple authors are flagged as target author.
+	 * Scores each matched author by how closely their name components match
+	 * the identity record, then picks the single best match if one exists.
+	 *
+	 * Scoring:
+	 *   +3  exact first name match
+	 *   +1  first initial match (only if no exact first name match)
+	 *   +2  exact middle name match
+	 *   +1  middle initial match (only if no exact middle name match)
+	 *
+	 * If exactly one author has the highest score and it exceeds the runner-up,
+	 * that author is kept and the others are unmarked. If tied, all remain marked
+	 * (no guessing).
+	 *
+	 * @param multipleMarkedTargetAuthor the set of authors currently marked as target
+	 * @param sanitizedIdentityAuthors the identity name variants to compare against
+	 * @return the number of authors still marked as target after disambiguation
+	 */
+	public int disambiguateMultipleMatches(Set<Entry<ReCiterAuthor, ReCiterAuthor>> multipleMarkedTargetAuthor,
+	                                        List<AuthorName> sanitizedIdentityAuthors) {
+		if(multipleMarkedTargetAuthor == null || multipleMarkedTargetAuthor.size() <= 1) {
+			return multipleMarkedTargetAuthor == null ? 0 : multipleMarkedTargetAuthor.size();
+		}
+
+		// Score each matched author
+		Entry<ReCiterAuthor, ReCiterAuthor> bestEntry = null;
+		int bestScore = -1;
+		boolean tied = false;
+
+		for(Entry<ReCiterAuthor, ReCiterAuthor> entry : multipleMarkedTargetAuthor) {
+			ReCiterAuthor author = entry.getValue();
+			if(!author.isTargetAuthor()) continue;
+
+			int score = 0;
+			for(AuthorName identityName : sanitizedIdentityAuthors) {
+				int nameScore = 0;
+
+				// First name scoring
+				if(author.getAuthorName().getFirstName() != null && identityName.getFirstName() != null
+						&& author.getAuthorName().getFirstName().length() > 1 && identityName.getFirstName().length() > 1
+						&& author.getAuthorName().getFirstName().equalsIgnoreCase(identityName.getFirstName())) {
+					nameScore += 3;
+				} else if(author.getAuthorName().getFirstInitial() != null && identityName.getFirstInitial() != null
+						&& author.getAuthorName().getFirstInitial().equalsIgnoreCase(identityName.getFirstInitial())) {
+					nameScore += 1;
+				}
+
+				// Middle name scoring
+				if(author.getAuthorName().getMiddleName() != null && identityName.getMiddleName() != null
+						&& author.getAuthorName().getMiddleName().length() > 1 && identityName.getMiddleName().length() > 1
+						&& author.getAuthorName().getMiddleName().equalsIgnoreCase(identityName.getMiddleName())) {
+					nameScore += 2;
+				} else if(author.getAuthorName().getMiddleInitial() != null && identityName.getMiddleInitial() != null
+						&& author.getAuthorName().getMiddleInitial().length() > 0 && identityName.getMiddleInitial().length() > 0
+						&& author.getAuthorName().getMiddleInitial().equalsIgnoreCase(identityName.getMiddleInitial())) {
+					nameScore += 1;
+				}
+
+				// Take the best score across all identity name variants
+				score = Math.max(score, nameScore);
+			}
+
+			if(score > bestScore) {
+				bestScore = score;
+				bestEntry = entry;
+				tied = false;
+			} else if(score == bestScore) {
+				tied = true;
+			}
+		}
+
+		// Only disambiguate if there's a clear winner (not tied)
+		if(!tied && bestEntry != null && bestScore > 0) {
+			for(Entry<ReCiterAuthor, ReCiterAuthor> entry : multipleMarkedTargetAuthor) {
+				ReCiterAuthor author = entry.getValue();
+				ReCiterAuthor originalAuthor = entry.getKey();
+				if(entry.equals(bestEntry)) {
+					author.setTargetAuthor(true);
+					originalAuthor.setTargetAuthor(true);
+				} else {
+					author.setTargetAuthor(false);
+					originalAuthor.setTargetAuthor(false);
+				}
+			}
+			return 1;
+		}
+
+		// Tied or no score — leave as-is
+		int remaining = 0;
+		for(Entry<ReCiterAuthor, ReCiterAuthor> entry : multipleMarkedTargetAuthor) {
+			if(entry.getValue().isTargetAuthor()) remaining++;
+		}
+		return remaining;
+	}
+
 	//Step 19: Attempt fuzzy last name match (Levenshtein distance <= 2) with first name or first initial match
 	/**
 	 * Check if last names are within Levenshtein distance 2 (handling typos and

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/articlesize/strategy/ArticleSizeStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/articlesize/strategy/ArticleSizeStrategy.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import reciter.ApplicationContextHolder;
 import reciter.algorithm.cluster.article.scorer.ReCiterArticleScorer;
 import reciter.algorithm.evidence.targetauthor.AbstractTargetAuthorStrategy;
+import reciter.database.dynamodb.model.ESearchCount;
 import reciter.database.dynamodb.model.ESearchPmid;
 import reciter.database.dynamodb.model.ESearchPmid.RetrievalRefreshFlag;
 import reciter.database.dynamodb.model.ESearchResult;
@@ -38,6 +39,7 @@ import reciter.model.article.ReCiterArticle;
 import reciter.model.article.ReCiterArticleAuthors;
 import reciter.model.article.ReCiterAuthor;
 import reciter.model.identity.Identity;
+import reciter.service.ESearchCountService;
 import reciter.service.ESearchResultService;
 
 /**
@@ -103,51 +105,78 @@ public class ArticleSizeStrategy extends AbstractTargetAuthorStrategy {
 
 	@Override
 	public double executeStrategy(List<ReCiterArticle> reCiterArticles, Identity identity) {
-		//Logic was updated to include lookupType in eSearchPmid so as to only count publications when
-		//ALL_PUBLICATIONS flag is being used and excluding GoldStandard Strategy retrieval type for actual candidate publication count
-		//https://github.com/wcmc-its/ReCiter/issues/455 
-		ESearchResultService eSearchResultService = ApplicationContextHolder.getContext().getBean(ESearchResultService.class);
+		ESearchCountService eSearchCountService = ApplicationContextHolder.getContext()
+				.getBean(ESearchCountService.class);
+		ESearchCount eSearchCount = eSearchCountService.findByUid(identity.getUid());
+
+		ESearchResultService eSearchResultService = ApplicationContextHolder.getContext()
+				.getBean(ESearchResultService.class);
 		ESearchResult eSearchResult = eSearchResultService.findByUid(identity.getUid());
+
 		reCiterArticles.forEach(reCiterArticle -> {
-		ArticleCountEvidence articleCountEvidence = new ArticleCountEvidence();
-		if(this.numberOfArticles > 0) {
-			int retrievalArticleCountByLookUpType = 0;
-			if(eSearchResult != null
-					&&
-					eSearchResult.getQueryType() != null 
-					&&
-					(eSearchResult.getQueryType() == QueryType.LENIENT_LOOKUP || eSearchResult.getQueryType() == QueryType.STRICT_COMPOUND_NAME_LOOKUP)) {
-				if(eSearchResult.getESearchPmids() != null
-						&&
-						!eSearchResult.getESearchPmids().isEmpty()) {
-							Set<Long> uniqueRetrievalArticle = new HashSet<>();
-							eSearchResult.getESearchPmids().stream()
-							.filter(eSearchPmid -> !eSearchPmid.getRetrievalStrategyName().equalsIgnoreCase("GoldStandardRetrievalStrategy") && eSearchPmid.getLookupType() == RetrievalRefreshFlag.ALL_PUBLICATIONS)
-							.map(ESearchPmid::getPmids)
-							.forEach(uniqueRetrievalArticle::addAll);
-							retrievalArticleCountByLookUpType = uniqueRetrievalArticle.size();
-							if(retrievalArticleCountByLookUpType > 0) {
-								articleCountEvidence.setCountArticlesRetrieved(retrievalArticleCountByLookUpType);
-								articleCountEvidence.setArticleCountScore(-(retrievalArticleCountByLookUpType - ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())/ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
-							} else {
-								articleCountEvidence.setCountArticlesRetrieved(this.numberOfArticles);
-								articleCountEvidence.setArticleCountScore(-(this.numberOfArticles - ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())/ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
-							}
+			ArticleCountEvidence articleCountEvidence = new ArticleCountEvidence();
+
+			if (eSearchCount != null && eSearchCount.getESearchCount() > 0) {
+				// Use true eSearch count stored during retrieval — log scale.
+				// This gives accurate name-ambiguity signal even for common names (e.g., Y Wang: 346K results).
+				int trueCount = eSearchCount.getESearchCount();
+				double logScore = Math.log(Math.max(trueCount, 1));
+				articleCountEvidence.setCountArticlesRetrieved(trueCount);
+				articleCountEvidence.setArticleCountScore(logScore);
+				slf4jLogger.info("Pmid: {} using stored eSearchCount={}, articleCountScore=log({})={}",
+						reCiterArticle.getArticleId(), trueCount, trueCount, logScore);
+
+			} else if (eSearchResult != null && this.numberOfArticles > 0) {
+				// Fallback: use retrieved PMID count with linear formula.
+				// This path handles: (a) old data without eSearchCount, (b) persons below the threshold
+				// where retrieved count == true count and the existing formula is adequate.
+				int retrievalArticleCountByLookUpType = 0;
+				if (eSearchResult.getQueryType() != null
+						&& (eSearchResult.getQueryType() == QueryType.LENIENT_LOOKUP
+							|| eSearchResult.getQueryType() == QueryType.STRICT_COMPOUND_NAME_LOOKUP)) {
+					if (eSearchResult.getESearchPmids() != null && !eSearchResult.getESearchPmids().isEmpty()) {
+						Set<Long> uniqueRetrievalArticle = new HashSet<>();
+						eSearchResult.getESearchPmids().stream()
+								.filter(eSearchPmid ->
+										!eSearchPmid.getRetrievalStrategyName()
+												.equalsIgnoreCase("GoldStandardRetrievalStrategy")
+										&& eSearchPmid.getLookupType() == RetrievalRefreshFlag.ALL_PUBLICATIONS)
+								.map(ESearchPmid::getPmids)
+								.forEach(uniqueRetrievalArticle::addAll);
+						retrievalArticleCountByLookUpType = uniqueRetrievalArticle.size();
+						if (retrievalArticleCountByLookUpType > 0) {
+							articleCountEvidence.setCountArticlesRetrieved(retrievalArticleCountByLookUpType);
+							articleCountEvidence.setArticleCountScore(
+									-(retrievalArticleCountByLookUpType
+											- ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())
+											/ ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
+						} else {
+							articleCountEvidence.setCountArticlesRetrieved(this.numberOfArticles);
+							articleCountEvidence.setArticleCountScore(
+									-(this.numberOfArticles
+											- ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())
+											/ ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
 						}
-			} else if(eSearchResult != null
-					&&
-					eSearchResult.getQueryType() != null 
-					&&
-					eSearchResult.getQueryType() == QueryType.STRICT_EXCEEDS_THRESHOLD_LOOKUP){//Strict Lookup
-				articleCountEvidence.setCountArticlesRetrieved(ReCiterArticleScorer.strategyParameters.getSearchStrategyLeninentThreshold());
-				articleCountEvidence.setArticleCountScore(-(ReCiterArticleScorer.strategyParameters.getSearchStrategyLeninentThreshold() - ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())/ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
+					}
+				} else if (eSearchResult.getQueryType() != null
+						&& eSearchResult.getQueryType() == QueryType.STRICT_EXCEEDS_THRESHOLD_LOOKUP) {
+					// Old STRICT_EXCEEDS_THRESHOLD records without eSearchCount — use threshold as floor.
+					// This is the same behavior as before; these records will get accurate counts
+					// after their next retrieval run.
+					articleCountEvidence.setCountArticlesRetrieved(
+							(int) ReCiterArticleScorer.strategyParameters.getSearchStrategyLeninentThreshold());
+					articleCountEvidence.setArticleCountScore(
+							-(ReCiterArticleScorer.strategyParameters.getSearchStrategyLeninentThreshold()
+									- ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())
+									/ ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
+				}
+
+				slf4jLogger.info("Pmid: {} {}", reCiterArticle.getArticleId(), articleCountEvidence.toString());
 			}
-			
+
 			reCiterArticle.setArticleCountEvidence(articleCountEvidence);
-			slf4jLogger.info("Pmid: " + reCiterArticle.getArticleId() + " " + articleCountEvidence.toString());
-		
-		}
 		});
+
 		return 0;
 	}
 

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/cites/strategy/CitesFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/cites/strategy/CitesFeedbackStrategy.java
@@ -60,8 +60,12 @@ public class CitesFeedbackStrategy extends AbstractTargetAuthorFeedbackStrategy 
 		stopWatchforCitesFeedback.start("Cites");
 		try {
 			slf4jLogger.info("reCiterArticles size in cites: ", reCiterArticles.size());
-			
-				 
+
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 			 Map<Long, ReCiterArticle> articleMap = reCiterArticles.stream()
 		                .collect(Collectors.toMap(ReCiterArticle::getArticleId, Function.identity()));
 			 
@@ -146,8 +150,16 @@ public class CitesFeedbackStrategy extends AbstractTargetAuthorFeedbackStrategy 
 	       							    int overallCountAccepted = citingArticlesCountAccepted + citedArticlesCountAccepted;
 	       							    
 	
-	       							    double scoreAll = computeScore(overallCountAccepted, overallCountRejected);
-	         							 
+	       							    double scoreAllBase = computeScore(overallCountAccepted, overallCountRejected);
+
+	       							    // Informed absence: no citing/cited articles in accepted or rejected
+	       							    final double scoreAll;
+	       							    if (overallCountAccepted == 0 && overallCountRejected == 0 && totalAccepted > 0) {
+	       							        scoreAll = computeInformedAbsencePenalty(totalAccepted);
+	       							    } else {
+	       							        scoreAll = scoreAllBase;
+	       							    }
+
 	         							 //Club the Rejected Articles and Accepted Articles
 	         							 List<ReCiterArticle> mergedList = Stream.of(
 	         									 (citingAcceptedArticles != null && !citingAcceptedArticles.isEmpty()) ? citingAcceptedArticles : new ArrayList<ReCiterArticle>(), 

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/coauthorname/strategy/CoauthorNameFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/coauthorname/strategy/CoauthorNameFeedbackStrategy.java
@@ -81,11 +81,14 @@ public class CoauthorNameFeedbackStrategy extends AbstractTargetAuthorFeedbackSt
 	        List<ReCiterArticle> acceptedArticles = groupedByGoldStandard.getOrDefault(ACCEPTED, Collections.emptyList());
 	        List<ReCiterArticle> rejectedArticles = groupedByGoldStandard.getOrDefault(REJECTED, Collections.emptyList());
 
+	        // Count co-author appearances across articles, deduplicating within each article
+	        // so the same co-author listed twice on one paper only counts once for that paper
 	        Map<String, Long> acceptArticlesCountByCoAuthor =  acceptedArticles.stream()
-            .flatMap(article -> article.getArticleCoAuthors().getAuthors().stream())
-            .filter(author-> !author.isTargetAuthor())
-            .map(author->processAuthor(author))
-            .filter(name -> name != null)  // Filter out initial-only names
+            .flatMap(article -> article.getArticleCoAuthors().getAuthors().stream()
+                .filter(author-> !author.isTargetAuthor())
+                .map(author->processAuthor(author))
+                .filter(name -> name != null)
+                .distinct())  // Deduplicate within each article
             .collect(Collectors.groupingBy(
                 Function.identity(),
                 Collectors.counting()
@@ -93,10 +96,11 @@ public class CoauthorNameFeedbackStrategy extends AbstractTargetAuthorFeedbackSt
 
 
 	        Map<String, Long> rejectedArticlesCountByCoAuthor =  rejectedArticles.stream()
-	                .flatMap(article -> article.getArticleCoAuthors().getAuthors().stream())
-	                .filter(author-> !author.isTargetAuthor())
-	                .map(author->processAuthor(author))
-	                .filter(name -> name != null)  // Filter out initial-only names
+	                .flatMap(article -> article.getArticleCoAuthors().getAuthors().stream()
+	                    .filter(author-> !author.isTargetAuthor())
+	                    .map(author->processAuthor(author))
+	                    .filter(name -> name != null)
+	                    .distinct())  // Deduplicate within each article
 	                .collect(Collectors.groupingBy(
 	                    Function.identity(),
 	                    Collectors.counting()
@@ -122,6 +126,7 @@ public class CoauthorNameFeedbackStrategy extends AbstractTargetAuthorFeedbackSt
 				.filter(author -> author != null && !author.isTargetAuthor())
 				.map(author -> processAuthor(author))        // Process each author to get the name
 				.filter(coAuthorName -> coAuthorName != null && !coAuthorName.isEmpty())
+				.distinct()  // Fix #394: same co-author listed twice on one paper only scored once
 				.forEach(coAuthorName -> {
 
 

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/coauthorname/strategy/CoauthorNameFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/coauthorname/strategy/CoauthorNameFeedbackStrategy.java
@@ -68,6 +68,11 @@ public class CoauthorNameFeedbackStrategy extends AbstractTargetAuthorFeedbackSt
 		try {
 			slf4jLogger.info("reCiterArticles size: ", reCiterArticles.size());
 
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 			// Group articles by gold standard
 	        Map<Integer, List<ReCiterArticle>> groupedByGoldStandard = reCiterArticles.stream()
 	            .collect(Collectors.groupingBy(ReCiterArticle::getGoldStandard));
@@ -157,6 +162,12 @@ public class CoauthorNameFeedbackStrategy extends AbstractTargetAuthorFeedbackSt
 							}
 							itemScore = computeScore(updatedCountAccepted , updatedCountRejected);
 						}
+						// Informed absence: if this co-author has never appeared in any
+						// accepted or rejected article, but the researcher has acceptance
+						// history, apply a negative penalty instead of leaving at 0.0
+						else if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+							itemScore = computeInformedAbsencePenalty(totalAccepted);
+						}
 						//Divide item score by count of the coAuthor of the interested article
 						if(nonTargetAuthorCountsByArticle !=null && nonTargetAuthorCountsByArticle.size() > 0)
 						{
@@ -171,6 +182,12 @@ public class CoauthorNameFeedbackStrategy extends AbstractTargetAuthorFeedbackSt
 								if(article.getGoldStandard() == -1 && coAuthorsCount > 0)
 								{
 									sumRejected = itemScore / coAuthorsCount;
+								}
+								// Also normalize for unasserted (NULL) articles so consortium
+								// papers with thousands of authors don't accumulate extreme scores
+								if(article.getGoldStandard() == 0 && coAuthorsCount > 0)
+								{
+									itemScore = itemScore / coAuthorsCount;
 								}
 
 							}

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/email/strategy/EmailFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/email/strategy/EmailFeedbackStrategy.java
@@ -53,7 +53,12 @@ public class EmailFeedbackStrategy extends AbstractTargetAuthorFeedbackStrategy 
 		stopWatchforEmailFeedback.start("Email");
 		try {
 			slf4jLogger.info("reCiterArticles size: ", reCiterArticles.size());
-			
+
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 			 Map<String, Map<Integer, Long>> emailCountsByArticleStatus = reCiterArticles.stream()
 	        		 .filter(article -> article!=null && article.getArticleCoAuthors() !=null && article.getArticleCoAuthors().getAuthors()!=null && article.getArticleCoAuthors().getAuthors().size() > 0)
 	                .flatMap(article -> article.getArticleCoAuthors().getAuthors().stream()
@@ -133,9 +138,19 @@ public class EmailFeedbackStrategy extends AbstractTargetAuthorFeedbackStrategy 
 																	   scoreWithout1Rejected,article.getGoldStandard(),feedbackScore,exportedFeedbackScore,"Email");
 															
 															feedbackEmailMap.computeIfAbsent(email, k -> new ArrayList<>()).add(feedbackEmail);
-															
+
 														}
-													
+													// Informed absence: email never seen
+													else if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+														double penalty = computeInformedAbsencePenalty(totalAccepted);
+														String exportedFeedbackScore = decimalFormat.format(penalty);
+														ReCiterArticleFeedbackScore feedbackEmail = populateArticleFeedbackScore(article.getArticleId(),email,
+																   countAccepted,countRejected,
+																   penalty,penalty,
+																   penalty,article.getGoldStandard(),penalty,exportedFeedbackScore,"Email");
+														feedbackEmailMap.computeIfAbsent(email, k -> new ArrayList<>()).add(feedbackEmail);
+													}
+
 													}
 												});
 										 

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/institution/strategy/InstitutionFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/institution/strategy/InstitutionFeedbackStrategy.java
@@ -139,7 +139,12 @@ public class InstitutionFeedbackStrategy extends AbstractTargetAuthorFeedbackStr
 	public double executeFeedbackStrategy(List<ReCiterArticle> reCiterArticles, Identity identity) {
 
 		try {
-			
+
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 			Map<String, Map<Integer, Long>> instCountsByArticleStatus = reCiterArticles.stream()
 	        		 .filter(article -> article!=null && article.getArticleCoAuthors() !=null && article.getArticleCoAuthors().getAuthors()!=null && article.getArticleCoAuthors().getAuthors().size() > 0)
 	                .flatMap(article -> article.getArticleCoAuthors().getAuthors().stream()
@@ -231,7 +236,17 @@ public class InstitutionFeedbackStrategy extends AbstractTargetAuthorFeedbackStr
 														
 
 													}
-											
+												// Informed absence: institution never seen
+												else if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+													double penalty = computeInformedAbsencePenalty(totalAccepted);
+													String exportedFeedbackScore = decimalFormat.format(penalty);
+													ReCiterArticleFeedbackScore feedbackInst = populateArticleFeedbackScore(article.getArticleId(),institution,
+															   countAccepted,countRejected,
+															   penalty,penalty,
+															   penalty,article.getGoldStandard(),penalty,exportedFeedbackScore,"Institution");
+													feedbackInstitutionMap.computeIfAbsent(institution, k -> new ArrayList<>()).add(feedbackInst);
+												}
+
 											});
 										});
 								   

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/journal/strategy/JournalFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/journal/strategy/JournalFeedbackStrategy.java
@@ -36,6 +36,11 @@ public class JournalFeedbackStrategy extends AbstractTargetAuthorFeedbackStrateg
 		try {
 			slf4jLogger.info("reCiterArticles size:", reCiterArticles.size());
 
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 			// Count articles based on status per journal title
 	        Map<String, Map<Integer, Long>> journalTitleCountByArticleStatus = reCiterArticles.stream()
 	        	.filter(article -> article!=null && article.getJournal()!=null  && article.getJournal().getJournalTitle()!=null && !article.getJournal().getJournalTitle().isEmpty())	
@@ -96,6 +101,20 @@ public class JournalFeedbackStrategy extends AbstractTargetAuthorFeedbackStrateg
 						String exportedJournalFeedackScore = decimalFormat.format(feedbackJournal.getFeedbackScore()); 
 						article.setExportedJournalFeedackScore(exportedJournalFeedackScore);
 				 }
+				// Informed absence: journal never seen in accepted or rejected
+				else if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+					double penalty = computeInformedAbsencePenalty(totalAccepted);
+					String exportedFeedbackScore = decimalFormat.format(penalty);
+					ReCiterArticleFeedbackScore feedbackJournal = populateArticleFeedbackScore(article.getArticleId(),article.getJournal().getJournalTitle(),
+																							   countAccepted,countRejected,
+																							   penalty,penalty,
+																							   penalty,article.getGoldStandard(),penalty,exportedFeedbackScore,"Journal");
+					feedbackJournalsListMap.computeIfAbsent(article.getJournal().getJournalTitle().trim(), k -> new ArrayList<>()).add(feedbackJournal);
+					article.addArticleFeedbackScoresMap(feedbackJournalsListMap);
+					article.setJournalFeedackScore(feedbackJournal.getFeedbackScore());
+					String exportedJournalFeedackScore = decimalFormat.format(feedbackJournal.getFeedbackScore());
+					article.setExportedJournalFeedackScore(exportedJournalFeedackScore);
+			 }
 			});
 			} catch (Exception e) {
 				e.printStackTrace();

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/journalsubfield/strategy/JournalSubFieldFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/journalsubfield/strategy/JournalSubFieldFeedbackStrategy.java
@@ -27,6 +27,7 @@ public class JournalSubFieldFeedbackStrategy extends AbstractTargetAuthorFeedbac
 	private static final Logger slf4jLogger = LoggerFactory.getLogger(JournalSubFieldFeedbackStrategy.class);
 	
 	private Map<String, List<ReCiterArticleFeedbackScore>> feedbackJournalsSubFieldMap = new HashMap<>();
+	private int totalAccepted = 0;
 	
 	Set<String> filterJournalSubFields = Stream.of("General Science & Technology")
             .collect(Collectors.toSet());
@@ -46,6 +47,11 @@ public class JournalSubFieldFeedbackStrategy extends AbstractTargetAuthorFeedbac
 	public double executeFeedbackStrategy(List<ReCiterArticle> reCiterArticles, Identity identity) {
 		try {
 	        slf4jLogger.info("reCiterArticles size: {}", reCiterArticles.size());
+
+	        // Compute total accepted articles for informed absence penalty
+	        totalAccepted = (int) reCiterArticles.stream()
+	            .filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+	            .count();
 
 	        // Group by gold standard
 	        Map<Integer, List<ReCiterArticle>> groupedByGoldStandard = reCiterArticles.stream()
@@ -123,6 +129,14 @@ public class JournalSubFieldFeedbackStrategy extends AbstractTargetAuthorFeedbac
 	    double scoreAll = computeScore(countAccepted, countRejected);
 	    double scoreWithout1Accepted = computeScore(countAccepted > 0 ? countAccepted - 1 : countAccepted, countRejected);
 	    double scoreWithout1Rejected = computeScore(countAccepted, countRejected > 0 ? countRejected - 1 : countRejected);
+
+	    // Informed absence: journal subfield never seen in accepted or rejected
+	    if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+	        double penalty = computeInformedAbsencePenalty(totalAccepted);
+	        scoreAll = penalty;
+	        scoreWithout1Accepted = penalty;
+	        scoreWithout1Rejected = penalty;
+	    }
 
 	    double feedbackScore = determineFeedbackScore(article.getGoldStandard(), scoreWithout1Accepted, scoreWithout1Rejected, scoreAll);
 	    String exportedFeedbackScore = decimalFormat.format(feedbackScore);

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/keyword/strategy/KeywordFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/keyword/strategy/KeywordFeedbackStrategy.java
@@ -79,8 +79,12 @@ public class KeywordFeedbackStrategy extends AbstractTargetAuthorFeedbackStrateg
 								                MeshTerm::getCount      // Use the count as the value
 								            ));
 			slf4jLogger.info("reCiterArticles size: ", reCiterArticles.size());
-			
-			
+
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 	        Map<String, Map<Integer, Long>> keywordCountsByArticleStatus = reCiterArticles.stream()
 	        		 .filter(article -> article!=null && article.getMeshHeadings() !=null && article.getMeshHeadings().size() > 0)
 	                .flatMap(article -> article.getMeshHeadings().stream()
@@ -171,9 +175,27 @@ public class KeywordFeedbackStrategy extends AbstractTargetAuthorFeedbackStrateg
 																   scoreWithout1Rejected,article.getGoldStandard(),feedbackScore,exportedFeedbackScore,"Keyword");
 														
 														feedbackKeywordMap.computeIfAbsent(keyword, k -> new ArrayList<>()).add(feedbackEmail);
-														
+
 													}
-												
+												// Informed absence: keyword never seen
+												else if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+													double penalty = computeInformedAbsencePenalty(totalAccepted);
+													long meshCount = 0;
+													double factor = 1.0;
+													if(meshCounts!=null && meshCounts.containsKey(keyword))
+													{
+														meshCount = meshCounts.get(keyword);
+														factor = calculateFactor(meshCount);
+														penalty = penalty * factor;
+													}
+													String exportedFeedbackScore = decimalFormat.format(penalty);
+													ReCiterArticleFeedbackScore feedbackEmail = populateArticleFeedbackScore(article.getArticleId(),keyword,
+															   countAccepted,countRejected,
+															   penalty,penalty,
+															   penalty,article.getGoldStandard(),penalty,exportedFeedbackScore,"Keyword");
+													feedbackKeywordMap.computeIfAbsent(keyword, k -> new ArrayList<>()).add(feedbackEmail);
+												}
+
 												}
 											});
 

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/orcid/strategy/OrcidFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/orcid/strategy/OrcidFeedbackStrategy.java
@@ -55,6 +55,11 @@ public class OrcidFeedbackStrategy extends AbstractTargetAuthorFeedbackStrategy 
 		try {
 			slf4jLogger.info("reCiterArticles size: ", reCiterArticles.size());
 
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 			List<ReCiterArticle> filteredArticles = reCiterArticles.stream()
 					.filter(article -> article.getGoldStandard() != 0)
 					 .collect(Collectors.toList());
@@ -93,7 +98,14 @@ public class OrcidFeedbackStrategy extends AbstractTargetAuthorFeedbackStrategy 
 							scoreWithout1Rejected = computeScore(countAccepted,
 									countRejected > 0 ? countRejected - 1 : countRejected);
 
-							
+							// Informed absence: orcid never seen in accepted or rejected
+							if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+								double penalty = computeInformedAbsencePenalty(totalAccepted);
+								scoreAll = penalty;
+								scoreWithout1Accepted = penalty;
+								scoreWithout1Rejected = penalty;
+							}
+
 							double feedbackScore= determineFeedbackScore(article.getGoldStandard(),scoreWithout1Accepted, scoreWithout1Rejected, scoreAll);
 							String exportedFeedbackScore = decimalFormat.format(feedbackScore);
 							

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/organization/strategy/OrganizationFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/organization/strategy/OrganizationFeedbackStrategy.java
@@ -85,7 +85,12 @@ public class OrganizationFeedbackStrategy extends AbstractTargetAuthorFeedbackSt
 	@Override
 	public double executeFeedbackStrategy(List<ReCiterArticle> reCiterArticles, Identity identity) {
 		try {
-			
+
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 			 Map<String, Map<Integer, Long>> orgCountsByArticleStatus = reCiterArticles.stream()
 	        		 .filter(article -> article!=null && article.getArticleCoAuthors() !=null && article.getArticleCoAuthors().getAuthors()!=null && article.getArticleCoAuthors().getAuthors().size() > 0)
 	                .flatMap(article -> article.getArticleCoAuthors().getAuthors().stream()
@@ -173,7 +178,17 @@ public class OrganizationFeedbackStrategy extends AbstractTargetAuthorFeedbackSt
 													}
 
 												}
-											
+											// Informed absence: organization never seen
+											else if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+												double penalty = computeInformedAbsencePenalty(totalAccepted);
+												String exportedFeedbackScore = decimalFormat.format(penalty);
+												ReCiterArticleFeedbackScore feedbackOrg = populateArticleFeedbackScore(article.getArticleId(),organization,
+														   countAccepted,countRejected,
+														   penalty,penalty,
+														   penalty,article.getGoldStandard(),penalty,exportedFeedbackScore, "Organization");
+												feedbackOrganizationMap.computeIfAbsent(organization, k -> new ArrayList<>()).add(feedbackOrg);
+											}
+
 											});
 										});
 								   

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/targetauthorname/strategy/TargetAuthorNameFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/targetauthorname/strategy/TargetAuthorNameFeedbackStrategy.java
@@ -50,8 +50,12 @@ public class TargetAuthorNameFeedbackStrategy extends AbstractTargetAuthorFeedba
 
 		try {
 			slf4jLogger.info("reCiterArticles size: " + reCiterArticles.size());
-			
-			
+
+			// Compute total accepted articles for informed absence penalty
+			final int totalAccepted = (int) reCiterArticles.stream()
+				.filter(a -> a != null && a.getGoldStandard() == ACCEPTED)
+				.count();
+
 			Map<String, Map<Integer, Long>> targetAuthorNameCountsByArticleStatus = reCiterArticles.stream()
 				    .filter(article -> article != null &&
 				                       article.getArticleCoAuthors() != null &&
@@ -124,8 +128,17 @@ public class TargetAuthorNameFeedbackStrategy extends AbstractTargetAuthorFeedba
 										countAccepted > 0 ? countAccepted - 1 : countAccepted, countRejected);
 								scoreWithout1Rejected = computeScore(countAccepted,
 										countRejected > 0 ? countRejected - 1 : countRejected);
-								
-								
+
+								// Informed absence: if this author name has never appeared in any
+								// accepted or rejected article, but the researcher has substantial
+								// acceptance history, apply a negative penalty instead of 0.0
+								if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
+									double penalty = computeInformedAbsencePenalty(totalAccepted);
+									scoreAll = penalty;
+									scoreWithout1Accepted = penalty;
+									scoreWithout1Rejected = penalty;
+								}
+
 								double feedbackScore= determineFeedbackScore(article.getGoldStandard(),scoreWithout1Accepted, scoreWithout1Rejected, scoreAll);
 								String exportedFeedbackScore = decimalFormat.format(feedbackScore);
 								

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/name/strategy/ScoreByNameStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/name/strategy/ScoreByNameStrategy.java
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 import reciter.algorithm.cluster.article.scorer.ReCiterArticleScorer;
 import reciter.algorithm.evidence.targetauthor.AbstractTargetAuthorStrategy;
 import reciter.algorithm.util.ReCiterStringUtil;
+import reciter.database.dynamodb.model.NameFrequency;
+import reciter.engine.EngineParameters;
 import reciter.engine.Feature;
 import reciter.engine.analysis.evidence.AuthorNameEvidence;
 import reciter.model.article.ReCiterArticle;
@@ -137,13 +139,65 @@ public class ScoreByNameStrategy extends AbstractTargetAuthorStrategy {
 				authorNameEvidence.setNameMatchMiddleType("nullTargetAuthor-MatchNotAttempted");
 			}
 			
+			// Add first name frequency modifier: rare names get higher scores
+			double nameFreqScore = computeFirstNameFrequencyScore(identity);
+			if (nameFreqScore != 0.0 && authorNameEvidence.getNameMatchFirstScore() > 0) {
+				double currentModifier = authorNameEvidence.getNameMatchModifierScore();
+				authorNameEvidence.setNameMatchModifierScore(currentModifier + nameFreqScore);
+				authorNameEvidence.setNameScoreTotal(
+					authorNameEvidence.getNameMatchFirstScore()
+					+ authorNameEvidence.getNameMatchLastScore()
+					+ authorNameEvidence.getNameMatchMiddleScore()
+					+ authorNameEvidence.getNameMatchModifierScore()
+				);
+			}
+
 			reCiterArticle.setAuthorNameEvidence(authorNameEvidence);
-			
+
 			slf4jLogger.info("Pmid: " + reCiterArticle.getArticleId() + " " + authorNameEvidence.toString());
 		}
 		return 1;
 	}
 	
+	/**
+	 * Compute IDF-like score for the identity's first name.
+	 * Rare names get higher scores; common names get ~0.
+	 * For compound names (e.g., "Jean-Pierre"), averages the scores of each token.
+	 */
+	private double computeFirstNameFrequencyScore(Identity identity) {
+		Map<String, NameFrequency> nameFrequencyMap = EngineParameters.getNameFrequencyMap();
+		if (nameFrequencyMap == null || nameFrequencyMap.isEmpty()) {
+			return 0.0;
+		}
+		String firstName = (identity.getPrimaryName() != null && identity.getPrimaryName().getFirstName() != null)
+				? identity.getPrimaryName().getFirstName().trim() : "";
+		if (firstName.isEmpty()) {
+			return 0.0;
+		}
+		// Split compound names by spaces and hyphens, discard single-char tokens (initials)
+		String[] tokens = firstName.toLowerCase().split("[\\s\\-]+");
+		double totalScore = 0.0;
+		int validTokens = 0;
+		for (String token : tokens) {
+			token = token.replaceAll("[^a-z]", "");
+			if (token.length() <= 1) {
+				continue;
+			}
+			NameFrequency nf = nameFrequencyMap.get(token);
+			if (nf != null) {
+				totalScore += nf.getScore();
+			} else {
+				// Unknown name — use median score (0.9997 from our frequency table)
+				totalScore += 1.0;
+			}
+			validTokens++;
+		}
+		if (validTokens == 0) {
+			return 0.0;
+		}
+		return totalScore / validTokens;
+	}
+
 	private void scoreCombinedMiddleLastName(AuthorName identityAuthor, AuthorName identityAuthorNameOriginal, Map<ReCiterAuthor, ReCiterAuthor> articleAuthorNames, AuthorNameEvidence authorNameEvidence) {
 		if(articleAuthorNames.size() > 0) {
 			Map.Entry<ReCiterAuthor,ReCiterAuthor> entry = articleAuthorNames.entrySet().iterator().next();

--- a/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
+++ b/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
@@ -40,6 +40,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import reciter.algorithm.article.score.predictor.NeuralNetworkModelArticlesScorer;
 import reciter.algorithm.evidence.StrategyContext;
@@ -551,25 +552,36 @@ public class ReciterFeedbackArticleScorer extends AbstractFeedbackArticleScorer 
 														    		    .collect(Collectors.toList());
 	
     	ObjectMapper objectMapper = new ObjectMapper();
-    	
+
+    	// Enrich scores with identity first name for name frequency scoring in Python
+    	String identityFirstName = (identity.getPrimaryName() != null && identity.getPrimaryName().getFirstName() != null)
+    	        ? identity.getPrimaryName().getFirstName() : "";
+    	List<ObjectNode> enrichedScores = articleIdentityFeedbackScore.stream()
+    	        .map(score -> {
+    	            ObjectNode node = objectMapper.convertValue(score, ObjectNode.class);
+    	            node.put("identityFirstName", identityFirstName);
+    	            return node;
+    	        })
+    	        .collect(Collectors.toList());
+
 		String fileName = StringUtils.join(identity.getUid(), "-feedbackIdentityScoringInput.json");
 		boolean isS3UploadRequired = isS3UploadRequired();
 		String feedbackIdentityS3BucketName = PropertiesUtils.get("aws.s3.feedback.score.bucketName");
         try {
-			NeuralNetworkModelArticlesScorer nnmodel = new NeuralNetworkModelArticlesScorer();																			   
-        	  if(isS3UploadRequired) 
+			NeuralNetworkModelArticlesScorer nnmodel = new NeuralNetworkModelArticlesScorer();
+        	  if(isS3UploadRequired)
         	  {
         		  File jsonFile = new File(fileName);
-        		  
+
         		// Write the User object to the JSON file
-                  objectMapper.writeValue(jsonFile, articleIdentityFeedbackScore);
+                  objectMapper.writeValue(jsonFile, enrichedScores);
                   log.info("JSON data written to file successfully: ", jsonFile.getAbsolutePath());
                   uploadJsonFileIntoS3(fileName, jsonFile);
         	  }
         	  else
-        	  {	  
+        	  {
         		  File jsonFile = new File("src/main/resources/scripts/"+fileName);
-	        	  objectMapper.writeValue(jsonFile,articleIdentityFeedbackScore);
+	        	  objectMapper.writeValue(jsonFile, enrichedScores);
 				  log.info("JSON written to file successfully.", jsonFile.getAbsolutePath() +"-" + fileName);
         	  }
         	  String isS3UploadRequiredString = Boolean.toString(isS3UploadRequired);

--- a/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
+++ b/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
@@ -123,21 +123,80 @@ public class ReciterFeedbackArticleScorer extends AbstractFeedbackArticleScorer 
 		ReciterFeedbackArticleScorer.strategyParameters = strategyParameters;
 		this.reciterArticles = articles;
 		this.identity = identity;
-		this.journalStrategyContext = new JournalFeedbackStrategyContext(new JournalFeedbackStrategy());
-		this.journalSubFieldStrategyContext = new JournalSubFieldFeedbackStrategyContext(new JournalSubFieldFeedbackStrategy());
-		this.orcidStrategyContext = new OrcidFeedbackStrategyContext(new OrcidFeedbackStrategy());
+
+		// Configure informed absence for target author name strategy
+		TargetAuthorNameFeedbackStrategy targetAuthorNameStrategy = new TargetAuthorNameFeedbackStrategy();
+		targetAuthorNameStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceTargetAuthorNameStrength());
+
+		// Configure informed absence for co-author name strategy
+		CoauthorNameFeedbackStrategy coAuthorNameStrategy = new CoauthorNameFeedbackStrategy();
+		coAuthorNameStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceCoAuthorNameStrength());
+
+		JournalFeedbackStrategy journalStrategy = new JournalFeedbackStrategy();
+		journalStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceJournalStrength());
+
+		JournalSubFieldFeedbackStrategy journalSubFieldStrategy = new JournalSubFieldFeedbackStrategy();
+		journalSubFieldStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceJournalSubFieldStrength());
+
+		OrcidFeedbackStrategy orcidStrategy = new OrcidFeedbackStrategy();
+		orcidStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceOrcidStrength());
+
+		this.journalStrategyContext = new JournalFeedbackStrategyContext(journalStrategy);
+		this.journalSubFieldStrategyContext = new JournalSubFieldFeedbackStrategyContext(journalSubFieldStrategy);
+		this.orcidStrategyContext = new OrcidFeedbackStrategyContext(orcidStrategy);
 		this.yearStrategyContext = new YearFeedbackStrategyContext(new YearFeedbackStrategy());
-		this.targetAuthorNameStrategyContext = new TargetAuthorNameFeedbackStrategyContext(new TargetAuthorNameFeedbackStrategy());
-		this.organizationStrategyContext = new OrganizationFeedbackStrategyContext(new OrganizationFeedbackStrategy());
+		this.targetAuthorNameStrategyContext = new TargetAuthorNameFeedbackStrategyContext(targetAuthorNameStrategy);
+		OrganizationFeedbackStrategy organizationStrategy = new OrganizationFeedbackStrategy();
+		organizationStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceOrganizationStrength());
+		this.organizationStrategyContext = new OrganizationFeedbackStrategyContext(organizationStrategy);
 		this.orcidCoAuthorStrategyContext = new OrcidCoauthorFeedbackStrategyContext(new OrcidCoauthorFeedbackStrategy());
-		this.keywordStrategyContext = new KeywordFeedbackStrategyContext(new KeywordFeedbackStrategy(strategyParameters));
-		this.institutionStrategyContext = new InstitutionFeedbackStrategyContext(new InstitutionFeedbackStrategy());
-		this.emailStrategyContext = new EmailFeedbackStrategyContext(new EmailFeedbackStrategy());
-		this.coAuthorNameStrategyContext = new CoauthorNameFeedbackStrategyContext(new CoauthorNameFeedbackStrategy());
-		this.citesStrategyContext = new CitesFeedbackStrategyContext(new CitesFeedbackStrategy());
+		KeywordFeedbackStrategy keywordStrategy = new KeywordFeedbackStrategy(strategyParameters);
+		keywordStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceKeywordStrength());
+		this.keywordStrategyContext = new KeywordFeedbackStrategyContext(keywordStrategy);
+		InstitutionFeedbackStrategy institutionStrategy = new InstitutionFeedbackStrategy();
+		institutionStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceInstitutionStrength());
+		this.institutionStrategyContext = new InstitutionFeedbackStrategyContext(institutionStrategy);
+
+		EmailFeedbackStrategy emailStrategy = new EmailFeedbackStrategy();
+		emailStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceEmailStrength());
+		this.emailStrategyContext = new EmailFeedbackStrategyContext(emailStrategy);
+		this.coAuthorNameStrategyContext = new CoauthorNameFeedbackStrategyContext(coAuthorNameStrategy);
+		CitesFeedbackStrategy citesStrategy = new CitesFeedbackStrategy();
+		citesStrategy.setInformedAbsenceConfig(
+			strategyParameters.isInformedAbsenceEnabled(),
+			strategyParameters.getInformedAbsenceScale(),
+			strategyParameters.getInformedAbsenceCitesStrength());
+		this.citesStrategyContext = new CitesFeedbackStrategyContext(citesStrategy);
 		this.feedbackEvidenceStrategyContext = new FeedbackEvidenceStrategyContext(new FeedbackEvidenceStrategy());
-		
-		
+
+
 	}
 	public void runFeedbackArticleScorer(List<ReCiterArticle> reCiterArticles, Identity identity) 
 	{

--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -33,6 +33,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.LocalDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import reciter.algorithm.cluster.similarity.clusteringstrategy.article.MeshMajorClusteringStrategy;
@@ -74,6 +76,8 @@ import reciter.utils.AuthorNameSanitizationUtils;
  */
 @Component
 public class ArticleTranslator {
+
+    private static final Logger slf4jLogger = LoggerFactory.getLogger(ArticleTranslator.class);
 
     /**
      * Translates a PubmedArticle into a ReCiterArticle.
@@ -159,6 +163,17 @@ public class ArticleTranslator {
                     } else if (initials != null) {
                         firstName = initials;
                     }
+                    // Fix #529: Detect reversed names where lastName is a single character
+                    // and firstName is a full name (e.g., lastName="S", firstName="John").
+                    // PubMed occasionally parses names this way (~0.03% of records).
+                    if (firstName != null && firstName.length() > 1 && lastName.length() == 1) {
+                        String temp = lastName;
+                        lastName = firstName;
+                        firstName = temp;
+                        slf4jLogger.info("Swapped reversed author name for PMID {}: firstName='{}', lastName='{}'",
+                            pubmedArticle.getMedlinecitation().getMedlinecitationpmid().getPmid(), firstName, lastName);
+                    }
+
                     String affiliation = author.getAffiliation();
                     AuthorName authorName = new AuthorName(firstName, middleName, lastName);
 

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -545,7 +545,7 @@ public class ReCiterController {
 						    .map(featureArticle -> {
 						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
 						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : -1 );
+						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
 						        return article;
 						    })
 						    .collect(Collectors.toList());
@@ -563,7 +563,7 @@ public class ReCiterController {
 						    .map(featureArticle -> {
 						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
 						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : -1 );
+						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
 						        return article;
 						    })
 						    .collect(Collectors.toList());
@@ -581,7 +581,7 @@ public class ReCiterController {
 						    .map(featureArticle -> {
 						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
 						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : -1 );
+						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
 						        return article;
 						    })
 						    .collect(Collectors.toList());
@@ -605,7 +605,7 @@ public class ReCiterController {
 						    .map(featureArticle -> {
 						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
 						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : -1 );
+						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
 						        return article;
 						    })
 						    .collect(Collectors.toList());
@@ -629,7 +629,7 @@ public class ReCiterController {
 						    .map(featureArticle -> {
 						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
 						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : -1 );
+						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
 						        return article;
 						    })
 						    .collect(Collectors.toList());
@@ -649,7 +649,7 @@ public class ReCiterController {
 						    .map(featureArticle -> {
 						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
 						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : -1 );
+						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
 						        return article;
 						    })
 						    .collect(Collectors.toList());
@@ -670,7 +670,7 @@ public class ReCiterController {
 						    .map(featureArticle -> {
 						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
 						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : -1 );
+						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
 						        return article;
 						    })
 						    .collect(Collectors.toList());

--- a/src/main/java/reciter/database/dyanmodb/files/NameFrequencyFileImport.java
+++ b/src/main/java/reciter/database/dyanmodb/files/NameFrequencyFileImport.java
@@ -1,0 +1,45 @@
+package reciter.database.dyanmodb.files;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+import reciter.database.dynamodb.model.NameFrequency;
+import reciter.service.NameFrequencyService;
+
+@Slf4j
+@Component
+public class NameFrequencyFileImport {
+
+	@Autowired
+	private NameFrequencyService nameFrequencyService;
+
+	public void importNameFrequency() {
+		ObjectMapper mapper = new ObjectMapper();
+		List<NameFrequency> nameFrequencies = null;
+		try {
+			nameFrequencies = Arrays.asList(mapper.readValue(getClass().getResourceAsStream("/files/NameFrequency.json"), NameFrequency[].class));
+		} catch (IOException e) {
+			log.error("IOException", e);
+		}
+		if(nameFrequencies != null
+				&&
+				nameFrequencies.size() == nameFrequencyService.getItemCount()) {
+			log.info("The file NameFrequency.json and the NameFrequency table in DynamoDb is isomorphic and hence skipping import.");
+		} else {
+			if(nameFrequencies != null
+					&&
+					!nameFrequencies.isEmpty()) {
+				log.info("The file NameFrequency.json and the NameFrequency table in DynamoDb is not isomorphic and hence starting import.");
+				nameFrequencyService.save(nameFrequencies);
+			}
+		}
+	}
+
+}

--- a/src/main/java/reciter/database/dynamodb/model/ESearchCount.java
+++ b/src/main/java/reciter/database/dynamodb/model/ESearchCount.java
@@ -1,0 +1,20 @@
+package reciter.database.dynamodb.model;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@DynamoDBTable(tableName = "ESearchCount")
+public class ESearchCount {
+
+    @DynamoDBHashKey
+    private String uid;
+
+    private int eSearchCount;
+}

--- a/src/main/java/reciter/database/dynamodb/model/NameFrequency.java
+++ b/src/main/java/reciter/database/dynamodb/model/NameFrequency.java
@@ -1,0 +1,24 @@
+package reciter.database.dynamodb.model;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@DynamoDBTable(tableName = "NameFrequency")
+public class NameFrequency {
+
+    @DynamoDBHashKey
+    private String name;
+
+    private int count;
+
+    private double percentile;
+
+    private double score;
+}

--- a/src/main/java/reciter/database/dynamodb/repository/ESearchCountRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/ESearchCountRepository.java
@@ -1,0 +1,10 @@
+package reciter.database.dynamodb.repository;
+
+import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
+import org.springframework.data.repository.CrudRepository;
+
+import reciter.database.dynamodb.model.ESearchCount;
+
+@EnableScan
+public interface ESearchCountRepository extends CrudRepository<ESearchCount, String> {
+}

--- a/src/main/java/reciter/database/dynamodb/repository/NameFrequencyRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/NameFrequencyRepository.java
@@ -1,0 +1,11 @@
+package reciter.database.dynamodb.repository;
+
+import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
+import org.springframework.data.repository.CrudRepository;
+
+import reciter.database.dynamodb.model.NameFrequency;
+
+@EnableScan
+public interface NameFrequencyRepository extends CrudRepository<NameFrequency, String>{
+
+}

--- a/src/main/java/reciter/engine/EngineParameters.java
+++ b/src/main/java/reciter/engine/EngineParameters.java
@@ -19,6 +19,7 @@
 package reciter.engine;
 
 import reciter.database.dynamodb.model.Gender;
+import reciter.database.dynamodb.model.NameFrequency;
 import reciter.database.dynamodb.model.ScienceMetrix;
 import reciter.database.dynamodb.model.ScienceMetrixDepartmentCategory;
 import reciter.model.article.ReCiterArticle;
@@ -51,6 +52,12 @@ public class EngineParameters {
 	@Getter
 	@Setter
     private static List<Gender> genders;
+	@Getter
+	@Setter
+    private static List<NameFrequency> nameFrequencies;
+	@Getter
+	@Setter
+    private static Map<String, NameFrequency> nameFrequencyMap;
     private Identity identity;
     private List<PubMedArticle> pubMedArticles;
     private List<ScopusArticle> scopusArticles;

--- a/src/main/java/reciter/engine/StrategyParameters.java
+++ b/src/main/java/reciter/engine/StrategyParameters.java
@@ -419,4 +419,40 @@ public class StrategyParameters {
     
     @Value("${strategy.education.year.discrepancy}")
     private boolean isEducationYearDiscrepancy;
+
+    @Value("${strategy.feedback.informedAbsence.enabled:true}")
+    private boolean informedAbsenceEnabled;
+
+    @Value("${strategy.feedback.informedAbsence.scale:10.0}")
+    private double informedAbsenceScale;
+
+    @Value("${strategy.feedback.informedAbsence.targetAuthorName.strength:1.0}")
+    private double informedAbsenceTargetAuthorNameStrength;
+
+    @Value("${strategy.feedback.informedAbsence.coAuthorName.strength:0.9}")
+    private double informedAbsenceCoAuthorNameStrength;
+
+    @Value("${strategy.feedback.informedAbsence.keyword.strength:0.9}")
+    private double informedAbsenceKeywordStrength;
+
+    @Value("${strategy.feedback.informedAbsence.journal.strength:0.7}")
+    private double informedAbsenceJournalStrength;
+
+    @Value("${strategy.feedback.informedAbsence.journalSubField.strength:0.7}")
+    private double informedAbsenceJournalSubFieldStrength;
+
+    @Value("${strategy.feedback.informedAbsence.institution.strength:0.5}")
+    private double informedAbsenceInstitutionStrength;
+
+    @Value("${strategy.feedback.informedAbsence.cites.strength:0.5}")
+    private double informedAbsenceCitesStrength;
+
+    @Value("${strategy.feedback.informedAbsence.organization.strength:0.5}")
+    private double informedAbsenceOrganizationStrength;
+
+    @Value("${strategy.feedback.informedAbsence.email.strength:0.3}")
+    private double informedAbsenceEmailStrength;
+
+    @Value("${strategy.feedback.informedAbsence.orcid.strength:0.3}")
+    private double informedAbsenceOrcidStrength;
 }

--- a/src/main/java/reciter/engine/erroranalysis/Analysis.java
+++ b/src/main/java/reciter/engine/erroranalysis/Analysis.java
@@ -1,0 +1,319 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package reciter.engine.erroranalysis;
+
+import reciter.model.article.ReCiterArticle;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Computes precision, recall, and accuracy for ReCiter article suggestions.
+ *
+ * <p><b>PENDING article handling (fixed 2026-02):</b> Articles with
+ * {@code goldStandard == 0} (PENDING / no curator decision) are excluded
+ * from all confusion-matrix counts. The old implementation treated them as
+ * false positives, which artificially deflated precision whenever undecided
+ * articles scored above the suggestion threshold.</p>
+ *
+ * <p><b>Precision formula (fixed 2026-02):</b> Now correctly computed as
+ * {@code TP / (TP + FP)}. The old implementation used
+ * {@code TP / selectedClusterSize} (total articles), which is not standard
+ * precision.</p>
+ *
+ * <p><b>Accuracy formula (fixed 2026-02):</b> Now computed as
+ * {@code (TP + TN) / (TP + TN + FP + FN)}. The old implementation used
+ * {@code (precision + recall) / 2}.</p>
+ *
+ * @author jil3004
+ */
+public class Analysis {
+
+    private double precision;
+    private double recall;
+    private double accuracy;
+
+    private int truePos;
+    private int trueNeg;
+    private int falseNeg;
+    private int falsePos;
+    private int goldStandardSize;
+    private int selectedClusterSize;
+    private int pendingSkippedCount;
+    private List<Long> truePositiveList = new ArrayList<>();
+    private List<Long> trueNegativeList = new ArrayList<>();
+    private List<Long> falsePositiveList = new ArrayList<>();
+    private List<Long> falseNegativeList = new ArrayList<>();
+
+    public Analysis() {
+    }
+
+    /**
+     * Assign gold standard labels to each ReCiterArticle based on accepted/rejected PMID lists.
+     *
+     * @param reCiterArticles articles to label
+     * @param acceptedPmids   PMIDs with ACCEPTED curator decision (goldStandard = 1)
+     * @param rejectedPmids   PMIDs with REJECTED curator decision (goldStandard = -1)
+     */
+    public static void assignGoldStandard(List<ReCiterArticle> reCiterArticles,
+                                          List<Long> acceptedPmids,
+                                          List<Long> rejectedPmids) {
+        Set<Long> acceptedSet = new HashSet<>();
+        if (acceptedPmids != null) {
+            acceptedSet.addAll(acceptedPmids);
+        }
+
+        for (ReCiterArticle article : reCiterArticles) {
+            if (acceptedSet.contains(article.getArticleId())) {
+                article.setGoldStandard(1);
+            }
+        }
+
+        if (rejectedPmids != null) {
+            Set<Long> rejectedSet = new HashSet<>(rejectedPmids);
+            for (ReCiterArticle article : reCiterArticles) {
+                if (rejectedSet.contains(article.getArticleId())) {
+                    article.setGoldStandard(-1);
+                }
+            }
+        }
+    }
+
+    /**
+     * Compute precision/recall/accuracy over a set of articles.
+     *
+     * <p>Called by {@code ReCiterController} (7 filter branches) and
+     * {@code ReCiterFeatureGenerator}.</p>
+     *
+     * @param articles          articles to evaluate; each must have
+     *                          {@code goldStandard} set (1 = ACCEPTED,
+     *                          -1 = REJECTED, 0 = PENDING/NULL)
+     * @param goldStandardPmids PMIDs of accepted (ground-truth positive)
+     *                          articles for this person
+     * @return populated Analysis object
+     */
+    public static Analysis performAnalysis(List<ReCiterArticle> articles,
+                                           List<Long> goldStandardPmids) {
+        Analysis analysis = new Analysis();
+
+        if (goldStandardPmids == null || goldStandardPmids.isEmpty()) {
+            return analysis;
+        }
+
+        Set<Long> goldSet = new HashSet<>(goldStandardPmids);
+        Set<Long> articlePmids = new HashSet<>();
+        int pendingSkipped = 0;
+
+        analysis.setGoldStandardSize(goldStandardPmids.size());
+        analysis.setSelectedClusterSize(articles.size());
+
+        for (ReCiterArticle article : articles) {
+            long pmid = article.getArticleId();
+            articlePmids.add(pmid);
+
+            // --- FIX: skip PENDING articles (goldStandard == 0) ---
+            // These have no curator decision and must not inflate FP count.
+            if (article.getGoldStandard() == 0) {
+                pendingSkipped++;
+                continue;
+            }
+
+            if (goldSet.contains(pmid)) {
+                // Ground-truth positive and present in article set → TP
+                analysis.getTruePositiveList().add(pmid);
+            } else if (article.getGoldStandard() == -1) {
+                // Confirmed rejected and present in article set → FP
+                analysis.getFalsePositiveList().add(pmid);
+            } else {
+                // goldStandard == 1 but not in goldSet — data inconsistency;
+                // treat conservatively as TN
+                analysis.getTrueNegativeList().add(pmid);
+            }
+        }
+
+        // False negatives: accepted articles NOT present in the article set
+        for (Long pmid : goldStandardPmids) {
+            if (!articlePmids.contains(pmid)) {
+                analysis.getFalseNegativeList().add(pmid);
+            }
+        }
+
+        analysis.setTruePos(analysis.getTruePositiveList().size());
+        analysis.setTrueNeg(analysis.getTrueNegativeList().size());
+        analysis.setFalsePos(analysis.getFalsePositiveList().size());
+        analysis.setFalseNeg(analysis.getFalseNegativeList().size());
+        analysis.setPendingSkippedCount(pendingSkipped);
+
+        // Cache computed values
+        analysis.setPrecision(analysis.getPrecision());
+        analysis.setRecall(analysis.getRecall());
+        analysis.setAccuracy(analysis.getAccuracy());
+
+        return analysis;
+    }
+
+    // --- Corrected metric formulas ---
+
+    /**
+     * Precision = TP / (TP + FP).
+     * <p>Old (buggy): TP / selectedClusterSize.</p>
+     */
+    public double getPrecision() {
+        int denominator = truePos + falsePos;
+        if (denominator == 0) return 0;
+        return (double) truePos / denominator;
+    }
+
+    public void setPrecision(double precision) {
+        this.precision = precision;
+    }
+
+    /**
+     * Recall = TP / goldStandardSize (= TP / (TP + FN)).
+     */
+    public double getRecall() {
+        if (goldStandardSize == 0) return 0;
+        return (double) truePos / goldStandardSize;
+    }
+
+    public void setRecall(double recall) {
+        this.recall = recall;
+    }
+
+    /**
+     * Accuracy = (TP + TN) / (TP + TN + FP + FN).
+     * <p>Old (buggy): (precision + recall) / 2.</p>
+     */
+    public double getAccuracy() {
+        int total = truePos + trueNeg + falsePos + falseNeg;
+        if (total == 0) return 0;
+        return (double) (truePos + trueNeg) / total;
+    }
+
+    public void setAccuracy(double accuracy) {
+        this.accuracy = accuracy;
+    }
+
+    // --- Getters and setters ---
+
+    public int getTruePos() {
+        return truePos;
+    }
+
+    public void setTruePos(int truePos) {
+        this.truePos = truePos;
+    }
+
+    public int getTrueNeg() {
+        return trueNeg;
+    }
+
+    public void setTrueNeg(int trueNeg) {
+        this.trueNeg = trueNeg;
+    }
+
+    public int getFalsePos() {
+        return falsePos;
+    }
+
+    public void setFalsePos(int falsePos) {
+        this.falsePos = falsePos;
+    }
+
+    public int getFalseNeg() {
+        return falseNeg;
+    }
+
+    public void setFalseNeg(int falseNeg) {
+        this.falseNeg = falseNeg;
+    }
+
+    public int getGoldStandardSize() {
+        return goldStandardSize;
+    }
+
+    public void setGoldStandardSize(int goldStandardSize) {
+        this.goldStandardSize = goldStandardSize;
+    }
+
+    public int getSelectedClusterSize() {
+        return selectedClusterSize;
+    }
+
+    public void setSelectedClusterSize(int selectedClusterSize) {
+        this.selectedClusterSize = selectedClusterSize;
+    }
+
+    public int getPendingSkippedCount() {
+        return pendingSkippedCount;
+    }
+
+    public void setPendingSkippedCount(int pendingSkippedCount) {
+        this.pendingSkippedCount = pendingSkippedCount;
+    }
+
+    public List<Long> getTruePositiveList() {
+        return truePositiveList;
+    }
+
+    public void setTruePositiveList(List<Long> truePositiveList) {
+        this.truePositiveList = truePositiveList;
+    }
+
+    public List<Long> getTrueNegativeList() {
+        return trueNegativeList;
+    }
+
+    public void setTrueNegativeList(List<Long> trueNegativeList) {
+        this.trueNegativeList = trueNegativeList;
+    }
+
+    public List<Long> getFalsePositiveList() {
+        return falsePositiveList;
+    }
+
+    public void setFalsePositiveList(List<Long> falsePositiveList) {
+        this.falsePositiveList = falsePositiveList;
+    }
+
+    public List<Long> getFalseNegativeList() {
+        return falseNegativeList;
+    }
+
+    public void setFalseNegativeList(List<Long> falseNegativeList) {
+        this.falseNegativeList = falseNegativeList;
+    }
+
+    @Override
+    public String toString() {
+        return "Analysis [precision=" + getPrecision()
+                + ", recall=" + getRecall()
+                + ", accuracy=" + getAccuracy()
+                + ", truePos=" + truePos
+                + ", trueNeg=" + trueNeg
+                + ", falsePos=" + falsePos
+                + ", falseNeg=" + falseNeg
+                + ", pendingSkipped=" + pendingSkippedCount
+                + ", goldStandardSize=" + goldStandardSize
+                + ", selectedClusterSize=" + selectedClusterSize
+                + "]";
+    }
+}

--- a/src/main/java/reciter/engine/erroranalysis/StatusEnum.java
+++ b/src/main/java/reciter/engine/erroranalysis/StatusEnum.java
@@ -1,0 +1,9 @@
+package reciter.engine.erroranalysis;
+
+public enum StatusEnum {
+    TRUE_POSITIVE,
+    TRUE_NEGATIVE,
+    FALSE_POSITIVE,
+    FALSE_NEGATIVE,
+    PENDING_SKIPPED
+}

--- a/src/main/java/reciter/service/ESearchCountService.java
+++ b/src/main/java/reciter/service/ESearchCountService.java
@@ -1,0 +1,8 @@
+package reciter.service;
+
+import reciter.database.dynamodb.model.ESearchCount;
+
+public interface ESearchCountService {
+    void save(ESearchCount eSearchCount);
+    ESearchCount findByUid(String uid);
+}

--- a/src/main/java/reciter/service/NameFrequencyService.java
+++ b/src/main/java/reciter/service/NameFrequencyService.java
@@ -1,0 +1,24 @@
+package reciter.service;
+
+import java.util.Collection;
+import java.util.List;
+
+import reciter.database.dynamodb.model.NameFrequency;
+
+public interface NameFrequencyService {
+
+	void save(NameFrequency nameFrequency);
+
+	void save(Collection<NameFrequency> nameFrequencies);
+
+	NameFrequency findByName(String name);
+
+	List<NameFrequency> findAll();
+
+	void deleteAll();
+
+	void delete(String name);
+
+	long getItemCount();
+
+}

--- a/src/main/java/reciter/service/dynamo/ESearchCountServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ESearchCountServiceImpl.java
@@ -1,0 +1,25 @@
+package reciter.service.dynamo;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import reciter.database.dynamodb.model.ESearchCount;
+import reciter.database.dynamodb.repository.ESearchCountRepository;
+import reciter.service.ESearchCountService;
+
+@Service
+public class ESearchCountServiceImpl implements ESearchCountService {
+
+    @Autowired
+    private ESearchCountRepository eSearchCountRepository;
+
+    @Override
+    public void save(ESearchCount eSearchCount) {
+        eSearchCountRepository.save(eSearchCount);
+    }
+
+    @Override
+    public ESearchCount findByUid(String uid) {
+        return eSearchCountRepository.findById(uid).orElse(null);
+    }
+}

--- a/src/main/java/reciter/service/dynamo/NameFrequencyServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/NameFrequencyServiceImpl.java
@@ -1,0 +1,64 @@
+package reciter.service.dynamo;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import reciter.database.dynamodb.model.NameFrequency;
+import reciter.database.dynamodb.repository.NameFrequencyRepository;
+import reciter.service.NameFrequencyService;
+
+@Service
+public class NameFrequencyServiceImpl implements NameFrequencyService {
+
+	@Autowired
+	private NameFrequencyRepository nameFrequencyRepository;
+
+	@Override
+	public void save(NameFrequency nameFrequency) {
+		nameFrequencyRepository.save(nameFrequency);
+	}
+
+	@Override
+	public void save(Collection<NameFrequency> nameFrequencies) {
+		nameFrequencyRepository.saveAll(nameFrequencies);
+	}
+
+	@Override
+	public NameFrequency findByName(String name) {
+		return nameFrequencyRepository.findById(name).orElse(null);
+	}
+
+	@Override
+	public List<NameFrequency> findAll() {
+		Iterable<NameFrequency> iterable = nameFrequencyRepository.findAll();
+		List<NameFrequency> nameFrequencies = new ArrayList<>();
+		Iterator<NameFrequency> iterator = iterable.iterator();
+		while (iterator.hasNext()) {
+			nameFrequencies.add(iterator.next());
+		}
+		return nameFrequencies;
+	}
+
+	@Override
+	public void deleteAll() {
+		nameFrequencyRepository.deleteAll();
+	}
+
+	@Override
+	public void delete(String name) {
+		if (nameFrequencyRepository.existsById(name)) {
+			nameFrequencyRepository.deleteById(name);
+		}
+	}
+
+	@Override
+	public long getItemCount() {
+		return nameFrequencyRepository.count();
+	}
+
+}

--- a/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
@@ -31,6 +31,7 @@ import reciter.database.dynamodb.model.ESearchPmid;
 import reciter.database.dynamodb.model.ESearchResult;
 import reciter.database.dynamodb.model.QueryType;
 import reciter.model.pubmed.PubMedArticle;
+import reciter.engine.StrategyParameters;
 import reciter.service.ESearchResultService;
 import reciter.service.IdentityService;
 import reciter.service.PubMedService;
@@ -44,6 +45,7 @@ import reciter.xml.retriever.pubmed.FullNameRetrievalStrategy;
 import reciter.xml.retriever.pubmed.GoldStandardRetrievalStrategy;
 import reciter.xml.retriever.pubmed.GrantRetrievalStrategy;
 import reciter.xml.retriever.pubmed.KnownRelationshipRetrievalStrategy;
+import reciter.xml.retriever.pubmed.OrcidRetrievalStrategy;
 import reciter.xml.retriever.pubmed.PubMedQueryResult;
 import reciter.xml.retriever.pubmed.SecondInitialRetrievalStrategy;
 
@@ -61,7 +63,10 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 
 	@Autowired
 	protected IdentityService identityService;
-	
+
+	@Autowired
+	protected StrategyParameters strategyParameters;
+
 	@Autowired
 	protected AffiliationInDbRetrievalStrategy affiliationInDbRetrievalStrategy;
 	
@@ -88,7 +93,10 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 	
 	@Autowired
 	protected GoldStandardRetrievalStrategy goldStandardRetrievalStrategy;
-	
+
+	@Autowired
+	protected OrcidRetrievalStrategy orcidRetrievalStrategy;
+
 	@Autowired
 	protected GrantRetrievalStrategy grantRetrievalStrategy;
 	

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 
 import reciter.algorithm.util.ReCiterStringUtil;
 import reciter.api.parameters.RetrievalRefreshFlag;
+import reciter.database.dynamodb.model.ESearchCount;
 import reciter.database.dynamodb.model.GoldStandard;
 import reciter.database.dynamodb.model.QueryType;
 import reciter.model.identity.AuthorName;
@@ -39,6 +40,7 @@ import reciter.model.identity.Identity;
 import reciter.model.identity.PubMedAlias;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.model.scopus.ScopusArticle;
+import reciter.service.ESearchCountService;
 import reciter.service.ESearchResultService;
 import reciter.service.dynamo.IDynamoDbGoldStandardService;
 import reciter.utils.AuthorNameUtils;
@@ -61,7 +63,10 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	
 	@Autowired
 	private ESearchResultService eSearchResultService;
-	
+
+	@Autowired
+	private ESearchCountService eSearchCountService;
+
 	public enum IdentityNameType {
 		ORIGINAL,
 		DERIVED
@@ -200,6 +205,12 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		if(r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLeninentThreshold) {
 			useStrictQueryOnly = true;
 			queryType = QueryType.STRICT_EXCEEDS_THRESHOLD_LOOKUP;
+
+			// Store the true eSearch count so ArticleSizeStrategy can use log(count) for scoring.
+			// This avoids a separate live eSearch call during the scoring phase.
+			int trueCount = r1.getPubMedQueryResults().get(0).getNumResult();
+			eSearchCountService.save(new ESearchCount(uid, trueCount));
+			slf4jLogger.info("Stored eSearchCount={} for uid={}", trueCount, uid);
 		}
 		
 		if(r1.getPubMedQueryResults() != null
@@ -410,6 +421,11 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				&&
 				r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLeninentThreshold) {
 			queryType = QueryType.STRICT_EXCEEDS_THRESHOLD_LOOKUP;
+
+			// Store the true eSearch count for scoring.
+			int trueCount = r1.getPubMedQueryResults().get(0).getNumResult();
+			eSearchCountService.save(new ESearchCount(uid, trueCount));
+			slf4jLogger.info("Stored eSearchCount={} for uid={}", trueCount, uid);
 		}
 		
 		if(r1.getPubMedQueryResults() != null

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -30,11 +30,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import reciter.algorithm.evidence.targetauthor.TargetAuthorSelection;
+import reciter.algorithm.util.ArticleTranslator;
 import reciter.algorithm.util.ReCiterStringUtil;
 import reciter.api.parameters.RetrievalRefreshFlag;
 import reciter.database.dynamodb.model.ESearchCount;
 import reciter.database.dynamodb.model.GoldStandard;
 import reciter.database.dynamodb.model.QueryType;
+import reciter.model.article.ReCiterArticle;
+import reciter.model.article.ReCiterAuthor;
 import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
 import reciter.model.identity.PubMedAlias;
@@ -43,6 +47,7 @@ import reciter.model.scopus.ScopusArticle;
 import reciter.service.ESearchCountService;
 import reciter.service.ESearchResultService;
 import reciter.service.dynamo.IDynamoDbGoldStandardService;
+import reciter.utils.AuthorNameSanitizationUtils;
 import reciter.utils.AuthorNameUtils;
 import reciter.utils.ThreadDelay;
 import reciter.xml.retriever.pubmed.AbstractRetrievalStrategy.RetrievalResult;
@@ -150,6 +155,37 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			savePubMedArticles(pubMedArticles.values(), uid, goldStandardRetrievalStrategy.getRetrievalStrategyName(), goldStandardRetrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(pubMedArticles.keySet());
 		//}
+
+		// Retrieve by ORCID (asserted from Identity, or inferred from accepted articles).
+		String orcidForRetrieval = null;
+		if (identity.getOrcid() != null && !identity.getOrcid().isEmpty()
+				&& !"NOT SET".equalsIgnoreCase(identity.getOrcid().trim())) {
+			orcidForRetrieval = identity.getOrcid().trim();
+			slf4jLogger.info("Using asserted ORCID [{}] for uid=[{}]", orcidForRetrieval, uid);
+		}
+		if (orcidForRetrieval == null) {
+			orcidForRetrieval = inferOrcidFromAcceptedArticles(pubMedArticles, goldStandard, identity);
+			if (orcidForRetrieval != null) {
+				slf4jLogger.info("Inferred ORCID [{}] from accepted articles for uid=[{}]",
+						orcidForRetrieval, uid);
+				// Persist inferred ORCID so subsequent runs use the fast asserted path.
+				identity.setOrcid(orcidForRetrieval);
+				identityService.save(identity);
+				slf4jLogger.info("Persisted inferred ORCID [{}] to Identity for uid=[{}]",
+						orcidForRetrieval, uid);
+			}
+		}
+		if (orcidForRetrieval != null) {
+			// Strategy reads identity.getOrcid() directly (thread-safe).
+			RetrievalResult orcidResult = orcidRetrievalStrategy.retrievePubMedArticles(
+					identity, identityNames, useStrictQueryOnly);
+			pubMedArticles.putAll(orcidResult.getPubMedArticles());
+			savePubMedArticles(orcidResult.getPubMedArticles().values(), uid,
+					orcidRetrievalStrategy.getRetrievalStrategyName(),
+					orcidResult.getPubMedQueryResults(), queryType, refreshFlag);
+			uniquePmids.addAll(orcidResult.getPubMedArticles().keySet());
+		}
+
 		// Retrieve by email.
 		RetrievalResult retrievalResult = emailRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
 		pubMedArticles = retrievalResult.getPubMedArticles();
@@ -158,7 +194,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			Map<Long, AuthorName> aliasSet = AuthorNameUtils.calculatePotentialAlias(identity, pubMedArticles.values());
 
 			slf4jLogger.info("Found " + aliasSet.size() + " new alias for uid=[" + uid + "]");
-			 
+
 			// Update alias.
 			List<PubMedAlias> pubMedAliases = new ArrayList<>();
 			for (Map.Entry<Long, AuthorName> entry : aliasSet.entrySet()) {
@@ -174,10 +210,10 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			identity.setDateInitialRun(date);
 			identity.setDateLastRun(date);
 			identityService.save(identity);
-      
+
 			uniquePmids.addAll(pubMedArticles.keySet());
 		}*/
-		
+
 		// TODO parallelize by putting save in a separate thread.
 		savePubMedArticles(pubMedArticles.values(), uid, emailRetrievalStrategy.getRetrievalStrategyName(), retrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
 		uniquePmids.addAll(pubMedArticles.keySet());
@@ -360,7 +396,37 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			savePubMedArticles(pubMedArticles.values(), uid, goldStandardRetrievalStrategy.getRetrievalStrategyName(), goldStandardRetrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(pubMedArticles.keySet());
 		//}
-		
+
+		// Retrieve by ORCID (asserted from Identity, or inferred from accepted articles).
+		String orcidForRetrieval = null;
+		if (identity.getOrcid() != null && !identity.getOrcid().isEmpty()
+				&& !"NOT SET".equalsIgnoreCase(identity.getOrcid().trim())) {
+			orcidForRetrieval = identity.getOrcid().trim();
+			slf4jLogger.info("Using asserted ORCID [{}] for uid=[{}]", orcidForRetrieval, uid);
+		}
+		if (orcidForRetrieval == null) {
+			orcidForRetrieval = inferOrcidFromAcceptedArticles(pubMedArticles, goldStandard, identity);
+			if (orcidForRetrieval != null) {
+				slf4jLogger.info("Inferred ORCID [{}] from accepted articles for uid=[{}]",
+						orcidForRetrieval, uid);
+				// Persist inferred ORCID so subsequent runs use the fast asserted path.
+				identity.setOrcid(orcidForRetrieval);
+				identityService.save(identity);
+				slf4jLogger.info("Persisted inferred ORCID [{}] to Identity for uid=[{}]",
+						orcidForRetrieval, uid);
+			}
+		}
+		if (orcidForRetrieval != null) {
+			// Strategy reads identity.getOrcid() directly (thread-safe).
+			RetrievalResult orcidResult = orcidRetrievalStrategy.retrievePubMedArticles(
+					identity, identityNames, startDate, endDate, useStrictQueryOnly);
+			pubMedArticles.putAll(orcidResult.getPubMedArticles());
+			savePubMedArticles(orcidResult.getPubMedArticles().values(), uid,
+					orcidRetrievalStrategy.getRetrievalStrategyName(),
+					orcidResult.getPubMedQueryResults(), queryType, refreshFlag);
+			uniquePmids.addAll(orcidResult.getPubMedArticles().keySet());
+		}
+
 		// Retrieve by email.
 		RetrievalResult retrievalResult = emailRetrievalStrategy.retrievePubMedArticles(identity, identityNames, startDate, endDate, useStrictQueryOnly);
 		//Map<Long, PubMedArticle> emailPubMedArticles = retrievalResult.getPubMedArticles();
@@ -370,7 +436,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			Map<Long, AuthorName> aliasSet = AuthorNameUtils.calculatePotentialAlias(identity, pubMedArticles.values());
 
 			slf4jLogger.info("Found " + aliasSet.size() + " new alias for uid=[" + uid + "]");
-			 
+
 			// Update alias.
 			List<PubMedAlias> pubMedAliases = new ArrayList<PubMedAlias>();
 			for (Map.Entry<Long, AuthorName> entry : aliasSet.entrySet()) {
@@ -387,7 +453,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			identity.setDateInitialRun(now);
 			identity.setDateLastRun(now);
 			identityService.save(identity);
-			
+
 			uniquePmids.addAll(pubMedArticles.keySet());
 		}*/
 		
@@ -562,6 +628,81 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		}*/
 	}
 	
+	/**
+	 * Infer the target author's ORCID by scanning accepted (known) PubMed articles.
+	 * Uses the full TargetAuthorSelection pipeline (19-step name matching cascade)
+	 * to identify the target author on each accepted article, then extracts
+	 * the ORCID from whichever author is identified. Returns the most common
+	 * matching ORCID, or null if none found.
+	 */
+	private String inferOrcidFromAcceptedArticles(Map<Long, PubMedArticle> pubMedArticles,
+			GoldStandard goldStandard, Identity identity) {
+		if (goldStandard == null || goldStandard.getKnownPmids() == null
+				|| goldStandard.getKnownPmids().isEmpty() || pubMedArticles == null) {
+			return null;
+		}
+
+		// Sanitize identity names (same as the scoring pipeline does)
+		AuthorNameSanitizationUtils sanitizationUtils = new AuthorNameSanitizationUtils(strategyParameters);
+		identity.setSanitizedNames(sanitizationUtils.sanitizeIdentityAuthorNames(identity));
+
+		// Translate accepted PubMed articles into ReCiterArticles and run target author selection
+		List<ReCiterArticle> acceptedReCiterArticles = new ArrayList<>();
+		for (Long knownPmid : goldStandard.getKnownPmids()) {
+			PubMedArticle pubMedArticle = pubMedArticles.get(knownPmid);
+			if (pubMedArticle == null) {
+				continue;
+			}
+			try {
+				ReCiterArticle reCiterArticle = ArticleTranslator.translate(
+						pubMedArticle, null,
+						strategyParameters.getNameIgnoredCoAuthors(),
+						strategyParameters);
+				// Sanitize article author names
+				reCiterArticle.getArticleCoAuthors().setSanitizedAuthorMap(
+						sanitizationUtils.sanitizeArticleAuthorNames(reCiterArticle));
+				acceptedReCiterArticles.add(reCiterArticle);
+			} catch (Exception e) {
+				slf4jLogger.warn("Could not translate PMID {} for ORCID inference: {}",
+						knownPmid, e.getMessage());
+			}
+		}
+
+		if (acceptedReCiterArticles.isEmpty()) {
+			return null;
+		}
+
+		// Run the full target author identification (19-step cascade)
+		TargetAuthorSelection targetAuthorSelection = new TargetAuthorSelection();
+		targetAuthorSelection.identifyTargetAuthor(acceptedReCiterArticles, identity);
+
+		// Collect ORCIDs from identified target authors
+		Map<String, Integer> orcidCounts = new HashMap<>();
+		for (ReCiterArticle article : acceptedReCiterArticles) {
+			if (article.getArticleCoAuthors() == null
+					|| article.getArticleCoAuthors().getAuthors() == null) {
+				continue;
+			}
+			for (ReCiterAuthor author : article.getArticleCoAuthors().getAuthors()) {
+				if (author.isTargetAuthor()
+						&& author.getOrcid() != null
+						&& !author.getOrcid().isEmpty()) {
+					orcidCounts.merge(author.getOrcid(), 1, Integer::sum);
+				}
+			}
+		}
+
+		if (orcidCounts.isEmpty()) {
+			return null;
+		}
+
+		// Return the most common ORCID
+		return orcidCounts.entrySet().stream()
+				.max(Map.Entry.comparingByValue())
+				.map(Map.Entry::getKey)
+				.orElse(null);
+	}
+
 	/**
 	 * This function get all authorNames and derive additional names as well.
 	 * @see <a href ="https://github.com/wcmc-its/ReCiter/issues/259">All Identity Name Sec 3.</a>

--- a/src/main/java/reciter/xml/retriever/pubmed/OrcidRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/OrcidRetrievalStrategy.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ ******************************************************************************/
+package reciter.xml.retriever.pubmed;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import reciter.model.identity.AuthorName;
+import reciter.model.identity.Identity;
+import reciter.pubmed.retriever.PubMedQuery;
+import reciter.xml.retriever.engine.AliasReCiterRetrievalEngine.IdentityNameType;
+import reciter.xml.retriever.pubmed.PubMedQueryType.PubMedQueryBuilder;
+
+/**
+ * Retrieves PubMed articles using the ORCID [auid] search qualifier.
+ * Reads the ORCID directly from Identity (thread-safe — no mutable state on this singleton).
+ * Lenient and strict queries are identical because [auid] is inherently precise.
+ */
+@Component("orcidRetrievalStrategy")
+public class OrcidRetrievalStrategy extends AbstractRetrievalStrategy {
+
+	private static final String retrievalStrategyName = "OrcidRetrievalStrategy";
+
+	@Override
+	public String getRetrievalStrategyName() {
+		return retrievalStrategyName;
+	}
+
+	private String constructOrcidQuery(Identity identity) {
+		String orcid = identity.getOrcid();
+		if (orcid != null && !orcid.isEmpty()) {
+			return orcid.trim() + "[auid]";
+		}
+		return null;
+	}
+
+	@Override
+	protected List<PubMedQueryType> buildQuery(Identity identity,
+			Map<IdentityNameType, Set<AuthorName>> identityNames) {
+		List<PubMedQueryType> pubMedQueries = new ArrayList<PubMedQueryType>();
+
+		String queryString = constructOrcidQuery(identity);
+		if (queryString == null) {
+			return pubMedQueries;
+		}
+
+		PubMedQueryBuilder pubMedQueryBuilder = new PubMedQueryBuilder(queryString);
+		PubMedQuery orcidQuery = pubMedQueryBuilder.build();
+
+		PubMedQueryType pubMedQueryType = new PubMedQueryType();
+		pubMedQueryType.setLenientQuery(new PubMedQueryResult(orcidQuery));
+		pubMedQueryType.setStrictQuery(new PubMedQueryResult(orcidQuery));
+		pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(orcidQuery));
+		pubMedQueryType.setStrictCountQuery(new PubMedQueryResult(orcidQuery));
+		pubMedQueries.add(pubMedQueryType);
+
+		return pubMedQueries;
+	}
+
+	@Override
+	protected List<PubMedQueryType> buildQuery(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames,
+			Date startDate, Date endDate) {
+		List<PubMedQueryType> pubMedQueries = new ArrayList<PubMedQueryType>();
+
+		String queryString = constructOrcidQuery(identity);
+		if (queryString == null) {
+			return pubMedQueries;
+		}
+
+		PubMedQueryBuilder pubMedQueryBuilder = new PubMedQueryBuilder(queryString).dateRange(true,
+				startDate, endDate);
+		PubMedQuery orcidQuery = pubMedQueryBuilder.build();
+
+		PubMedQueryBuilder pubMedQueryBuilderCount = new PubMedQueryBuilder(queryString);
+		PubMedQuery orcidQueryCount = pubMedQueryBuilderCount.build();
+
+		PubMedQueryType pubMedQueryType = new PubMedQueryType();
+		pubMedQueryType.setLenientQuery(new PubMedQueryResult(orcidQuery));
+		pubMedQueryType.setStrictQuery(new PubMedQueryResult(orcidQuery));
+		pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(orcidQueryCount));
+		pubMedQueryType.setStrictCountQuery(new PubMedQueryResult(orcidQueryCount));
+		pubMedQueries.add(pubMedQueryType);
+
+		return pubMedQueries;
+	}
+
+	@Override
+	public RetrievalResult retrievePubMedArticles(List<Long> pmids) throws IOException {
+		throw new UnsupportedOperationException("Does not support retrieval by pmids.");
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -135,6 +135,8 @@ strategy.feedback.score.journalsubfield=true
 strategy.feedback.score.journalfield=false 
 strategy.feedback.score.journaldomain=false 
 strategy.feedback.score.cites=true
+strategy.orcidRetrieval=true
+
 #### Retrieval ####
 
 ## Usage: controls the maximum number of results returned under "lenient" and "strict" retrieval. 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -370,6 +370,9 @@ strategy.articleCountScoringStrategy.articleCountThresholdScore=800
 ## Increasing this value decreases the weight of this strategy. Decreasing this value, increases the weight.
 strategy.articleCountScoringStrategy.articleCountWeight=583.9
 
+## eSearch count is now stored during retrieval (in ESearchResult.eSearchCount field).
+## ArticleSizeStrategy uses the stored count automatically — no config needed.
+
 ## Median number of authors for baseline likelihood calculation
 strategy.articleCountScoringStrategy.authorCountThreshold=6
 
@@ -393,6 +396,30 @@ strategy.feedback.keywordLogBase=25
 ## Adjustment offset for keyword factor calculation
 ## This is a constant added to the logarithmic result to shift the final factor.
 strategy.feedback.keywordOffset=0.4
+
+## Informed absence penalty: when a feedback attribute value (e.g., author name)
+## has never been seen among accepted or rejected articles, but the researcher has
+## substantial acceptance history, apply a negative penalty instead of neutral 0.0.
+## strength controls penalty magnitude per feature (0=off, 1=full); scale controls
+## how quickly penalty ramps with total accepted count.
+strategy.feedback.informedAbsence.enabled=true
+strategy.feedback.informedAbsence.scale=10.0
+## Strength per feature: based on accepted zero-rate (lower = safer to penalize)
+## targetAuthorName: 0.4% of accepted are zero — safest
+strategy.feedback.informedAbsence.targetAuthorName.strength=1.0
+## coAuthorName: 2.3%, keyword: 3.4%
+strategy.feedback.informedAbsence.coAuthorName.strength=0.9
+strategy.feedback.informedAbsence.keyword.strength=0.9
+## journal: 5.1%, journalSubField: 4.3%
+strategy.feedback.informedAbsence.journal.strength=0.7
+strategy.feedback.informedAbsence.journalSubField.strength=0.7
+## institution: 8.6%, cites: 9.2%, organization: 10.9%
+strategy.feedback.informedAbsence.institution.strength=0.5
+strategy.feedback.informedAbsence.cites.strength=0.5
+strategy.feedback.informedAbsence.organization.strength=0.5
+## email: 16.1%, orcid: 16.4%
+strategy.feedback.informedAbsence.email.strength=0.3
+strategy.feedback.informedAbsence.orcid.strength=0.3
 
 
 #### Scoring ####

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -113,6 +113,7 @@ strategy.mesh.major=true
 strategy.persontype=true
 strategy.averageclustering=false
 strategy.gender=true
+strategy.nameFrequency=true
 strategy.education.year.discrepancy=true
 
 #Feedback toggle options


### PR DESCRIPTION
## Summary

CART scoring v2 changes: eSearch count storage, feedback strategy updates, precision/recall fix, and target author selection improvements.

### Commits in this PR

#### 1. Add informed absence penalties, eSearch count storage, and gold standard fix
- **ESearchCount DynamoDB table**: Stores true PubMed eSearch result count for high-ambiguity names (> `searchStrategy-leninent-threshold`). Auto-created on startup. Used for log-scale scoring in ArticleSizeStrategy.
- **Feedback strategies**: Updated CoAuthorName, TargetAuthorName, Journal, Keyword, Email, Institution, Organization, ORCID, JournalSubField, and Cites strategies
- **ArticleCountScore**: Log-scale scoring using stored eSearch count for high-ambiguity names
- **New files**: `ESearchCount.java`, `ESearchCountRepository.java`, `ESearchCountService.java`, `ESearchCountServiceImpl.java`

#### 2. Fix precision/recall: restore Analysis.java, exclude PENDING from metrics
- **Restored `erroranalysis` package** (was accidentally deleted in prior commit)
- **3 bug fixes in Analysis.java**:
  - PENDING articles (`goldStandard == 0`) now excluded from confusion matrix counts (were inflating FP)
  - Precision formula fixed: `TP / (TP + FP)` instead of `TP / totalArticles`
  - Accuracy formula fixed: `(TP + TN) / (TP + TN + FP + FN)` instead of `(precision + recall) / 2`
- Added `StatusEnum.java` with `PENDING_SKIPPED` value
- `assignGoldStandard()` method restored (called by ReCiterEngine.java)

#### 3. Add 7 new target author matching steps (13-19) for edge cases
Extends the 12-step waterfall in `TargetAuthorSelection.java`. New steps only fire when all existing steps fail:
- **Step 13**: First name + last initial match
- **Step 14**: Identity middle name to article last name
- **Step 15**: First/last name swap (catches PubMed name reversal)
- **Step 17**: Last-to-first + first initial to last initial
- **Step 18**: Both initials match (loosest exact match)
- **Step 19**: Fuzzy last name via Levenshtein distance ≤ 2 (catches typos: Kovanhkaya→Kovanlikaya, Polanecsky→Polaneczky, Seidman→Siedman)

Addresses remaining cases from issue #362.

#### 4. Add multi-match disambiguation to target author selection
When 2+ authors are flagged as target after all matching steps, scores each by name similarity:
- Full first name match: +3, First initial: +1
- Full middle name: +2, Middle initial: +1

Picks clear winner; leaves tied cases as-is (no guessing). Resolves ~89% of multi-match cases (68/76).

## Test plan

- [ ] Verify ReCiter compiles and starts successfully
- [ ] Confirm `ESearchCount` DynamoDB table is auto-created on startup
- [ ] Run Feature Generator for a known high-ambiguity person → verify eSearch count is stored and used
- [ ] Run Feature Generator for a known person → verify precision/recall metrics exclude PENDING articles
- [ ] Spot-check target author selection on previously failing PMIDs:
  - lid9035 / 24680142 (name swap) → should now match
  - mpolanec / 18767068 (spelling variant) → should now match via fuzzy
  - chs4029 / 21415408 (Siedman/Seidman) → should now match via fuzzy
- [ ] Verify no regression on existing target author matches