### PR TITLE
Strip backslashes from PubMed text fields (#586)

### DIFF
--- a/src/main/java/reciter/engine/ReCiterFeatureGenerator.java
+++ b/src/main/java/reciter/engine/ReCiterFeatureGenerator.java
@@ -31,6 +31,7 @@ import reciter.model.article.ReCiterArticle;
 import reciter.model.article.ReCiterArticleMeshHeading;
 import reciter.model.article.ReCiterAuthor;
 import reciter.model.identity.Identity;
+import reciter.utils.ReCiterStringUtil;
 
 
 @Data
@@ -217,7 +218,7 @@ public class ReCiterFeatureGenerator {
             
             //abstract
             if(reCiterArticle.getPublicationAbstract() != null) {
-            	reCiterArticleFeature.setPublicationAbstract(reCiterArticle.getPublicationAbstract());
+            	reCiterArticleFeature.setPublicationAbstract(ReCiterStringUtil.stripBackslashes(reCiterArticle.getPublicationAbstract()));
             }
             
             //article keywords
@@ -236,26 +237,26 @@ public class ReCiterFeatureGenerator {
             }
             //scopus doc id
             if(reCiterArticle.getScopusDocId() != null) {
-            	reCiterArticleFeature.setScopusDocID(reCiterArticle.getScopusDocId());
+            	reCiterArticleFeature.setScopusDocID(ReCiterStringUtil.stripBackslashes(reCiterArticle.getScopusDocId()));
             }
        
             // journal title
-            reCiterArticleFeature.setJournalTitleVerbose(reCiterArticle.getJournal().getJournalTitle());
+            reCiterArticleFeature.setJournalTitleVerbose(ReCiterStringUtil.stripBackslashes(reCiterArticle.getJournal().getJournalTitle()));
             
             //journal issn
             reCiterArticleFeature.setIssn(reCiterArticle.getJournal().getJournalIssn());
 
             // journal title ISO Abbreviation
-            reCiterArticleFeature.setJournalTitleISOabbreviation(reCiterArticle.getJournal().getIsoAbbreviation());
+            reCiterArticleFeature.setJournalTitleISOabbreviation(ReCiterStringUtil.stripBackslashes(reCiterArticle.getJournal().getIsoAbbreviation()));
 
             // article title
-            reCiterArticleFeature.setArticleTitle(reCiterArticle.getArticleTitle());
+            reCiterArticleFeature.setArticleTitle(ReCiterStringUtil.stripBackslashes(reCiterArticle.getArticleTitle()));
 
             // volume
-            reCiterArticleFeature.setVolume(reCiterArticle.getVolume());
+            reCiterArticleFeature.setVolume(ReCiterStringUtil.stripBackslashes(reCiterArticle.getVolume()));
             
             // issue
-            reCiterArticleFeature.setIssue(reCiterArticle.getIssue());
+            reCiterArticleFeature.setIssue(ReCiterStringUtil.stripBackslashes(reCiterArticle.getIssue()));
 
             /**
              * <Pagination>
@@ -263,18 +264,18 @@ public class ReCiterFeatureGenerator {
              </Pagination>
              */
             // pages
-            reCiterArticleFeature.setPages(reCiterArticle.getPages());
+            reCiterArticleFeature.setPages(ReCiterStringUtil.stripBackslashes(reCiterArticle.getPages()));
 
             // pmcid (https://www.ncbi.nlm.nih.gov/pubmed/26174865?report=xml&format=text)
             // Need to add parsing for <OtherID Source="NLM">PMC5009940 [Available on 01/01/17]</OtherID>
             // Or check <ArticleId IdType="pmc">PMC2907408</ArticleId>
             if(reCiterArticle.getPmcid() != null) {
-            	reCiterArticleFeature.setPmcid(reCiterArticle.getPmcid());
+            	reCiterArticleFeature.setPmcid(ReCiterStringUtil.stripBackslashes(reCiterArticle.getPmcid()));
             }
 
             // doi
             // <ArticleId IdType="doi">10.1093/jnci/djq238</ArticleId>
-            reCiterArticleFeature.setDoi(reCiterArticle.getDoi());
+            reCiterArticleFeature.setDoi(ReCiterStringUtil.stripBackslashes(reCiterArticle.getDoi()));
 
             // author list
             List<ReCiterArticleAuthorFeature> reCiterArticleAuthorFeatures = new ArrayList<>();
@@ -286,11 +287,11 @@ public class ReCiterFeatureGenerator {
                 reCiterArticleAuthorFeature.setRank(i++);
 
                 // lastname
-                reCiterArticleAuthorFeature.setLastName(reCiterArticleAuthor.getAuthorName().getLastName());
+                reCiterArticleAuthorFeature.setLastName(ReCiterStringUtil.stripBackslashes(reCiterArticleAuthor.getAuthorName().getLastName()));
                 // first name
-                reCiterArticleAuthorFeature.setFirstName(reCiterArticleAuthor.getAuthorName().getFirstName());
+                reCiterArticleAuthorFeature.setFirstName(ReCiterStringUtil.stripBackslashes(reCiterArticleAuthor.getAuthorName().getFirstName()));
                 // initials
-                reCiterArticleAuthorFeature.setInitials(reCiterArticleAuthor.getAuthorName().getFirstInitial());
+                reCiterArticleAuthorFeature.setInitials(ReCiterStringUtil.stripBackslashes(reCiterArticleAuthor.getAuthorName().getFirstInitial()));
                 // affiliation scopus
                 //Commenting out as not necessary at the moment
                 /*ReCiterArticleAffiliationFeature reCiterArticleAffiliationFeature =
@@ -344,7 +345,7 @@ public class ReCiterFeatureGenerator {
                 //EqualContrib
                 if(reCiterArticleAuthor.getEqualContrib()!=null && !reCiterArticleAuthor.getEqualContrib().isEmpty())
                 {
-                	reCiterArticleAuthorFeature.setEqualContrib(reCiterArticleAuthor.getEqualContrib());
+                	reCiterArticleAuthorFeature.setEqualContrib(ReCiterStringUtil.stripBackslashes(reCiterArticleAuthor.getEqualContrib()));
                 }
                 
 

--- a/src/main/java/reciter/utils/ReCiterStringUtil.java
+++ b/src/main/java/reciter/utils/ReCiterStringUtil.java
@@ -102,8 +102,15 @@ public class ReCiterStringUtil {
 	 * @return
 	 */
 	public static String deAccent(String str) {
-		String nfdNormalizedString = Normalizer.normalize(str, Normalizer.Form.NFD); 
+		String nfdNormalizedString = Normalizer.normalize(str, Normalizer.Form.NFD);
 		Pattern pattern = Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
 		return pattern.matcher(nfdNormalizedString).replaceAll("");
+	}
+
+	public static String stripBackslashes(String str) {
+		if (str == null) {
+			return null;
+		}
+		return str.replace("\\", "");
 	}
 }

--- a/src/test/java/reciter/tfidf/ReCiterStringUtilTest.java
+++ b/src/test/java/reciter/tfidf/ReCiterStringUtilTest.java
@@ -107,4 +107,30 @@ public class ReCiterStringUtilTest {
 		String deAccentedS = ReCiterStringUtil.deAccent(s);
 		assertEquals("equal", "o", deAccentedS);
 	}
+
+	@Test
+	public void testStripBackslashesWithBackslashDash() {
+		String s = "Non\\-alcoholic fatty liver disease";
+		String result = ReCiterStringUtil.stripBackslashes(s);
+		assertEquals("Backslash-dash should be stripped", "Non-alcoholic fatty liver disease", result);
+	}
+
+	@Test
+	public void testStripBackslashesNoBackslashes() {
+		String s = "Normal title without backslashes";
+		String result = ReCiterStringUtil.stripBackslashes(s);
+		assertEquals("String without backslashes should be unchanged", "Normal title without backslashes", result);
+	}
+
+	@Test
+	public void testStripBackslashesNull() {
+		String result = ReCiterStringUtil.stripBackslashes(null);
+		assertEquals("Null input should return null", null, result);
+	}
+
+	@Test
+	public void testStripBackslashesEmpty() {
+		String result = ReCiterStringUtil.stripBackslashes("");
+		assertEquals("Empty string should return empty", "", result);
+	}
 }


### PR DESCRIPTION
## Summary

- PubMed article PMID 38665446 contains a literal `\-` in its title, causing intermittent `json.decoder.JSONDecodeError: Invalid \escape` when the feature-generator response is parsed downstream from the DynamoDB cache
- Adds `ReCiterStringUtil.stripBackslashes()` and wraps 14 PubMed/Scopus string setters in `ReCiterFeatureGenerator` to sanitize at the API output boundary
- Adds 4 unit tests for the new utility method

## Test plan

- [ ] `mvn clean test -Dtest=ReCiterStringUtilTest` — unit tests pass
- [ ] `mvn clean package -DskipTests` — full build succeeds (note: text-similarity compilation issue from #585 is pre-existing)
- [ ] After deploy: delete `AnalysisOutput` entry for `tcdutta`, call feature-generator twice (fresh + cached), confirm both return valid JSON with no backslashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)