### PR TITLE
Null-safe evidence strategies for non-journal articles

### DIFF
--- a/src/main/java/reciter/algorithm/cluster/model/ReCiterCluster.java
+++ b/src/main/java/reciter/algorithm/cluster/model/ReCiterCluster.java
@@ -313,6 +313,7 @@ public class ReCiterCluster implements Comparable<ReCiterCluster>{
 			}
 		} else if(comparisonType.equalsIgnoreCase("meshMajor")) {
 			for(ReCiterArticle reCiterArticle: o.getArticleCluster()) {
+				if(reCiterArticle.getMeshHeadings() == null) continue;
 				for(ReCiterArticleMeshHeading meshHeading: reCiterArticle.getMeshHeadings()) {
 					if(meshHeading != null && MeshMajorClusteringStrategy.isMeshMajor(meshHeading)) {
 						match = this.articleCluster.stream().anyMatch(articleList -> articleList.getMeshHeadings() != null && 

--- a/src/main/java/reciter/algorithm/cluster/similarity/clusteringstrategy/article/GrantFeatureClusteringStrategy.java
+++ b/src/main/java/reciter/algorithm/cluster/similarity/clusteringstrategy/article/GrantFeatureClusteringStrategy.java
@@ -74,6 +74,7 @@ public class GrantFeatureClusteringStrategy extends AbstractClusteringStrategy {
 	}
 	
 	private void checkForValidGrant(ReCiterArticle reCiterArticle) {
+		if (reCiterArticle.getGrantList() == null) return;
 		for (ReCiterArticleGrant grant : reCiterArticle.getGrantList()) {
 			if(grant.getGrantID() != null) {
 				String sanitizedGrant = sanitizeGrant(grant.getGrantID().replaceAll("[\\s\\-]", ""));

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/year/strategy/YearFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/year/strategy/YearFeedbackStrategy.java
@@ -119,7 +119,9 @@ public class YearFeedbackStrategy extends AbstractTargetAuthorFeedbackStrategy {
 										   scoreWithout1Rejected,article.getGoldStandard(),feedbackScore,exportedFeedbackScore, "Year");	
 	
 								
-								feedbackYearMap.computeIfAbsent(article.getJournal().getJournalTitle().trim(), k -> new ArrayList<>()).add(feedbackYear);
+								String yearMapKey = (article.getJournal() != null && article.getJournal().getJournalTitle() != null)
+										? article.getJournal().getJournalTitle().trim() : "Unknown";
+								feedbackYearMap.computeIfAbsent(yearMapKey, k -> new ArrayList<>()).add(feedbackYear);
 								
 								feedbackYearMap.entrySet().stream()
 								.filter(entry -> entry.getKey() != null && entry.getValue() != null)

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/grant/strategy/GrantStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/grant/strategy/GrantStrategy.java
@@ -53,6 +53,10 @@ public class GrantStrategy extends AbstractTargetAuthorStrategy {
 		GrantEvidence grantEvidence = new GrantEvidence();
 		List<Grant> grants = new ArrayList<>();
 		grantEvidence.setGrants(grants);
+		if (reCiterArticle.getGrantList() == null) {
+			reCiterArticle.setGrantEvidence(grantEvidence);
+			return 0;
+		}
 		for (ReCiterArticleGrant grant : reCiterArticle.getGrantList()) {
 			for (String identityGrantId : identity.getGrants()) {
 				log.info("identity grant {}", identityGrantId);
@@ -85,6 +89,7 @@ public class GrantStrategy extends AbstractTargetAuthorStrategy {
 			//score += executeStrategy(reCiterArticle, identity);
 			List<Grant> grants = new ArrayList<>();
 			checkForValidGrant(reCiterArticle); // Calling here as we removed the old clustering logic for the Grants
+			if (reCiterArticle.getGrantList() == null) continue;
 			for (ReCiterArticleGrant grant : reCiterArticle.getGrantList()) {
 				for (String identityGrantId : sanitizedIdentityGrants) {
 					//log.info("identity grant {}", identityGrantId);
@@ -137,6 +142,7 @@ public class GrantStrategy extends AbstractTargetAuthorStrategy {
 		}
 	}
 	private void checkForValidGrant(ReCiterArticle reCiterArticle) {
+		if (reCiterArticle.getGrantList() == null) return;
 		for (ReCiterArticleGrant grant : reCiterArticle.getGrantList()) {
 			if(grant.getGrantID() != null) {
 				String sanitizedGrant = sanitizeGrant(grant.getGrantID().replaceAll("[\\s\\-]", ""));

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/journalcategory/strategy/JournalCategoryStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/journalcategory/strategy/JournalCategoryStrategy.java
@@ -40,6 +40,7 @@ public class JournalCategoryStrategy extends AbstractTargetAuthorStrategy {
 		Map<String, List<String>> identityOrgUnitToSynonymMap = identity.getIdentityOrgUnitToSynonymMap();
 
 		reCiterArticles.forEach(reCiterArticle -> {
+			if (reCiterArticle.getJournal() == null) return;
 			List<MedlineCitationJournalISSN> journalIssn = reCiterArticle.getJournal().getJournalIssn();
 		    if (journalIssn != null && !journalIssn.isEmpty()) {
 		        JournalCategoryEvidence journalCategoryEvidence = null;

--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -102,9 +102,24 @@ public class ArticleTranslator {
         // Article title
         String articleTitle = pubmedArticle.getMedlinecitation().getArticle().getArticletitle();
 
-        // Journal Title
-        String journalTitle = pubmedArticle.getMedlinecitation().getArticle().getJournal().getTitle();
-        
+        // Journal Title (may be null for PubmedBookArticle records)
+        String journalTitle = null;
+        List<MedlineCitationJournalISSN> journalIssn = null;
+        int journalIssuePubDateYear = 0;
+        String isoAbbreviation = null;
+        boolean hasJournal = pubmedArticle.getMedlinecitation().getArticle().getJournal() != null;
+
+        if (hasJournal) {
+            journalTitle = pubmedArticle.getMedlinecitation().getArticle().getJournal().getTitle();
+            journalIssn = pubmedArticle.getMedlinecitation().getArticle().getJournal().getIssn();
+            isoAbbreviation = pubmedArticle.getMedlinecitation().getArticle().getJournal().getIsoAbbreviation();
+            if (pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue() != null
+                    && pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate() != null
+                    && pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate().getYear() != null) {
+                journalIssuePubDateYear = Integer.parseInt(pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate().getYear());
+            }
+        }
+
         //Pubmed Publication Type
         if(pubmedArticle.getMedlinecitation().getArticle().getPublicationtypelist() != null && !pubmedArticle.getMedlinecitation().getArticle().getPublicationtypelist().isEmpty()) {
 	        List<String> publicationTypePubmed = pubmedArticle.getMedlinecitation().getArticle().getPublicationtypelist().stream().map(pubType -> pubType.getPublicationtype()).collect(Collectors.toList());
@@ -123,11 +138,6 @@ public class ArticleTranslator {
         
         
         
-
-        List<MedlineCitationJournalISSN> journalIssn = pubmedArticle.getMedlinecitation().getArticle().getJournal().getIssn();
-
-        // Translating Journal Issue PubDate Year.
-        int journalIssuePubDateYear = Integer.parseInt(pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate().getYear());
 
         // Co-authors
         List<MedlineCitationArticleAuthor> coAuthors = pubmedArticle.getMedlinecitation().getArticle().getAuthorlist();
@@ -238,12 +248,14 @@ public class ArticleTranslator {
         }
 
         reCiterArticle.setArticleTitle(articleTitle);
-        reCiterArticle.setJournal(new ReCiterJournal(journalTitle));
+        if (hasJournal) {
+            reCiterArticle.setJournal(new ReCiterJournal(journalTitle));
+            reCiterArticle.getJournal().setJournalIssuePubDateYear(journalIssuePubDateYear);
+            reCiterArticle.getJournal().setJournalIssn(journalIssn);
+            reCiterArticle.getJournal().setIsoAbbreviation(isoAbbreviation);
+        }
         reCiterArticle.setArticleCoAuthors(reCiterCoAuthors);
         reCiterArticle.setArticleKeywords(articleKeywords);
-        reCiterArticle.getJournal().setJournalIssuePubDateYear(journalIssuePubDateYear);
-        reCiterArticle.getJournal().setJournalIssn(journalIssn);
-        reCiterArticle.getJournal().setIsoAbbreviation(pubmedArticle.getMedlinecitation().getArticle().getJournal().getIsoAbbreviation());
         reCiterArticle.setMeshHeadings(reCiterArticleMeshHeadings);
 
         // Use PubMed Article date as the publication date (pubdate)
@@ -275,8 +287,9 @@ public class ArticleTranslator {
         
         //Case when ArticleDate does not exist use PubDate as date standardized date
         if (reCiterArticle.getPublicationDateStandardized() == null
-        		&&
-        		pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate() != null) {
+        		&& hasJournal
+        		&& pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue() != null
+        		&& pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate() != null) {
         	medlineCitationDate = pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getPubdate();
         	String articleDateMonth = null;
         	String articleDateDay = null;
@@ -422,13 +435,15 @@ public class ArticleTranslator {
         }
 
         // Volume
-        if (pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getVolume() != null &&
-                !pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getVolume().isEmpty()) {
+        if (hasJournal && pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue() != null
+                && pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getVolume() != null
+                && !pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getVolume().isEmpty()) {
             reCiterArticle.setVolume(pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getVolume());
         }
         // issue
-        if (pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getIssue() != null &&
-                !pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getIssue().isEmpty()) {
+        if (hasJournal && pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue() != null
+                && pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getIssue() != null
+                && !pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getIssue().isEmpty()) {
             reCiterArticle.setIssue(pubmedArticle.getMedlinecitation().getArticle().getJournal().getJournalissue().getIssue());
         }
 
@@ -588,7 +603,7 @@ public class ArticleTranslator {
     	int featureCount = reCiterArticleFeatures.getFeatureCount();
     	
     	//Journal Feature Name
-		if (reCiterArticle.getJournal().exist()) {
+		if (reCiterArticle.getJournal() != null && reCiterArticle.getJournal().exist()) {
 			reCiterArticleFeatures.setJournalName(reCiterArticle.getJournal().getJournalTitle());
 			featureCount++;
 		}

--- a/src/main/java/reciter/engine/ReCiterFeatureGenerator.java
+++ b/src/main/java/reciter/engine/ReCiterFeatureGenerator.java
@@ -239,14 +239,12 @@ public class ReCiterFeatureGenerator {
             	reCiterArticleFeature.setScopusDocID(reCiterArticle.getScopusDocId());
             }
        
-            // journal title
-            reCiterArticleFeature.setJournalTitleVerbose(reCiterArticle.getJournal().getJournalTitle());
-            
-            //journal issn
-            reCiterArticleFeature.setIssn(reCiterArticle.getJournal().getJournalIssn());
-
-            // journal title ISO Abbreviation
-            reCiterArticleFeature.setJournalTitleISOabbreviation(reCiterArticle.getJournal().getIsoAbbreviation());
+            // journal title (may be null for book articles or non-journal sources)
+            if (reCiterArticle.getJournal() != null) {
+                reCiterArticleFeature.setJournalTitleVerbose(reCiterArticle.getJournal().getJournalTitle());
+                reCiterArticleFeature.setIssn(reCiterArticle.getJournal().getJournalIssn());
+                reCiterArticleFeature.setJournalTitleISOabbreviation(reCiterArticle.getJournal().getIsoAbbreviation());
+            }
 
             // article title
             reCiterArticleFeature.setArticleTitle(reCiterArticle.getArticleTitle());


### PR DESCRIPTION
## Summary

- Hardens 7 files against `NullPointerException` when processing articles without journal data (e.g., PubmedBookArticle records, future OpenAlex/non-journal sources)
- `ArticleTranslator`: Extracts journal fields behind a `hasJournal` guard so book articles produce `journal=null` instead of crashing
- All downstream strategies (`JournalCategoryStrategy`, `GrantStrategy`, `YearFeedbackStrategy`, `ReCiterCluster`, `ReCiterFeatureGenerator`, etc.) now gracefully skip or use safe defaults when journal/grants/mesh are null

## Context

PR #105 in ReCiter-PubMed-Retrieval-Tool fixed the SAX parser so `PubmedBookArticle` records no longer corrupt adjacent journal articles. However, if book articles were ever to flow through the pipeline (for multi-source support), the evidence strategies would NPE on null journal/grant/mesh fields. This PR makes those strategies resilient.

## Files changed (7)

| File | Change |
|------|--------|
| `ArticleTranslator.java` | `hasJournal` guard for all journal field extraction; null-safe volume/issue/date fallback; `populateFeatures()` guard |
| `JournalCategoryStrategy.java` | Early return when `getJournal() == null` |
| `GrantStrategy.java` | Null check in single-article method, batch method, and `checkForValidGrant()` helper |
| `GrantFeatureClusteringStrategy.java` | Null check before grant list iteration |
| `YearFeedbackStrategy.java` | Null-safe journal title for feedback map key |
| `ReCiterCluster.java` | Null check before mesh heading iteration in `compareTo()` |
| `ReCiterFeatureGenerator.java` | Wrap journal title/ISSN/ISO access in null check |

## Test plan

- [x] `mvn compile` — clean build
- [x] `mvn test` — all tests pass
- [ ] Deploy to dev and run a user with known good articles to confirm no regression
- [ ] Eventually test with a PubmedBookArticle flowing through the pipeline