### PR TITLE
Phase 1: PmidProvenance, ORCID inference, Lombok fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 		<java.version>11</java.version>
     	<sqlite4java.version>1.0.392</sqlite4java.version>
 		<log4j2.version>2.16.0</log4j2.version>
+		<lombok.version>1.18.44</lombok.version>
   	</properties>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -67,10 +68,17 @@
         <plugins>
             <plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
@@ -349,7 +357,7 @@
 	    <dependency>
 	    	<groupId>edu.cornell.weill.reciter</groupId>
 	    	<artifactId>reciter-article-model</artifactId>
-	    	<version>2.0.32</version>
+	    	<version>2.0.33-SNAPSHOT</version>
 	    </dependency>
 	    <dependency>
 	    	<groupId>edu.cornell.weill.reciter</groupId>

--- a/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
+++ b/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
@@ -468,9 +468,9 @@ public class ReCiterArticleScorer extends AbstractArticleScorer {
 	 // Function to calculate likelihood adjustment
     private static Function<Double, Double> calculateLikelihoodAdjustment = authorCount -> {
         // Baseline likelihood (at authorCountThreshold)
-        double y_baseline = strategyParameters.getInCoefficent() * Math.log(strategyParameters.getAuthorCountThreshold()) + strategyParameters.getConstantCoefficeint();
+        double y_baseline = strategyParameters.getLnCoefficient() * Math.log(strategyParameters.getAuthorCountThreshold()) + strategyParameters.getConstantCoefficient();
         // Likelihood for the given author count
-        double y = authorCount > 0 ? strategyParameters.getInCoefficent() * Math.log(authorCount) + strategyParameters.getConstantCoefficeint() : y_baseline;
+        double y = authorCount > 0 ? strategyParameters.getLnCoefficient() * Math.log(authorCount) + strategyParameters.getConstantCoefficient() : y_baseline;
         // Adjustment is scaled by gamma
         return strategyParameters.getAuthorCountAdjustmentGamma() * (y - y_baseline);
     };

--- a/src/main/java/reciter/algorithm/evidence/author/authorcount/strategy/AuthorCountStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/author/authorcount/strategy/AuthorCountStrategy.java
@@ -76,10 +76,10 @@ public class AuthorCountStrategy extends AbstractTargetAuthorStrategy {
     private static Function<Integer, Double> calculateLikelihoodAdjustment = authorCount -> {
         // Baseline likelihood (at authorCountThreshold)
     	
-        double y_baseline = strategyParameters.getInCoefficent() * Math.log(strategyParameters.getAuthorCountThreshold()) + strategyParameters.getConstantCoefficeint();
+        double y_baseline = strategyParameters.getLnCoefficient() * Math.log(strategyParameters.getAuthorCountThreshold()) + strategyParameters.getConstantCoefficient();
 
         // Likelihood for the given author count
-        double y = authorCount > 0 ? strategyParameters.getInCoefficent() * Math.log(authorCount) + strategyParameters.getConstantCoefficeint() : y_baseline;
+        double y = authorCount > 0 ? strategyParameters.getLnCoefficient() * Math.log(authorCount) + strategyParameters.getConstantCoefficient() : y_baseline;
 
         // Adjustment is scaled by gamma
         return strategyParameters.getAuthorCountAdjustmentGamma() * (y - y_baseline);

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/articlesize/strategy/ArticleSizeStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/articlesize/strategy/ArticleSizeStrategy.java
@@ -164,9 +164,9 @@ public class ArticleSizeStrategy extends AbstractTargetAuthorStrategy {
 					// This is the same behavior as before; these records will get accurate counts
 					// after their next retrieval run.
 					articleCountEvidence.setCountArticlesRetrieved(
-							(int) ReCiterArticleScorer.strategyParameters.getSearchStrategyLeninentThreshold());
+							(int) ReCiterArticleScorer.strategyParameters.getSearchStrategyLenientThreshold());
 					articleCountEvidence.setArticleCountScore(
-							-(ReCiterArticleScorer.strategyParameters.getSearchStrategyLeninentThreshold()
+							-(ReCiterArticleScorer.strategyParameters.getSearchStrategyLenientThreshold()
 									- ReCiterArticleScorer.strategyParameters.getArticleCountThresholdScore())
 									/ ReCiterArticleScorer.strategyParameters.getArticleCountWeight());
 				}

--- a/src/main/java/reciter/algorithm/evidence/targetauthor/degree/strategy/YearDiscrepancyStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/degree/strategy/YearDiscrepancyStrategy.java
@@ -183,7 +183,7 @@ public class YearDiscrepancyStrategy extends AbstractRemoveReCiterArticleStrateg
 						reCiterArticle.setEducationYearEvidence(educationYearEvidence);
 					} else if (hasValidBachelor) {
 						discrepancyDegreeYearBachelor = articleYear - identity.getDegreeYear().getBachelorYear()
-								+ ReCiterArticleScorer.strategyParameters.getBacherlorYearWeight();
+								+ ReCiterArticleScorer.strategyParameters.getBachelorYearWeight();
 						discrepancyDegreeYearBachelor = (discrepancyDegreeYearBachelor < -99) ? -99
 								: discrepancyDegreeYearBachelor;
 						discrepancyDegreeYearBachelor = (discrepancyDegreeYearBachelor > 100) ? 100

--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -493,132 +493,289 @@ public class ArticleTranslator {
         return reCiterArticle;
     }
     
+    /**
+     * Phase 1: Determine canonical publication type from PubMed publication types.
+     *
+     * Priority order matters — first match wins. Retraction takes highest priority
+     * among content types because it supersedes the original article type.
+     *
+     * Phase 2 (evidence-based reclassification) runs after this method when the
+     * result is "Academic Article" or "Article", using supplementary signals like
+     * title patterns, journal title, and abstract structure.
+     *
+     * See docs/README-publication-type.md for full rationale and audit results.
+     */
     private static void determinePublicationTypeCanonical(ReCiterArticle reCiterArticle, ScopusArticle scopusArticle) {
     	String publicationTypeCanonical = null;
 
-        if(publicationTypeCanonical == null && reCiterArticle.getPublicationTypePubmed() != null) {
-            if(reCiterArticle.getPublicationTypePubmed().contains("Editorial")) {
+        if(reCiterArticle.getPublicationTypePubmed() != null) {
+            List<String> pubTypes = reCiterArticle.getPublicationTypePubmed();
+
+            if(pubTypes.contains("Editorial")
+                    ||
+                    pubTypes.contains("News")
+                    ||
+                    pubTypes.contains("Introductory Journal Article")
+                    ||
+                    pubTypes.contains("Interview")) {
                 publicationTypeCanonical = "Editorial Article";
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Letter")) {
+            } else if(pubTypes.contains("Letter")) {
                 publicationTypeCanonical = "Letter";
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Comment")) {
+            } else if(pubTypes.contains("Comment")) {
                 publicationTypeCanonical = "Comment";
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Preprint")) {
-                  publicationTypeCanonical = "Preprint";
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Published Erratum")) {
-                  publicationTypeCanonical = "Erratum";                
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Consensus Development Conference")
+            } else if(pubTypes.contains("Preprint")) {
+                publicationTypeCanonical = "Preprint";
+            } else if(pubTypes.contains("Retraction of Publication")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Consensus Development Conference, NIH")
+                    pubTypes.contains("Retracted Publication")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Address")
+                    pubTypes.contains("Retraction Notice")) {
+                publicationTypeCanonical = "Retraction";
+            } else if(pubTypes.contains("Published Erratum")) {
+                publicationTypeCanonical = "Erratum";
+            } else if(pubTypes.contains("Consensus Development Conference")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Clinical Conference")
+                    pubTypes.contains("Consensus Development Conference, NIH")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Congress")
+                    pubTypes.contains("Address")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Lecture")) {
+                    pubTypes.contains("Clinical Conference")
+                    ||
+                    pubTypes.contains("Congress")
+                    ||
+                    pubTypes.contains("Conference Proceedings")
+                    ||
+                    pubTypes.contains("Lecture")) {
                 publicationTypeCanonical = "Conference Paper";
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Guideline")
+            } else if(pubTypes.contains("Guideline")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Practice Guideline")) {
+                    pubTypes.contains("Practice Guideline")
+                    ||
+                    pubTypes.contains("Consensus Statement")) {
                 publicationTypeCanonical = "Guideline";
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Meta-Analysis")
+            } else if(pubTypes.contains("Meta-Analysis")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Review")
+                    pubTypes.contains("Review")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Classical Article")
+                    pubTypes.contains("Systematic Review")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Scientific Integrity Review")) {
+                    pubTypes.contains("Scoping Review")
+                    ||
+                    pubTypes.contains("Network Meta-Analysis")
+                    ||
+                    pubTypes.contains("Classical Article")
+                    ||
+                    pubTypes.contains("Scientific Integrity Review")) {
                 publicationTypeCanonical = "Review";
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Case Reports")) {
+            } else if(pubTypes.contains("Case Reports")) {
                 publicationTypeCanonical = "Case Report";
-            } else if(reCiterArticle.getPublicationTypePubmed().contains("Journal Article")
+            } else if(pubTypes.contains("Journal Article")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Clinical Trial, Phase I")
+                    pubTypes.contains("Clinical Trial, Phase I")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Clinical Trial, Phase II")
+                    pubTypes.contains("Clinical Trial, Phase II")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Clinical Trial, Phase III")
+                    pubTypes.contains("Clinical Trial, Phase III")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Clinical Trial, Phase IV")
+                    pubTypes.contains("Clinical Trial, Phase IV")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Controlled Clinical Trial")
+                    pubTypes.contains("Controlled Clinical Trial")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Randomized Controlled Trial")
+                    pubTypes.contains("Randomized Controlled Trial")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Multicenter Study")
+                    pubTypes.contains("Multicenter Study")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Twin Study")
+                    pubTypes.contains("Twin Study")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Validation Study")
+                    pubTypes.contains("Validation Study")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Controlled Clinical Trial")
+                    pubTypes.contains("Pragmatic Clinical Trial")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Pragmatic Clinical Trial")
+                    pubTypes.contains("Clinical Study")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Clinical Study")
+                    pubTypes.contains("Clinical Trial Protocol")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Clinical Trial Protocol")
+                    pubTypes.contains("Comparative Study")
                     ||
-                    reCiterArticle.getPublicationTypePubmed().contains("Comparative Study")
+                    pubTypes.contains("Observational Study")
                     ||
-					reCiterArticle.getPublicationTypePubmed().contains("Clinical Trial")                    
-            		||
-                    reCiterArticle.getPublicationTypePubmed().contains("Technical Report")) {
+                    pubTypes.contains("Evaluation Study")
+                    ||
+                    pubTypes.contains("Clinical Trial")
+                    ||
+                    pubTypes.contains("Technical Report")) {
                 publicationTypeCanonical = "Academic Article";
             } else {
                 publicationTypeCanonical = "Article";
             }
         }
 
-/*
+        // Phase 2: Evidence-based reclassification for ambiguous defaults.
+        // Only runs when Phase 1 returns "Academic Article" or "Article" (the catch-all types).
+        // Uses title patterns, journal title, and abstract structure to override.
+        if ("Academic Article".equals(publicationTypeCanonical) || "Article".equals(publicationTypeCanonical)) {
+            String reclassified = reclassifyByEvidence(reCiterArticle);
+            if (reclassified != null) {
+                publicationTypeCanonical = reclassified;
+            }
+        }
 
-## The below code uses publication type data from Scopus to infer publication type. Scopus has its virtues but it is commented out 
-## for now so that we rely on PubMed exclusively. The reasoning is:
-## 1. PubMed is freely available
-## 2. More commonly used, and 
-## 3. Less aggressive about mapping publications to what they call "articles" and what we would map to "academic articles."
-
-    	if(reCiterArticle.getPublicationTypeScopus() != null && scopusArticle.getSubType() != null) {
-    		if(scopusArticle.getSubType().equalsIgnoreCase("cp")
-    				||
-    				(reCiterArticle.getArticleTitle() != null && reCiterArticle.getArticleTitle().contains("Consensus Development Conference"))
-    				||
-    				(reCiterArticle.getArticleTitle() != null && reCiterArticle.getArticleTitle().contains("Consensus Development Conference, NIH"))
-    				||
-    				(reCiterArticle.getArticleTitle() != null && reCiterArticle.getArticleTitle().contains("Address"))
-    				||
-    				(reCiterArticle.getArticleTitle() != null && reCiterArticle.getArticleTitle().contains("Clinical Conference"))
-    				||
-    				(reCiterArticle.getArticleTitle() != null && reCiterArticle.getArticleTitle().contains("Congress"))
-    				||
-    				(reCiterArticle.getArticleTitle() != null && reCiterArticle.getArticleTitle().contains("Lecture"))) {
-    			publicationTypeCanonical = "Conference Paper";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("re")) {
-    			publicationTypeCanonical = "Review";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("rp")) {
-    			publicationTypeCanonical = "Report";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("ch")) {
-    			publicationTypeCanonical = "Chapter";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("ed")) {
-    			publicationTypeCanonical = "Editorial Article";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("ip")) {
-    			publicationTypeCanonical = "In Process";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("bk")) {
-    			publicationTypeCanonical = "Book";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("le")) {
-    			publicationTypeCanonical = "Letter";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("no")) {
-    			publicationTypeCanonical = "Comment";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("ar")) {
-    			publicationTypeCanonical = "Academic Article";
-    		} else if(scopusArticle.getSubType().equalsIgnoreCase("ab") || scopusArticle.getSubType().equalsIgnoreCase("bz") || scopusArticle.getSubType().equalsIgnoreCase("cr") || scopusArticle.getSubType().equalsIgnoreCase("sh")) {
-    			publicationTypeCanonical = "Article";
-    		}
-    	}
-*/        
     	reCiterArticle.setPublicationTypeCanonical(publicationTypeCanonical);
+    }
+
+    /**
+     * Phase 2: Evidence-based reclassification.
+     *
+     * Evaluates supplementary signals (title patterns, journal title, abstract
+     * structure) to reclassify articles that Phase 1 defaulted to "Academic Article"
+     * or "Article". Each signal contributes a weighted score toward candidate types.
+     * A candidate needs score >= 3 (one Strong signal) to override.
+     *
+     * Weights: Strong = 3, Moderate = 2, Weak = 1.
+     *
+     * Returns the new canonical type, or null if no candidate meets threshold.
+     */
+    private static String reclassifyByEvidence(ReCiterArticle reCiterArticle) {
+        String title = reCiterArticle.getArticleTitle() != null ? reCiterArticle.getArticleTitle() : "";
+        String titleLower = title.toLowerCase();
+        String journalTitle = reCiterArticle.getJournal() != null && reCiterArticle.getJournal().getJournalTitle() != null
+                ? reCiterArticle.getJournal().getJournalTitle().toLowerCase() : "";
+        boolean hasAbstract = reCiterArticle.getPublicationAbstract() != null
+                && !reCiterArticle.getPublicationAbstract().isEmpty();
+        boolean hasStructuredAbstract = hasAbstract && (
+                reCiterArticle.getPublicationAbstract().contains("METHODS:")
+                || reCiterArticle.getPublicationAbstract().contains("RESULTS:")
+                || reCiterArticle.getPublicationAbstract().contains("MATERIALS AND METHODS:")
+                || reCiterArticle.getPublicationAbstract().contains("FINDINGS:"));
+        int authorCount = reCiterArticle.getArticleCoAuthors() != null
+                && reCiterArticle.getArticleCoAuthors().getAuthors() != null
+                ? reCiterArticle.getArticleCoAuthors().getAuthors().size() : 0;
+
+        // Track scores for each candidate type
+        int reviewScore = 0;
+        int caseReportScore = 0;
+        int editorialScore = 0;
+        int letterScore = 0;
+        int commentScore = 0;
+        int erratumScore = 0;
+        int retractionScore = 0;
+
+        // --- Retraction signals ---
+        if (titleLower.startsWith("retraction:") || titleLower.startsWith("retraction notice")) {
+            retractionScore += 3; // Strong
+        }
+
+        // --- Erratum signals ---
+        if (titleLower.startsWith("erratum") || titleLower.startsWith("corrigendum")
+                || titleLower.startsWith("correction to") || titleLower.startsWith("correction:")) {
+            erratumScore += 3; // Strong
+        }
+
+        // --- Review signals ---
+        // Journal title patterns (Strong)
+        if (journalTitle.contains("annual review of")
+                || journalTitle.startsWith("nature reviews")
+                || journalTitle.startsWith("current opinion in")
+                || journalTitle.contains("cochrane database of systematic reviews")
+                || journalTitle.contains("campbell systematic reviews")
+                || journalTitle.endsWith(" reviews")
+                || journalTitle.contains("systematic reviews")) {
+            reviewScore += 3; // Strong
+        }
+        // Title contains "systematic review" (Strong)
+        if (titleLower.contains("systematic review")) {
+            reviewScore += 3; // Strong
+        }
+        // Title contains "a review" or "review of" without "systematic" (Weak)
+        if ((titleLower.contains("a review") || titleLower.contains("review of"))
+                && !titleLower.contains("systematic review")) {
+            reviewScore += 1; // Weak
+        }
+        // No structured abstract + long article (Weak) — approximate via page string
+        if (!hasStructuredAbstract && hasAbstract) {
+            reviewScore += 1; // Weak (at most; can't reliably check page count)
+        }
+
+        // --- Case Report signals ---
+        if (titleLower.contains("case report")) {
+            caseReportScore += 3; // Strong
+        }
+        if (titleLower.startsWith("a case of") || titleLower.startsWith("a rare case of")) {
+            caseReportScore += 3; // Strong
+        }
+        // Journal title patterns (Moderate)
+        if (journalTitle.contains("case reports")) {
+            caseReportScore += 2; // Moderate
+        }
+        // Abstract has CASE section labels (Moderate)
+        if (hasAbstract && (reCiterArticle.getPublicationAbstract().contains("CASE PRESENTATION:")
+                || reCiterArticle.getPublicationAbstract().contains("CASE REPORT:")
+                || reCiterArticle.getPublicationAbstract().contains("CASE:"))) {
+            caseReportScore += 2; // Moderate
+        }
+
+        // --- Editorial signals ---
+        if (titleLower.startsWith("editorial:") || titleLower.startsWith("editor's note")
+                || titleLower.endsWith("[editorial]")) {
+            editorialScore += 3; // Strong
+        }
+        // No abstract + 1 author (Weak + Weak combined as Moderate)
+        if (!hasAbstract && authorCount == 1) {
+            editorialScore += 2; // Moderate (combined weak signals)
+        }
+
+        // --- Letter signals ---
+        if (titleLower.startsWith("letter to the editor") || titleLower.startsWith("letter:")
+                || titleLower.startsWith("correspondence:")) {
+            letterScore += 3; // Strong
+        }
+
+        // --- Comment signals ---
+        if (titleLower.startsWith("comment on") || titleLower.startsWith("response to")
+                || titleLower.startsWith("reply to")) {
+            commentScore += 3; // Strong
+        }
+
+        // --- Confirming Academic Article (prevents weak signals from overriding) ---
+        int academicScore = 0;
+        if (hasStructuredAbstract) {
+            academicScore += 3; // Strong — structured METHODS/RESULTS confirms original research
+        }
+
+        // Find the highest-scoring candidate that meets threshold
+        // Tiebreaker priority: Retraction > Erratum > Review > Case Report > Editorial > Letter > Comment
+        int threshold = 3;
+        String bestType = null;
+        int bestScore = 0;
+
+        if (retractionScore >= threshold && retractionScore > bestScore) {
+            bestScore = retractionScore; bestType = "Retraction";
+        }
+        if (erratumScore >= threshold && erratumScore > bestScore) {
+            bestScore = erratumScore; bestType = "Erratum";
+        }
+        if (reviewScore >= threshold && reviewScore > bestScore) {
+            bestScore = reviewScore; bestType = "Review";
+        }
+        if (caseReportScore >= threshold && caseReportScore > bestScore) {
+            bestScore = caseReportScore; bestType = "Case Report";
+        }
+        if (editorialScore >= threshold && editorialScore > bestScore) {
+            bestScore = editorialScore; bestType = "Editorial Article";
+        }
+        if (letterScore >= threshold && letterScore > bestScore) {
+            bestScore = letterScore; bestType = "Letter";
+        }
+        if (commentScore >= threshold && commentScore > bestScore) {
+            bestScore = commentScore; bestType = "Comment";
+        }
+
+        // Don't override if Academic Article evidence is equally strong or stronger
+        if (bestType != null && academicScore >= bestScore) {
+            return null;
+        }
+
+        return bestType;
     }
 	
     private static void populateFeatures(ReCiterArticle reCiterArticle, String nameIgnoredCoAuthors) {

--- a/src/main/java/reciter/consumer/service/CognitoTokenService.java
+++ b/src/main/java/reciter/consumer/service/CognitoTokenService.java
@@ -79,7 +79,7 @@ public class CognitoTokenService {
 	 	@Value("${aws.secretsmanager.consumer.secretName}")
 		private String consumerSecretName;
 	 	
-	 	@Value("${aws.congito.userpool.region}")
+	 	@Value("${aws.cognito.userpool.region}")
 		private String cognitoPoolRegion;
 	 	
 	 // Cache with a single key (since it's one token)

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -151,7 +151,8 @@ public class ReCiterController {
     })
     @RequestMapping(value = "/reciter/goldstandard", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody
-    public ResponseEntity updateGoldStandard(@RequestBody GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag) {
+    public ResponseEntity updateGoldStandard(@RequestBody GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+    		@RequestParam(value = "source", required = false) String provenanceSource) {
         StopWatch stopWatch = new StopWatch("Update GoldStandard");
         stopWatch.start("Update GoldStandard");
     	if(goldStandard == null) {
@@ -162,12 +163,12 @@ public class ReCiterController {
     	if(goldStandardUpdateFlag == null ||
     			goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE || goldStandardUpdateFlag == GoldStandardUpdateFlag.DELETE) {
     		if(goldStandardUpdateFlag == null) {
-    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE);
+    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource);
     		} else {
-    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag);
+    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource);
     		}
     	} else {
-    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH);
+    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource);
         }
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
@@ -186,18 +187,19 @@ public class ReCiterController {
     })
     @RequestMapping(value = "/reciter/goldstandard", method = RequestMethod.PUT, produces = "application/json")
     @ResponseBody
-    public ResponseEntity<List<GoldStandard>> updateGoldStandard(@RequestBody List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag) {
+    public ResponseEntity<List<GoldStandard>> updateGoldStandard(@RequestBody List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+    		@RequestParam(value = "source", required = false) String provenanceSource) {
         StopWatch stopWatch = new StopWatch("Update GoldStandard with List");
         stopWatch.start("Update GoldStandard with List");
     	if(goldStandardUpdateFlag == null ||
     			goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE || goldStandardUpdateFlag == GoldStandardUpdateFlag.DELETE) {
     		if(goldStandardUpdateFlag == null) {
-    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE);
+    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource);
     		} else {
-    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag);
+    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource);
     		}
     	} else {
-    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH);
+    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource);
         }
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");

--- a/src/main/java/reciter/database/dynamodb/DynamoDbConfig.java
+++ b/src/main/java/reciter/database/dynamodb/DynamoDbConfig.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
 import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
@@ -202,11 +203,24 @@ public class DynamoDbConfig {
                                                                      bd.getBeanClassName()));
                 }
 
+                // Detect optional range key
+                String rangeKeyName = null;
+                Class<?> rangeKeyType = null;
+                for (Field field : clazz.getDeclaredFields()) {
+                    if (field.isAnnotationPresent(DynamoDBRangeKey.class)) {
+                        DynamoDBRangeKey rangeKeyAnnotation = field.getAnnotation(DynamoDBRangeKey.class);
+                        rangeKeyName = (rangeKeyAnnotation.attributeName() != null && !rangeKeyAnnotation.attributeName().isEmpty())
+                                ? rangeKeyAnnotation.attributeName() : field.getName();
+                        rangeKeyType = field.getType();
+                        break;
+                    }
+                }
+
                 List<AttributeDefinition> attributeDefinitions = new ArrayList<AttributeDefinition>();
-                if(tableName.equalsIgnoreCase("ScienceMetrixDepartmentCategory") 
-                		|| 
-                		tableName.equalsIgnoreCase("ScienceMetrix") 
-                		|| 
+                if(tableName.equalsIgnoreCase("ScienceMetrixDepartmentCategory")
+                		||
+                		tableName.equalsIgnoreCase("ScienceMetrix")
+                		||
                 		tableName.equalsIgnoreCase("PubMedArticle")) {
                 	attributeDefinitions.add(new AttributeDefinition().withAttributeName(keyName).withAttributeType(ScalarAttributeType.N));
 					/*if(tableName.equalsIgnoreCase("ScienceMetrix")) {
@@ -216,30 +230,41 @@ public class DynamoDbConfig {
                 } else {
                 	attributeDefinitions.add(new AttributeDefinition().withAttributeName(keyName).withAttributeType(ScalarAttributeType.S));
                 }
-                
+
+                // Add range key attribute definition if present
+                if (rangeKeyName != null) {
+                    ScalarAttributeType rangeKeyAttrType =
+                            (rangeKeyType == long.class || rangeKeyType == Long.class
+                                    || rangeKeyType == int.class || rangeKeyType == Integer.class)
+                            ? ScalarAttributeType.N : ScalarAttributeType.S;
+                    attributeDefinitions.add(new AttributeDefinition()
+                            .withAttributeName(rangeKeyName)
+                            .withAttributeType(rangeKeyAttrType));
+                }
+
                 /*if(tableName.equalsIgnoreCase("ScienceMetrix")) {
                 	List<GlobalSecondaryIndex> globalSecondardyIndexes = new ArrayList<GlobalSecondaryIndex>();
-                	
+
                 	List<KeySchemaElement> keyTableSchemaElements = new ArrayList<KeySchemaElement>();
                 	keyTableSchemaElements.add(new KeySchemaElement().withAttributeName(keyName).withKeyType(KeyType.HASH));
-                	
+
                 	GlobalSecondaryIndex issnIndex = new GlobalSecondaryIndex()
                 			.withIndexName("issn-index")
                 			.withKeySchema(new KeySchemaElement().withAttributeName("issn").withKeyType(KeyType.HASH))
                 			.withProvisionedThroughput(new ProvisionedThroughput(READ_CAPACITY_UNITS, WRITE_CAPACITY_UNITS))
                 			.withProjection(new Projection().withProjectionType(ProjectionType.ALL));
-                	
+
                 	GlobalSecondaryIndex eissnIndex = new GlobalSecondaryIndex()
                 			.withIndexName("eissn-index")
                 			.withKeySchema(new KeySchemaElement().withAttributeName("eissn").withKeyType(KeyType.HASH))
                 			.withProvisionedThroughput(new ProvisionedThroughput(READ_CAPACITY_UNITS, WRITE_CAPACITY_UNITS))
                 			.withProjection(new Projection().withProjectionType(ProjectionType.ALL));
-                	
-                	
-                    
+
+
+
                     globalSecondardyIndexes.add(issnIndex);
                     globalSecondardyIndexes.add(eissnIndex);
-                    
+
 					CreateTableRequest request =
 					        new CreateTableRequest()
 					                                .withTableName(tableName)
@@ -249,7 +274,7 @@ public class DynamoDbConfig {
 					                                .withProvisionedThroughput(
 					                                                           new ProvisionedThroughput().withReadCapacityUnits(READ_CAPACITY_UNITS)
 					                                                                                      .withWriteCapacityUnits(WRITE_CAPACITY_UNITS));
-                    
+
 	                if(request != null) {
 	                	amazonDynamoDB.createTable(request);
 	                }
@@ -262,6 +287,11 @@ public class DynamoDbConfig {
                 } else {*/
                 	List<KeySchemaElement> keySchemaElements = new ArrayList<KeySchemaElement>();
 	                keySchemaElements.add(new KeySchemaElement().withAttributeName(keyName).withKeyType(KeyType.HASH));
+
+	                // Add range key to key schema if present
+	                if (rangeKeyName != null) {
+	                    keySchemaElements.add(new KeySchemaElement().withAttributeName(rangeKeyName).withKeyType(KeyType.RANGE));
+	                }
 	
 	                CreateTableRequest request = null;
 	                

--- a/src/main/java/reciter/database/dynamodb/model/PmidProvenance.java
+++ b/src/main/java/reciter/database/dynamodb/model/PmidProvenance.java
@@ -1,0 +1,31 @@
+package reciter.database.dynamodb.model;
+
+import java.util.Date;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@DynamoDBTable(tableName = "PmidProvenance")
+public class PmidProvenance {
+
+    @DynamoDBHashKey(attributeName = "uid")
+    private String uid;
+
+    @DynamoDBRangeKey(attributeName = "pmid")
+    private long pmid;
+
+    @DynamoDBAttribute(attributeName = "firstRetrievalDate")
+    private Date firstRetrievalDate;
+
+    @DynamoDBAttribute(attributeName = "retrievalStrategy")
+    private String retrievalStrategy;
+}

--- a/src/main/java/reciter/engine/StrategyParameters.java
+++ b/src/main/java/reciter/engine/StrategyParameters.java
@@ -85,14 +85,6 @@ public class StrategyParameters {
     @Value("${nameScoringStrategy-excludedSuffixes}")
     private String nameExcludedSuffixes;
     
-    @Positive(message = "cluster.similarity.threshold score needs to be a positive number.")
-    @Value("${cluster.similarity.threshold.score}")
-    private double clusterSimilarityThresholdScore;
-    
-    @Positive(message = "clusteringGrants-threshold score needs to be a positive integer number.")
-    @Value("${clusteringGrants-threshold}")
-    private double clusteringGrantsThreshold;
-
     @Value("${nameMatchFirstType.full-exact}")
     private double nameMatchFirstTypeFullExactScore;
 
@@ -216,8 +208,8 @@ public class StrategyParameters {
     @Value("${strategy.discrepancyDegreeYear.degreeYearDiscrepancyScore}")
     private String degreeYearDiscrepancyScore;
 
-    @Value("${strategy.discrepancyDegreeYear.bacherlorYearWeight}")
-    private int bacherlorYearWeight;
+    @Value("${strategy.discrepancyDegreeYear.bachelorYearWeight}")
+    private int bachelorYearWeight;
 
     @Value("${strategy.orgUnitScoringStrategy.organizationalUnitDepartmentMatchingScore}")
     private double organizationalUnitDepartmentMatchingScore;
@@ -231,9 +223,6 @@ public class StrategyParameters {
     @Value("${strategy.orgUnitScoringStrategy.organizationalUnitProgramMatchingScore}")
     private double organizationalUnitProgramMatchingScore;
     
-    @Value("${strategy.orgUnitScoringStrategy.organizationalUnitSynonym}")
-    private String organizationalUnitSynonym;
-
     @Value("${strategy.articleCountScoringStrategy.articleCountThresholdScore}")
     private double articleCountThresholdScore;
 
@@ -304,9 +293,9 @@ public class StrategyParameters {
     private double searchStrategyStrictThreshold;
     
     @NotNull
-    @Positive(message = "searchStrategy-leninent-threshold should be a positive integer. We recommend a number of 2000.")
-    @Value("${searchStrategy-leninent-threshold}")
-    private double searchStrategyLeninentThreshold;
+    @Positive(message = "searchStrategy-lenient-threshold should be a positive integer. We recommend a number of 2000.")
+    @Value("${searchStrategy-lenient-threshold}")
+    private double searchStrategyLenientThreshold;
     
     @Value("${strategy.journalCategoryScore.journalSubfieldScore}")
     private double journalSubfieldScore;
@@ -385,10 +374,10 @@ public class StrategyParameters {
     private double authorCountAdjustmentGamma;
     
     @Value("${strategy.articleCountScoringStrategy.lnCoefficient}")
-    private double inCoefficent;
+    private double lnCoefficient;
     
     @Value("${strategy.articleCountScoringStrategy.constantCoefficient}")
-    private double constantCoefficeint;
+    private double constantCoefficient;
     
     @Value("${strategy.feedback.keywordCountBaseline}")
     private long keywordCountBaseline;

--- a/src/main/java/reciter/security/JwtTokenAuthenticationFilter.java
+++ b/src/main/java/reciter/security/JwtTokenAuthenticationFilter.java
@@ -65,7 +65,7 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
 	@Autowired
 	private S3UserLogHandler s3UserLogHandler;
 
-	@Value("${aws.congito.userpool.region}")
+	@Value("${aws.cognito.userpool.region}")
     private String cogintoRegion;
 	
 	@Value("${aws.secretsmanager.consumer.secretName}")

--- a/src/main/java/reciter/security/S3UserLogHandler.java
+++ b/src/main/java/reciter/security/S3UserLogHandler.java
@@ -35,7 +35,7 @@ public class S3UserLogHandler {
     @Value("${aws.s3.consumer.api.logs.bucketName}")
     private String apiLogsBucketName;
     
-    @Value("${aws.congito.userpool.region}")
+    @Value("${aws.cognito.userpool.region}")
     private String apiLogsBucketRegion;
     
     public S3UserLogHandler() {

--- a/src/main/java/reciter/service/PmidProvenanceService.java
+++ b/src/main/java/reciter/service/PmidProvenanceService.java
@@ -1,0 +1,16 @@
+package reciter.service;
+
+import java.util.List;
+import java.util.Set;
+
+import reciter.database.dynamodb.model.PmidProvenance;
+
+public interface PmidProvenanceService {
+    void save(PmidProvenance pmidProvenance);
+    void saveIfNotExists(PmidProvenance pmidProvenance);
+    void saveAllIfNotExists(List<PmidProvenance> pmidProvenances);
+    List<PmidProvenance> findByUid(String uid);
+    Set<Long> findPmidsByUid(String uid);
+    Set<Long> findPmidsByUidAndStrategy(String uid, String strategy);
+    void updateStrategyIfBackfill(String uid, long pmid, String realStrategy);
+}

--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -40,7 +40,11 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     private PmidProvenanceService pmidProvenanceService;
 
     @Override
-    public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag) {
+    public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource) {
+    	// Resolve provenance strategy: caller-supplied source, or default
+    	String strategy = (provenanceSource != null && !provenanceSource.isBlank())
+    			? provenanceSource : PM_MANUAL_STRATEGY;
+
     	// Capture incoming accepted PMIDs before merge logic mutates them
     	List<Long> incomingAcceptedPmids = (goldStandard.getKnownPmids() != null)
     			? new ArrayList<>(goldStandard.getKnownPmids()) : Collections.emptyList();
@@ -179,7 +183,7 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     	// get a provenance record.
     	if (goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE
     			&& !incomingAcceptedPmids.isEmpty()) {
-    		writeProvenanceForAcceptedPmids(goldStandard.getUid(), incomingAcceptedPmids);
+    		writeProvenanceForAcceptedPmids(goldStandard.getUid(), incomingAcceptedPmids, strategy);
     	}
     }
 
@@ -189,7 +193,10 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     }
 
 	@Override
-	public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag) {
+	public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource) {
+		// Resolve provenance strategy: caller-supplied source, or default
+		String strategy = (provenanceSource != null && !provenanceSource.isBlank())
+				? provenanceSource : PM_MANUAL_STRATEGY;
 		// Capture incoming accepted PMIDs before merge logic mutates them
 		Map<String, List<Long>> incomingAcceptedPmidsMap = new HashMap<>();
 		if (goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE) {
@@ -253,7 +260,7 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 
     	// Track provenance for accepted PMIDs in batch
     	for (Map.Entry<String, List<Long>> entry : incomingAcceptedPmidsMap.entrySet()) {
-    		writeProvenanceForAcceptedPmids(entry.getKey(), entry.getValue());
+    		writeProvenanceForAcceptedPmids(entry.getKey(), entry.getValue(), strategy);
     	}
 	}
 
@@ -275,14 +282,14 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 	 * keep their original provenance. Only PMIDs with no existing provenance
 	 * (e.g., manually added via Publication Manager) get a new record.
 	 */
-	private void writeProvenanceForAcceptedPmids(String uid, List<Long> pmids) {
+	private void writeProvenanceForAcceptedPmids(String uid, List<Long> pmids, String strategy) {
 		List<PmidProvenance> provenanceRecords = new ArrayList<>();
 		Date now = new Date();
 		for (Long pmid : pmids) {
-			PmidProvenance provenance = new PmidProvenance(uid, pmid, now, PM_MANUAL_STRATEGY);
+			PmidProvenance provenance = new PmidProvenance(uid, pmid, now, strategy);
 			provenanceRecords.add(provenance);
 		}
 		pmidProvenanceService.saveAllIfNotExists(provenanceRecords);
-		log.info("Tracked provenance for {} accepted PMIDs for uid={}", pmids.size(), uid);
+		log.info("Tracked provenance ({}) for {} accepted PMIDs for uid={}", strategy, pmids.size(), uid);
 	}
 }

--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -1,11 +1,17 @@
 package reciter.service.dynamo;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,20 +19,32 @@ import reciter.api.parameters.GoldStandardUpdateFlag;
 import reciter.database.dynamodb.model.ESearchPmid;
 import reciter.database.dynamodb.model.ESearchResult;
 import reciter.database.dynamodb.model.GoldStandard;
+import reciter.database.dynamodb.model.PmidProvenance;
 import reciter.database.dynamodb.repository.DynamoDbGoldStandardRepository;
 import reciter.service.ESearchResultService;
+import reciter.service.PmidProvenanceService;
 
 @Service("DynamoDbGoldStandardService")
 public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService {
 
+    private static final Logger log = LoggerFactory.getLogger(DynamoDbGoldStandardService.class);
+    private static final String PM_MANUAL_STRATEGY = "PublicationManagerManual";
+
     @Autowired
     private DynamoDbGoldStandardRepository dynamoDbGoldStandardRepository;
-    
+
     @Autowired
     private ESearchResultService eSearchResultService;
 
+    @Autowired
+    private PmidProvenanceService pmidProvenanceService;
+
     @Override
     public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag) {
+    	// Capture incoming accepted PMIDs before merge logic mutates them
+    	List<Long> incomingAcceptedPmids = (goldStandard.getKnownPmids() != null)
+    			? new ArrayList<>(goldStandard.getKnownPmids()) : Collections.emptyList();
+
     	if(goldStandardUpdateFlag == GoldStandardUpdateFlag.REFRESH) {
     		dynamoDbGoldStandardRepository.save(goldStandard);
     	} else {
@@ -154,7 +172,15 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     			dynamoDbGoldStandardRepository.save(goldStandard);
     		}
     	}
-        
+
+    	// Track provenance for accepted PMIDs. saveIfNotExists ensures we
+    	// don't overwrite existing automated-retrieval provenance — only
+    	// truly new PMIDs (e.g., manually added via Publication Manager)
+    	// get a provenance record.
+    	if (goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE
+    			&& !incomingAcceptedPmids.isEmpty()) {
+    		writeProvenanceForAcceptedPmids(goldStandard.getUid(), incomingAcceptedPmids);
+    	}
     }
 
     @Override
@@ -164,7 +190,16 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 
 	@Override
 	public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag) {
-		
+		// Capture incoming accepted PMIDs before merge logic mutates them
+		Map<String, List<Long>> incomingAcceptedPmidsMap = new HashMap<>();
+		if (goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE) {
+			for (GoldStandard gs : goldStandard) {
+				if (gs.getKnownPmids() != null && !gs.getKnownPmids().isEmpty()) {
+					incomingAcceptedPmidsMap.put(gs.getUid(), new ArrayList<>(gs.getKnownPmids()));
+				}
+			}
+		}
+
 		if(goldStandardUpdateFlag == GoldStandardUpdateFlag.REFRESH) {
     		dynamoDbGoldStandardRepository.saveAll(goldStandard);
     	} else {
@@ -215,7 +250,11 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     			dynamoDbGoldStandardRepository.saveAll(goldStandard);
     		}
     	}
-		
+
+    	// Track provenance for accepted PMIDs in batch
+    	for (Map.Entry<String, List<Long>> entry : incomingAcceptedPmidsMap.entrySet()) {
+    		writeProvenanceForAcceptedPmids(entry.getKey(), entry.getValue());
+    	}
 	}
 
 
@@ -229,5 +268,21 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 		}
 		return goldStanards;
 	}
-		
+
+	/**
+	 * Write PmidProvenance records for accepted PMIDs. Uses saveIfNotExists
+	 * so that PMIDs already discovered by automated retrieval strategies
+	 * keep their original provenance. Only PMIDs with no existing provenance
+	 * (e.g., manually added via Publication Manager) get a new record.
+	 */
+	private void writeProvenanceForAcceptedPmids(String uid, List<Long> pmids) {
+		List<PmidProvenance> provenanceRecords = new ArrayList<>();
+		Date now = new Date();
+		for (Long pmid : pmids) {
+			PmidProvenance provenance = new PmidProvenance(uid, pmid, now, PM_MANUAL_STRATEGY);
+			provenanceRecords.add(provenance);
+		}
+		pmidProvenanceService.saveAllIfNotExists(provenanceRecords);
+		log.info("Tracked provenance for {} accepted PMIDs for uid={}", pmids.size(), uid);
+	}
 }

--- a/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
@@ -6,8 +6,8 @@ import reciter.api.parameters.GoldStandardUpdateFlag;
 import reciter.database.dynamodb.model.GoldStandard;
 
 public interface IDynamoDbGoldStandardService {
-    void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag);
-    void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag);
+    void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource);
+    void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource);
     GoldStandard findByUid(String uid);
     List<GoldStandard> findByUids(List<String> uid);
 }

--- a/src/main/java/reciter/service/dynamo/PmidProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/PmidProvenanceServiceImpl.java
@@ -1,0 +1,146 @@
+package reciter.service.dynamo;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBSaveExpression;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
+
+import reciter.database.dynamodb.model.PmidProvenance;
+import reciter.service.PmidProvenanceService;
+
+@Service
+public class PmidProvenanceServiceImpl implements PmidProvenanceService {
+
+    private static final Logger log = LoggerFactory.getLogger(PmidProvenanceServiceImpl.class);
+    private static final String BACKFILL_STRATEGY = "BACKFILL_FROM_ESEARCHRESULT";
+
+    private final DynamoDBMapper dynamoDBMapper;
+
+    public PmidProvenanceServiceImpl(AmazonDynamoDB amazonDynamoDB) {
+        this.dynamoDBMapper = new DynamoDBMapper(amazonDynamoDB);
+    }
+
+    @Override
+    public void save(PmidProvenance pmidProvenance) {
+        dynamoDBMapper.save(pmidProvenance);
+    }
+
+    @Override
+    public void saveIfNotExists(PmidProvenance pmidProvenance) {
+        DynamoDBSaveExpression saveExpression = new DynamoDBSaveExpression();
+        Map<String, ExpectedAttributeValue> expected = new HashMap<>();
+        expected.put("uid", new ExpectedAttributeValue(false));
+        saveExpression.setExpected(expected);
+        try {
+            dynamoDBMapper.save(pmidProvenance, saveExpression);
+        } catch (ConditionalCheckFailedException e) {
+            // Item already exists — this is expected, not an error
+            log.debug("PmidProvenance already exists for uid={} pmid={}, skipping",
+                    pmidProvenance.getUid(), pmidProvenance.getPmid());
+        }
+    }
+
+    @Override
+    public void saveAllIfNotExists(List<PmidProvenance> pmidProvenances) {
+        int saved = 0;
+        int skipped = 0;
+        for (PmidProvenance pmidProvenance : pmidProvenances) {
+            try {
+                saveIfNotExists(pmidProvenance);
+                saved++;
+            } catch (Exception e) {
+                skipped++;
+                log.warn("Failed to save provenance for uid={} pmid={}: {}",
+                        pmidProvenance.getUid(), pmidProvenance.getPmid(), e.getMessage());
+            }
+        }
+        log.info("PmidProvenance batch: saved={}, skipped={}, total={}",
+                saved, skipped, pmidProvenances.size());
+    }
+
+    @Override
+    public List<PmidProvenance> findByUid(String uid) {
+        PmidProvenance hashKey = new PmidProvenance();
+        hashKey.setUid(uid);
+        DynamoDBQueryExpression<PmidProvenance> queryExpression =
+                new DynamoDBQueryExpression<PmidProvenance>()
+                        .withHashKeyValues(hashKey)
+                        .withConsistentRead(false);
+        return dynamoDBMapper.query(PmidProvenance.class, queryExpression);
+    }
+
+    @Override
+    public Set<Long> findPmidsByUid(String uid) {
+        List<PmidProvenance> results = findByUid(uid);
+        Set<Long> pmids = new HashSet<>();
+        for (PmidProvenance p : results) {
+            pmids.add(p.getPmid());
+        }
+        return pmids;
+    }
+
+    @Override
+    public Set<Long> findPmidsByUidAndStrategy(String uid, String strategy) {
+        PmidProvenance hashKey = new PmidProvenance();
+        hashKey.setUid(uid);
+
+        Map<String, AttributeValue> expressionValues = new HashMap<>();
+        expressionValues.put(":strategy", new AttributeValue().withS(strategy));
+
+        DynamoDBQueryExpression<PmidProvenance> queryExpression =
+                new DynamoDBQueryExpression<PmidProvenance>()
+                        .withHashKeyValues(hashKey)
+                        .withFilterExpression("retrievalStrategy = :strategy")
+                        .withExpressionAttributeValues(expressionValues)
+                        .withConsistentRead(false);
+
+        List<PmidProvenance> results = dynamoDBMapper.query(PmidProvenance.class, queryExpression);
+        Set<Long> pmids = new HashSet<>();
+        for (PmidProvenance p : results) {
+            pmids.add(p.getPmid());
+        }
+        return pmids;
+    }
+
+    @Override
+    public void updateStrategyIfBackfill(String uid, long pmid, String realStrategy) {
+        PmidProvenance existing = dynamoDBMapper.load(PmidProvenance.class, uid, pmid);
+        if (existing == null || !BACKFILL_STRATEGY.equals(existing.getRetrievalStrategy())) {
+            return;
+        }
+
+        existing.setRetrievalStrategy(realStrategy);
+        // Preserve original firstRetrievalDate — only the strategy tag is healed.
+
+        DynamoDBSaveExpression saveExpression = new DynamoDBSaveExpression();
+        Map<String, ExpectedAttributeValue> expected = new HashMap<>();
+        expected.put("retrievalStrategy",
+                new ExpectedAttributeValue(new AttributeValue().withS(BACKFILL_STRATEGY))
+                        .withComparisonOperator(ComparisonOperator.EQ));
+        saveExpression.setExpected(expected);
+
+        try {
+            dynamoDBMapper.save(existing, saveExpression);
+            log.info("Healed backfill provenance for uid={} pmid={} to strategy={}",
+                    uid, pmid, realStrategy);
+        } catch (ConditionalCheckFailedException e) {
+            log.debug("Provenance for uid={} pmid={} already healed, skipping", uid, pmid);
+        }
+    }
+}

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -44,8 +44,10 @@ import reciter.model.identity.Identity;
 import reciter.model.identity.PubMedAlias;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.model.scopus.ScopusArticle;
+import reciter.database.dynamodb.model.PmidProvenance;
 import reciter.service.ESearchCountService;
 import reciter.service.ESearchResultService;
+import reciter.service.PmidProvenanceService;
 import reciter.service.dynamo.IDynamoDbGoldStandardService;
 import reciter.utils.AuthorNameSanitizationUtils;
 import reciter.utils.AuthorNameUtils;
@@ -60,8 +62,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	@Value("${use.scopus.articles}")
 	private boolean useScopusArticles;
 	
-	@Value("${searchStrategy-leninent-threshold}")
-	private double searchStrategyLeninentThreshold;
+	@Value("${searchStrategy-lenient-threshold}")
+	private double searchStrategyLenientThreshold;
 	
 	@Autowired
 	private IDynamoDbGoldStandardService dynamoDbGoldStandardService;
@@ -71,6 +73,9 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 
 	@Autowired
 	private ESearchCountService eSearchCountService;
+
+	@Autowired
+	private PmidProvenanceService pmidProvenanceService;
 
 	public enum IdentityNameType {
 		ORIGINAL,
@@ -137,15 +142,30 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		//eSearchResultService.delete();
 		
 		String uid = identity.getUid();
-		
+
+		// Phase 1 provenance tracking state
+		Set<Long> nonGsStrategyPmids = new HashSet<>();
+		Map<Long, String> newPmidStrategy = new LinkedHashMap<>();
+		Set<Long> backfillPmids = new HashSet<>(pmidProvenanceService.findPmidsByUidAndStrategy(uid, "BACKFILL_FROM_ESEARCHRESULT"));
+		// Build set of already-known PMIDs from existing ESearchResult
+		Set<Long> existingPmids = new HashSet<>();
+		reciter.database.dynamodb.model.ESearchResult existingESearch = eSearchResultService.findByUid(uid);
+		if (existingESearch != null && existingESearch.getESearchPmids() != null) {
+			for (reciter.database.dynamodb.model.ESearchPmid esp : existingESearch.getESearchPmids()) {
+				if (esp.getPmids() != null) {
+					existingPmids.addAll(esp.getPmids());
+				}
+			}
+		}
+
 		Map<IdentityNameType, Set<AuthorName>> identityNames = new LinkedHashMap<IdentityNameType, Set<AuthorName>>();
 		identityAuthorNames(identity, identityNames);
 		boolean useStrictQueryOnly = identityNames.entrySet().stream().anyMatch(entry -> entry.getKey() == IdentityNameType.DERIVED && entry.getValue().size() > 0);
-		
+
 		if(useStrictQueryOnly) {
 			queryType = QueryType.STRICT_COMPOUND_NAME_LOOKUP;
 		}
-		
+
 		//Retreive by GoldStandard
 		Map<Long, PubMedArticle> pubMedArticles = null;
 		GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(identity.getUid().trim());
@@ -154,6 +174,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			pubMedArticles = goldStandardRetrievalResult.getPubMedArticles();
 			savePubMedArticles(pubMedArticles.values(), uid, goldStandardRetrievalStrategy.getRetrievalStrategyName(), goldStandardRetrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(pubMedArticles.keySet());
+			trackNewPmids(pubMedArticles, goldStandardRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 		//}
 
 		// Retrieve by ORCID (asserted from Identity, or inferred from accepted articles).
@@ -184,6 +205,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 					orcidRetrievalStrategy.getRetrievalStrategyName(),
 					orcidResult.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(orcidResult.getPubMedArticles().keySet());
+			nonGsStrategyPmids.addAll(orcidResult.getPubMedArticles().keySet());
+			trackNewPmids(orcidResult.getPubMedArticles(), orcidRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 		}
 
 		// Retrieve by email.
@@ -217,6 +240,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		// TODO parallelize by putting save in a separate thread.
 		savePubMedArticles(pubMedArticles.values(), uid, emailRetrievalStrategy.getRetrievalStrategyName(), retrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
 		uniquePmids.addAll(pubMedArticles.keySet());
+		nonGsStrategyPmids.addAll(pubMedArticles.keySet());
+		trackNewPmids(pubMedArticles, emailRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 		
 		RetrievalResult r1;
 		if(useStrictQueryOnly) {
@@ -229,16 +254,18 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				&&
 				r1.getPubMedQueryResults().size() > 0
 				&&
-				r1.getPubMedQueryResults().get(0).getNumResult() < searchStrategyLeninentThreshold) {
+				r1.getPubMedQueryResults().get(0).getNumResult() < searchStrategyLenientThreshold) {
 			if(queryType == null) {
 				queryType = QueryType.LENIENT_LOOKUP;
 			}
 			pubMedArticles.putAll(r1.getPubMedArticles());
 			savePubMedArticles(r1.getPubMedArticles().values(), uid, firstNameInitialRetrievalStrategy.getRetrievalStrategyName(), r1.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r1.getPubMedArticles().keySet());
-		} 
+			nonGsStrategyPmids.addAll(r1.getPubMedArticles().keySet());
+			trackNewPmids(r1.getPubMedArticles(), firstNameInitialRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+		}
 		//toggle useStrictQUery as true if results from Last Name First Initial Strategy is larger than lenientStrategy
-		if(r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLeninentThreshold) {
+		if(r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLenientThreshold) {
 			useStrictQueryOnly = true;
 			queryType = QueryType.STRICT_EXCEEDS_THRESHOLD_LOOKUP;
 
@@ -248,12 +275,12 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			eSearchCountService.save(new ESearchCount(uid, trueCount));
 			slf4jLogger.info("Stored eSearchCount={} for uid={}", trueCount, uid);
 		}
-		
+
 		if(r1.getPubMedQueryResults() != null
 				&&
 				r1.getPubMedQueryResults().size() > 0
 				&&
-				r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLeninentThreshold
+				r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLenientThreshold
 				||
 				useStrictQueryOnly) {
 			//Check to see if there is an actual need to do query for all steps
@@ -262,59 +289,93 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				pubMedArticles.putAll(r2.getPubMedArticles());
 				savePubMedArticles(r2.getPubMedArticles().values(), uid, affiliationInDbRetrievalStrategy.getRetrievalStrategyName(), r2.getPubMedQueryResults(), queryType, refreshFlag);
 				uniquePmids.addAll(r2.getPubMedArticles().keySet());
-				
+				nonGsStrategyPmids.addAll(r2.getPubMedArticles().keySet());
+				trackNewPmids(r2.getPubMedArticles(), affiliationInDbRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 			} else {
 				slf4jLogger.info("Skipping " + affiliationInDbRetrievalStrategy.getRetrievalStrategyName() + " since no affiliation for " + identity.getUid());
 			}
-			
+
 			RetrievalResult r3 = affiliationRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
 			pubMedArticles.putAll(r3.getPubMedArticles());
 			savePubMedArticles(r3.getPubMedArticles().values(), uid, affiliationRetrievalStrategy.getRetrievalStrategyName(), r3.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r3.getPubMedArticles().keySet());
-			
+			nonGsStrategyPmids.addAll(r3.getPubMedArticles().keySet());
+			trackNewPmids(r3.getPubMedArticles(), affiliationRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 			if(identity.getOrganizationalUnits() != null && !identity.getOrganizationalUnits().isEmpty()) {
 				RetrievalResult r4 = departmentRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
 				pubMedArticles.putAll(r4.getPubMedArticles());
 				savePubMedArticles(r4.getPubMedArticles().values(), uid, departmentRetrievalStrategy.getRetrievalStrategyName(), r4.getPubMedQueryResults(), queryType, refreshFlag);
 				uniquePmids.addAll(r4.getPubMedArticles().keySet());
-				
+				nonGsStrategyPmids.addAll(r4.getPubMedArticles().keySet());
+				trackNewPmids(r4.getPubMedArticles(), departmentRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 			} else {
 				slf4jLogger.info("Skipping " + departmentRetrievalStrategy.getRetrievalStrategyName() + " since no departments for " + identity.getUid());
 			}
-			
+
 			if(identity.getGrants() != null && !identity.getGrants().isEmpty()) {
 				RetrievalResult r5 = grantRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
 				pubMedArticles.putAll(r5.getPubMedArticles());
 				savePubMedArticles(r5.getPubMedArticles().values(), uid, grantRetrievalStrategy.getRetrievalStrategyName(), r5.getPubMedQueryResults(), queryType, refreshFlag);
 				uniquePmids.addAll(r5.getPubMedArticles().keySet());
-				
+				nonGsStrategyPmids.addAll(r5.getPubMedArticles().keySet());
+				trackNewPmids(r5.getPubMedArticles(), grantRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 			} else {
 				slf4jLogger.info("Skipping " + grantRetrievalStrategy.getRetrievalStrategyName() + " since no grants for " + identity.getUid());
 			}
-			
+
 			RetrievalResult r6 = fullNameRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
 			pubMedArticles.putAll(r6.getPubMedArticles());
 			savePubMedArticles(r6.getPubMedArticles().values(), uid, fullNameRetrievalStrategy.getRetrievalStrategyName(), r6.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r6.getPubMedArticles().keySet());
-			
+			nonGsStrategyPmids.addAll(r6.getPubMedArticles().keySet());
+			trackNewPmids(r6.getPubMedArticles(), fullNameRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 			if(identity.getKnownRelationships() != null && !identity.getKnownRelationships().isEmpty()) {
 				RetrievalResult r7 = knownRelationshipRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
 				pubMedArticles.putAll(r7.getPubMedArticles());
 				savePubMedArticles(r7.getPubMedArticles().values(), uid, knownRelationshipRetrievalStrategy.getRetrievalStrategyName(), r7.getPubMedQueryResults(), queryType, refreshFlag);
 				uniquePmids.addAll(r7.getPubMedArticles().keySet());
-				
+				nonGsStrategyPmids.addAll(r7.getPubMedArticles().keySet());
+				trackNewPmids(r7.getPubMedArticles(), knownRelationshipRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 			} else {
 				slf4jLogger.info("Skipping " + knownRelationshipRetrievalStrategy.getRetrievalStrategyName() + " since no Known Relationships for " + identity.getUid());
 			}
-			
+
 			RetrievalResult r8 = secondIntialRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
 			pubMedArticles.putAll(r8.getPubMedArticles());
 			savePubMedArticles(r8.getPubMedArticles().values(), uid, secondIntialRetrievalStrategy.getRetrievalStrategyName(), r8.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r8.getPubMedArticles().keySet());
-			
+			nonGsStrategyPmids.addAll(r8.getPubMedArticles().keySet());
+			trackNewPmids(r8.getPubMedArticles(), secondIntialRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 		}
-		
-		
+
+		// Phase 1: Save ESearchCount for users who didn't already get a threshold-path
+		// count (line 275). For threshold-exceeding users, the raw PubMed count is
+		// the correct value for ArticleSizeStrategy's log(count) scoring formula.
+		// This guard will be removed in Phase 2 when ArticleSizeStrategy is updated
+		// to use the retrieved-PMID semantic consistently.
+		if (queryType != QueryType.STRICT_EXCEEDS_THRESHOLD_LOOKUP) {
+			eSearchCountService.save(new ESearchCount(uid, nonGsStrategyPmids.size()));
+			slf4jLogger.info("Stored final eSearchCount={} for uid={}", nonGsStrategyPmids.size(), uid);
+		}
+
+		// Phase 1: Write provenance records for newly discovered PMIDs
+		if (!newPmidStrategy.isEmpty()) {
+			Date now = new Date();
+			List<PmidProvenance> provenanceRecords = new ArrayList<>();
+			for (Map.Entry<Long, String> entry : newPmidStrategy.entrySet()) {
+				provenanceRecords.add(new PmidProvenance(uid, entry.getKey(), now, entry.getValue()));
+			}
+			pmidProvenanceService.saveAllIfNotExists(provenanceRecords);
+			slf4jLogger.info("Wrote {} provenance records for uid={}", provenanceRecords.size(), uid);
+		}
+
 		if (useScopusArticles) {
 			List<ScopusArticle> scopusArticles = emailRetrievalStrategy.retrieveScopus(uniquePmids);
 
@@ -392,18 +453,31 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	public void retrieveDataByDateRange(Identity identity, Date startDate, Date endDate, RetrievalRefreshFlag refreshFlag) throws IOException {
 		slf4jLogger.info("Coming in retrieveData section with date range****");
 		Set<Long> uniquePmids = new HashSet<>();
-		QueryType queryType = null; 
+		QueryType queryType = null;
 		String uid = identity.getUid();
-		
+
+		// Phase 1 provenance tracking state (no always-save ESearchCount for date-range runs)
+		Map<Long, String> newPmidStrategy = new LinkedHashMap<>();
+		Set<Long> backfillPmids = new HashSet<>(pmidProvenanceService.findPmidsByUidAndStrategy(uid, "BACKFILL_FROM_ESEARCHRESULT"));
+		Set<Long> existingPmids = new HashSet<>();
+		reciter.database.dynamodb.model.ESearchResult existingESearch = eSearchResultService.findByUid(uid);
+		if (existingESearch != null && existingESearch.getESearchPmids() != null) {
+			for (reciter.database.dynamodb.model.ESearchPmid esp : existingESearch.getESearchPmids()) {
+				if (esp.getPmids() != null) {
+					existingPmids.addAll(esp.getPmids());
+				}
+			}
+		}
+
 		Map<IdentityNameType, Set<AuthorName>> identityNames = new LinkedHashMap<IdentityNameType, Set<AuthorName>>();
 		identityAuthorNames(identity, identityNames);
-		
+
 		boolean useStrictQueryOnly = identityNames.entrySet().stream().anyMatch(entry -> entry.getKey() == IdentityNameType.DERIVED && entry.getValue().size() > 0);
-		
+
 		if(useStrictQueryOnly) {
 			queryType = QueryType.STRICT_COMPOUND_NAME_LOOKUP;
 		}
-		
+
 		Map<Long, PubMedArticle> pubMedArticles = null;
 		//Retreive by GoldStandard
 		GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(identity.getUid().trim());
@@ -412,6 +486,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			pubMedArticles = goldStandardRetrievalResult.getPubMedArticles();
 			savePubMedArticles(pubMedArticles.values(), uid, goldStandardRetrievalStrategy.getRetrievalStrategyName(), goldStandardRetrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(pubMedArticles.keySet());
+			trackNewPmids(pubMedArticles, goldStandardRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 		//}
 
 		// Retrieve by ORCID (asserted from Identity, or inferred from accepted articles).
@@ -442,6 +517,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 					orcidRetrievalStrategy.getRetrievalStrategyName(),
 					orcidResult.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(orcidResult.getPubMedArticles().keySet());
+			trackNewPmids(orcidResult.getPubMedArticles(), orcidRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 		}
 
 		// Retrieve by email.
@@ -473,10 +549,11 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 
 			uniquePmids.addAll(pubMedArticles.keySet());
 		}*/
-		
+
 		// TODO parallelize by putting save in a separate thread.
 		savePubMedArticles(pubMedArticles.values(), uid, emailRetrievalStrategy.getRetrievalStrategyName(), retrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
 		uniquePmids.addAll(pubMedArticles.keySet());
+		trackNewPmids(pubMedArticles, emailRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 
 		RetrievalResult r1;
 		if(useStrictQueryOnly) {
@@ -489,20 +566,21 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				&&
 				r1.getPubMedQueryResults().size() > 0
 				&&
-				r1.getPubMedQueryResults().get(0).getNumResult() < searchStrategyLeninentThreshold) {
+				r1.getPubMedQueryResults().get(0).getNumResult() < searchStrategyLenientThreshold) {
 			if(queryType == null) {
 				queryType = QueryType.LENIENT_LOOKUP;
 			}
 			pubMedArticles.putAll(r1.getPubMedArticles());
 			savePubMedArticles(r1.getPubMedArticles().values(), uid, firstNameInitialRetrievalStrategy.getRetrievalStrategyName(), r1.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r1.getPubMedArticles().keySet());
+			trackNewPmids(r1.getPubMedArticles(), firstNameInitialRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 		}
-		
+
 		if(r1.getPubMedQueryResults() != null
 				&&
 				r1.getPubMedQueryResults().size() > 0
 				&&
-				r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLeninentThreshold) {
+				r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLenientThreshold) {
 			queryType = QueryType.STRICT_EXCEEDS_THRESHOLD_LOOKUP;
 
 			// Store the true eSearch count for scoring.
@@ -510,20 +588,21 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			eSearchCountService.save(new ESearchCount(uid, trueCount));
 			slf4jLogger.info("Stored eSearchCount={} for uid={}", trueCount, uid);
 		}
-		
+
 		if(r1.getPubMedQueryResults() != null
 				&&
 				r1.getPubMedQueryResults().size() > 0
 				&&
-				r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLeninentThreshold
+				r1.getPubMedQueryResults().get(0).getNumResult() > searchStrategyLenientThreshold
 				||
 				useStrictQueryOnly) {
-			
+
 			if(identity.getInstitutions() != null && !identity.getInstitutions().isEmpty()) {
 				RetrievalResult r2 = affiliationInDbRetrievalStrategy.retrievePubMedArticles(identity, identityNames, startDate, endDate, useStrictQueryOnly);
 				pubMedArticles.putAll(r2.getPubMedArticles());
 				savePubMedArticles(r2.getPubMedArticles().values(), uid, affiliationInDbRetrievalStrategy.getRetrievalStrategyName(), r2.getPubMedQueryResults(), queryType, refreshFlag);
 				uniquePmids.addAll(r2.getPubMedArticles().keySet());
+				trackNewPmids(r2.getPubMedArticles(), affiliationInDbRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 			} else {
 				slf4jLogger.info("Skipping " + affiliationInDbRetrievalStrategy.getRetrievalStrategyName() + " since no affiliation for " + identity.getUid());
 			}
@@ -532,36 +611,41 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			pubMedArticles.putAll(r3.getPubMedArticles());
 			savePubMedArticles(r3.getPubMedArticles().values(), uid, affiliationRetrievalStrategy.getRetrievalStrategyName(), r3.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r3.getPubMedArticles().keySet());
-			
+			trackNewPmids(r3.getPubMedArticles(), affiliationRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 			if(identity.getOrganizationalUnits() != null && !identity.getOrganizationalUnits().isEmpty()) {
 				RetrievalResult r4 = departmentRetrievalStrategy.retrievePubMedArticles(identity, identityNames, startDate, endDate, useStrictQueryOnly);
 				pubMedArticles.putAll(r4.getPubMedArticles());
 				savePubMedArticles(r4.getPubMedArticles().values(), uid, departmentRetrievalStrategy.getRetrievalStrategyName(), r4.getPubMedQueryResults(), queryType, refreshFlag);
 				uniquePmids.addAll(r4.getPubMedArticles().keySet());
-				
+				trackNewPmids(r4.getPubMedArticles(), departmentRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+
 			} else {
 				slf4jLogger.info("Skipping " + departmentRetrievalStrategy.getRetrievalStrategyName() + " since no departments for " + identity.getUid());
 			}
-			
+
 			if(identity.getGrants() != null && !identity.getGrants().isEmpty()) {
 				RetrievalResult r5 = grantRetrievalStrategy.retrievePubMedArticles(identity, identityNames, startDate, endDate, useStrictQueryOnly);
 				pubMedArticles.putAll(r5.getPubMedArticles());
 				savePubMedArticles(r5.getPubMedArticles().values(), uid, grantRetrievalStrategy.getRetrievalStrategyName(), r5.getPubMedQueryResults(), queryType, refreshFlag);
 				uniquePmids.addAll(r5.getPubMedArticles().keySet());
+				trackNewPmids(r5.getPubMedArticles(), grantRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 			} else {
 				slf4jLogger.info("Skipping " + grantRetrievalStrategy.getRetrievalStrategyName() + " since no grants for " + identity.getUid());
 			}
-			
+
 			RetrievalResult r6 = fullNameRetrievalStrategy.retrievePubMedArticles(identity, identityNames, startDate, endDate, useStrictQueryOnly);
 			pubMedArticles.putAll(r6.getPubMedArticles());
 			savePubMedArticles(r6.getPubMedArticles().values(), uid, fullNameRetrievalStrategy.getRetrievalStrategyName(), r6.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r6.getPubMedArticles().keySet());
+			trackNewPmids(r6.getPubMedArticles(), fullNameRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 
 			if(identity.getKnownRelationships() != null && !identity.getKnownRelationships().isEmpty()) {
 				RetrievalResult r7 = knownRelationshipRetrievalStrategy.retrievePubMedArticles(identity, identityNames, startDate, endDate, useStrictQueryOnly);
 				pubMedArticles.putAll(r7.getPubMedArticles());
 				savePubMedArticles(r7.getPubMedArticles().values(), uid, knownRelationshipRetrievalStrategy.getRetrievalStrategyName(), r7.getPubMedQueryResults(), queryType, refreshFlag);
 				uniquePmids.addAll(r7.getPubMedArticles().keySet());
+				trackNewPmids(r7.getPubMedArticles(), knownRelationshipRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 			} else {
 				slf4jLogger.info("Skipping " + knownRelationshipRetrievalStrategy.getRetrievalStrategyName() + " since no Known Relationships for " + identity.getUid());
 			}
@@ -569,7 +653,20 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			pubMedArticles.putAll(r8.getPubMedArticles());
 			savePubMedArticles(r8.getPubMedArticles().values(), uid, secondIntialRetrievalStrategy.getRetrievalStrategyName(), r8.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r8.getPubMedArticles().keySet());
+			trackNewPmids(r8.getPubMedArticles(), secondIntialRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
 		}
+
+		// Phase 1: Write provenance records for newly discovered PMIDs (no ESearchCount always-save for date-range runs)
+		if (!newPmidStrategy.isEmpty()) {
+			Date now = new Date();
+			List<PmidProvenance> provenanceRecords = new ArrayList<>();
+			for (Map.Entry<Long, String> entry : newPmidStrategy.entrySet()) {
+				provenanceRecords.add(new PmidProvenance(uid, entry.getKey(), now, entry.getValue()));
+			}
+			pmidProvenanceService.saveAllIfNotExists(provenanceRecords);
+			slf4jLogger.info("Wrote {} provenance records (date-range) for uid={}", provenanceRecords.size(), uid);
+		}
+
 		slf4jLogger.info("uniquePmids in retrieveData section with date range****"+uniquePmids.size());
 		//List<ScopusArticle> scopusArticles = emailRetrievalStrategy.retrieveScopus(uniquePmids);
 		//scopusService.save(scopusArticles);
@@ -736,6 +833,25 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				.max(Map.Entry.comparingByValue())
 				.map(Map.Entry::getKey)
 				.orElse(null);
+	}
+
+	/**
+	 * Track newly discovered PMIDs for provenance recording.
+	 * For each PMID in the articles map, if it's not already known (from existingPmids or newPmidStrategy),
+	 * record which strategy first discovered it. Also heal any backfill provenance records.
+	 */
+	private void trackNewPmids(Map<Long, ?> articles, String strategyName,
+			String uid, Set<Long> existingPmids, Map<Long, String> newPmidStrategy,
+			Set<Long> backfillPmids) {
+		for (Long pmid : articles.keySet()) {
+			if (!existingPmids.contains(pmid) && !newPmidStrategy.containsKey(pmid)) {
+				newPmidStrategy.put(pmid, strategyName);
+			}
+			if (backfillPmids.contains(pmid)) {
+				pmidProvenanceService.updateStrategyIfBackfill(uid, pmid, strategyName);
+				backfillPmids.remove(pmid);
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/reciter/xml/retriever/pubmed/AbstractRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/AbstractRetrievalStrategy.java
@@ -71,7 +71,7 @@ public abstract class AbstractRetrievalStrategy implements RetrievalStrategy {
 	/**
 	 * Retrieval threshold.
 	 */
-	@Value("${searchStrategy-leninent-threshold}")
+	@Value("${searchStrategy-lenient-threshold}")
 	protected final int DEFAULT_THRESHOLD = 2000;
 	
 	/**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,106 +1,141 @@
 
-    
-application.properties local
+#### Application ####
+
+# Log file path (note: logging.file is deprecated in newer Spring Boot; prefer logging.file.name)
 logging.file=logs/reciter.log
 
-###Spring configuration ###
-##This is to make sure bean oveririding is true since relase of 2.1.0 bean overriding is by default false. 
-##For more details see - https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes
+# Bean overriding required since Spring Boot 2.1.0 changed default to false
 spring.main.allow-bean-definition-overriding=true
 
-##Spring Security configuration##
-spring.security.enabled=true
-
-
-#### Server configuration ####
-
-## Server port. You can override this by passing your port using environment variable SERVER_PORT.
+# Server port (override with SERVER_PORT environment variable)
 server.port=5000
 
 
-#### Database configuration ####
-## Set the region for your dynamodb tables. They can be us-east-1(US East (N. Virginia)), us-east-2(US East (Ohio)) etc.
+#### Security ####
+
+# Toggle Spring Security on/off (set false for local development)
+spring.security.enabled=true
+
+# Cognito user pool region for JWT verification
+aws.cognito.userpool.region=us-east-1
+
+# Secret Manager name for consumer API key validation
+aws.secretsmanager.consumer.secretName=prod/reciter-consumer/apikey
+
+# S3 bucket for consumer API access logs
+aws.s3.consumer.api.logs.bucketName=logsconsumerapi
+
+
+#### AWS: DynamoDB ####
+
+# Region for DynamoDB tables
 aws.dynamodb.settings.region=us-east-1
+
+# Auto-create tables on startup
 aws.dynamodb.settings.table.create=true
+
+# Provisioned capacity (ignored when billingmode=PAY_PER_REQUEST)
 aws.dynamodb.settings.table.readcapacityunits=5
 aws.dynamodb.settings.table.writecapacityunits=5
-## Note this is the billing mode for dynamodb. It accepts a enum of type BillingMode which has two values either PROVISIONED or PAY_PER_REQUEST
-## Use PAY_PER_REQUEST for unpredicatable workloads. This provisions the resources for any amount data you want to insert or read.
-## Use PROVISIONED for predictable workloads where you are sure about the data input. Also if you want to control the cost this is better.
+
+# PAY_PER_REQUEST for variable workloads; PROVISIONED for predictable workloads
 aws.dynamodb.settings.table.billingmode=PAY_PER_REQUEST
 
-## Method of identity data import ##
-## You can import identity data to ReCiter in one of two ways:
-## Option 1: Load data from the JSON file located here: https://github.com/wcmc-its/ReCiter/blob/master/src/main/resources/files/Identity.json To use this
-## method, set the below value to "true." With this option, scholars' identities will only be refreshed upon application startup.
-## Option 2: Use the Identity API. For this, you will need to use the /reciter/identity/ API for a single identity or the /reciter/save/identities/ API for multiple
-## identities. To use this method, set the below value to "false."
-
+# Import identities from JSON file on startup (false = use Identity API instead)
 aws.dynamodb.settings.file.import=false
 
-## Local or AWS-hosted DynamoDB. Set this flag to true if you want to test ReCiter with DynamoDB local. 
-## For more about local hosting, refer to https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
-## If you are using an AWS hosted version, those parameters are controlled in the environment 
-## variables of your IDE.
-aws.dynamoDb.local=false 
+# Local DynamoDB for development (set to true with local DynamoDB instance)
+aws.dynamoDb.local=false
 aws.dynamoDb.local.port=8000
 aws.dynamoDb.local.region=us-west-2
 aws.dynamoDb.local.accesskey=dummy
 aws.dynamoDb.local.secretkey=dummy
-aws.dynamoDb.local.dbpath=/Users/szd2013/Documents/Reciter/dynamodb_local_latest/2019-06-25
- 
-
-#### AWS Simple Queue Service (SQS) ####
-## This faeture is not yet ruled out with reciter. If you turn this on  uncomment code in /ReCiter/src/main/java/reciter/queue/sqs/AmazonSQSExtendedClientConfig.java
-## Usage: toggle to use SQS in front of all DynamoDB operations for efficient request handling.
-## Note: Turn this off if you are using dynamodb local
-##aws.sqs.use=false
-##aws.sqs.region=us-east-1
-
-## Since SQS has a size limit of 256kb. Use if you need additional storage for large messages. 
-## BucketName needs to have a *globally* unique name. If it isn't, you'll get an error during the build.
-## Note: Turn this off if you are using dynamodb local
-##aws.sqs.extendedClient=false
-##aws.sqs.s3.bucketName=reciter-queue
 
 
-#### AWS S3 file storage ####
+#### AWS: S3 ####
 
-## Enable S3. Usage: turn on if you expect the item size for DynamoDB to exceed 400kb. This is common.
-## BucketName needs to have a *globally* unique name
-## Consider naming it like "myInstitution-reciter-dynamodb"
-## Note: Turn this off if you are using dynamodb local
+# Enable S3 for large DynamoDB items (>400kb); required for most deployments
 aws.s3.use=true
 aws.s3.region=us-east-1
 aws.s3.dynamodb.bucketName=reciter-dynamodb
-## This option might trigger a failed build if set as false since bucket name have to be globally unique. We recommend turning this option true. 
-## So reciter will dynamically generate the bucket name following the convention of <aws.s3.dynamodb.bucketName>-<aws.s3.region>-<awsaccountNumber>
+
+# Generate bucket name dynamically: <bucketName>-<region>-<accountNumber>
 aws.s3.use.dynamic.bucketName=false
-## This option allows you to cache identityAll endpoint result to store in S3 bucket in path <${aws.s3.dynamodb.bucketName}/idenity>.
-## This helps in performance of the endpoint and latency thereby reducing cost by avoiding expensive scans dynamodb Identity table.
-## In order to use caching options aws.s3.use flags and its corresponding flags should be set with proper values
+
+# Cache /identity/all results in S3 to avoid expensive DynamoDB scans
 aws.s3.use.cached.identityAll=true
-## This option helps in setting number of days the data will be cached in S3 before replacing it. It takes number of days in integer.
 aws.s3.use.cached.identityAll.cacheTime=1
 
 
-#### Scopus configuration (optional) ####
+#### AWS: Lambda & Scoring ####
 
-## Usage: use Scopus for disambiguated organizations and more complete names.
-## For more: see https://github.com/wcmc-its/ReCiter/wiki/Configuring-Scopus-(optional)
-use.scopus.articles=true
- 
+aws.lambda.region=us-east-1
+aws.secretsmanager.region=us-east-1
 
-#### Strategies ####
+# Secret containing Lambda function names (keys: devlambdaFunctionName, prodlambdaFunctionName)
+aws.secretsmanager.reciterscoring.secretName=reciterscore
 
-## By setting any of these strategies to false, you negate them.
-## This allows you to see how individual strategies contribute to overall performance.
+# Local scoring service config (for local development only)
+aws.reciterscoring.service.portNo=9000
+local.lambda.function.invocation.url=/2015-03-31/functions/function/invocations
+
+
+
+#### Retrieval ####
+
+# Maximum PubMed results before switching from lenient to strict retrieval
+searchStrategy-lenient-threshold=2000
+searchStrategy-strict-threshold=1000
+
+
+
+#### INSTITUTION-SPECIFIC CONFIGURATION ####
+## Deployers at other institutions must customize this entire section.
+
+# Email suffixes for the home institution
+strategy.email.default.suffixes=@med.cornell.edu,@mail.med.cornell.edu,@weill.cornell.edu,@nyp.org
+
+# Keywords identifying the home institution in affiliation statements
+# "|" = AND within group, "," = OR between groups
+strategy.authorAffiliationScoringStrategy.homeInstitution-keywords=weil|cornell, weill|cornell, weill|medicine, cornell|medicine, cornell|medical, weill|medical, weill|bugando, weill|graduate, cornell|presbyterian, weill|presbyterian, 10065|cornell, 10065|presbyterian, 10021|cornell, 10021|presbyterian, weill|qatar, cornell|qatar, @med.cornell.edu, @qatar-med.cornell.edu, tri-institutional|md-phd, memorial|sloan|kettering, rockefeller|university, hospital|special|surgery
+
+# Display label for the home institution
+strategy.authorAffiliationScoringStrategy.homeInstitution-label=Weill Cornell Medicine / NewYork-Presbyterian Hospital
+
+# Keywords for collaborating institutions
+strategy.authorAffiliationScoringStrategy.collaboratingInstitutions-keywords=new|york|presbyterian, rockefeller|university, HSS, hospital|special|surgery, North|Shore|hospital, Long|Island|Jewish, memorial|sloan, sloan|kettering, hamad, mount|sinai, methodist|houston, National|Institute|Mental|Health, beth israel, University|Pennsylvania|Medicine, Merck|Research, New|York|Medical|College, Medicine|Dentistry|New|Jersey, Montefiore, Lenox|Hill, Cold|Spring|Harbor, St|Luke|Roosevelt, New|York|University|Medicine, Langone, SUNY|Downstate, Albert|Einstein|Medicine, Yeshiva, UMDNJ, Icahn|Medicine, Mount|Sinai, columbia|medical, columbia|physicians
+
+# Stopwords removed from both identity and article affiliations before matching
+strategy.authorAffiliationScoringStrategy.institutionStopwords=of, the, for, and, to
+
+# Org unit synonyms now loaded from OrganizationalUnitSynonyms.json
+
+# Modifier for common org units (e.g., "Medicine" gets lower score)
+strategy.orgUnitScoringStrategy.organizationalUnitModifier=Medicine
+strategy.orgUnitScoringStrategy.organizationalUnitModifierScore=0
+
+# Common author names excluded from co-author clustering (format: Last FirstInitial)
+# Source: Torvik et al. https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2805000/figure/F8/
+#         Vishnyakova et al. https://www.ncbi.nlm.nih.gov/pubmed/30958542
+namesIgnoredCoauthors=Zhang Y, Lee J, Wang J, Kim J, Wang X, Chen Y, Li J, Zhang J, Kim H, Chen J, Wang L, Liu J, Wang Z, Zhang H, Wang S, Wang C, Lee H, Li H, Chen H, Zhang Z, Yang Y, Li L, Li Z, Park S, Yang J, Lee Y, Li S, Lee C, Chen L, Smith J, Kim S, Lee S
+## Alternative: top 500 most common names (~7.5% of PubMed authors)
+## namesIgnoredCoauthors=Wang Y, Zhang Y, Li Y, Wang J, Wang X, Liu Y, Li J, Lee J, Zhang X, Chen Y, Zhang J, Li X, Kim J, Lee S, Wang H, Kim S, Wang L, Liu J, Chen J, Zhang L, Liu X, Wang Z, Zhang H, Kim H, Li H, Wang S, Chen X, Wang C, Kim Y, Zhang Z, Yang Y, Li Z, Chen C, Li L, Chen H, Li S, Liu H, Yang J, Lee H, Chen S, Chen L, Wang W, Li C, Zhang W, Liu Z, Park J, Zhao Y, Wu Y, Zhang S, Huang Y, Li W, Wu J, Liu C, Park S, Lee K, Lee Y, Liu S, Chen Z, Liu L, Yang X, Wang Q, Zhang C, Lee C, Xu Y, Chen W, Li M, Zhou Y, Kim D, Kim K, Zhang Q, Xu J, Wang M, Li Q, Wang D, Sun Y, Yang H, Kim M, Liu W, Wu X, Xu X, Zhang M, Huang J, Lee M, Zhao J, Yang L, Yang S, Lin Y, Zhou J, Lin C, Chen M, Li D, Zhou X, Zhu Y, Wang T, Wang G, Wu C, Li G, Yang C, Wang F, Zhao X, Huang C, Yu J, Lu Y, Wu H, Yang Z, Lee D, Wang B, Hu Y, Huang X, Xu H, Lin J, Zhang D, Li B, Sun J, Smith J, Liu Q, Liu M, Sun X, Wang P, Gao Y, Huang H, Xu L, Jiang Y, Zhu J, Choi J, Guo Y, Zhang B, Wu S, Zhang G, Park H, Zhu X, Yu Y, Chen G, Ma Y, Liu B, Wang R, Yu H, Li F, Wang K, Liu D, Huang S, Ma J, Song Y, Chang C, Xu Z, Li T, Kim C, Lin S, Singh S, Liu F, He Y, Zhang F, Liu G, Zhao L, Hu J, Lee W, Zhao H, Lin H, Wu Z, Li P, Zheng Y, Chen D, Kumar A, Chen Q, Han J, Zhou H, Lu J, Kim B, Kumar S, Zhang R, Zhang T, Choi S, Yang W, Smith M, Huang L, Chen T, Kim T, Hu X, Liu T, Yu X, Smith R, He J, Shi Y, Wu L, Park Y, Smith D, Zhou L, Smith A, Huang W, Song J, Sun L, Chang Y, Ma X, Li R, Sun H, Wu W, Guo X, Chen K, Zhou Z, Yang M, Chen P, Park K, Lee B, Zhang P, Zhu H, Chen B, Jiang H, Xu W, Guo J, Wu M, Cheng Y, Lee T, Han S, Zhu L, Zhao Z, Lu X, Gupta S, Jiang X, Miller J, Tang Y, Shen Y, Kim E, Huang Z, Lee E, Sharma S, He X, Choi Y, Smith S, Jiang J, Smith C, Brown J, Chen F, Gao X, Chang S, Yu L, Yu S, Cao Y, Singh A, Luo Y, Ma L, Han Y, Suzuki K, Park C, Hong S, Liu P, Kang S, Gao J, Johnson J, Li K, Khan M, Williams J, Zhang K, Li N, Liu K, Yu C, Xu C, Chang J, Xu S, Martin J, Cho S, Johnson M, Chen R, Jones R, Sharma A, Yang D, Wu D, Feng Y, Liu R, Yang G, Shi J, Cheng J, Tang J, Kim W, Jiang L, Xie Y, Lu H, Chang H, Zheng X, Zheng J, Yang Q, Choi H, Lin L, Zhao S, Sun Z, Wei Y, Kang J, Lu C, Zhu Z, Williams R, Gupta A, Zhao W, Yang F, Kumar R, Liang Y, Luo J, Singh R, Zhou Q, Zhou W, Khan A, Wilson J, Yu Z, Lee A, Shen J, Guo L, Miller M, Smith G, Hu Z, Wang N, Lin X, Watanabe K, Anderson J, Wu T, Nguyen T, Xu M, Song H, Ding Y, Guo H, Sun S, Tang X, Shi X, Sun W, Jones D, Miller D, Zhao C, Yuan Y, Williams D, Miller R, Brown R, Lu Z, Brown M, Xu Q, Ma H, Kang H, Guo Z, Johnson R, Taylor J, Johnson D, Han X, Davis J, Cheng C, Jones J, Zhao Q, Yang T, Huang M, Zhao M, Zhu W, Thompson J, Khan S, Cho Y, Lin W, Lin M, Gupta R, Fu Y, Yan J, Lin Z, Pan Y, Hu S, Park M, Oh S, Thomas J, Lim S, Lu L, Luo X, Yan Y, Das S, Xu D, Peng Y, Jones M, Xu G, Brown D, Cohen M, Shin J, Smith P, Cui Y, Cheng H, Xu B, Feng J, Lu S, Hong J, Smith K, Anderson R, Zheng H, Ma C, Patel S, Wang A, Jiang S, Hu C, Smith T, Yu M, Cho J, Zhang N, Hu W, Huang T, Shah S, Cao J, Wei J, Du Y, Yang K, Shi L, Sharma R, Yang P, Yao Y, Zhu S, Lee P, Brown S, Zhou M, Johnson A, Cohen J, Smith L, Williams M, Lim J, Zhu C, Lee G, Kato T, Moore J, Brown C, Song S, Patel A, Hwang S, Ghosh S, Smith B, Yuan J, Jung S, Johnson C, Brown A, Martin M, Fan J, Kumar P, Shin S, Kim I, Chan K, Chung J, Wilson M, Jones A, Shen H, Tang H, Martin R, Cheng L, Hwang J, Sun M, Smith E, Lee R, Li A, Kim G, Singh M, Cho H, Williams A, Fang Y, Cheng S, Johnson S, Jones S, Yu D, Chan C, Kumar V, Williams S, Young J, Miller A, Bai Y, Kang Y, Thomas D, Tang L, White J, Wright J, Wilson D, Cohen S, Chen A, Tang S, Zheng W, Thomas M, Kim N, Shen X, Martin C, Tan Y, Jiang C, Tang C, Oh J, Tang W, Johnson K, Martin A, Williams C, Wei L, Scott J, Yoon S, Lu M, Yao J, Jung H, Ye J, Shah A, Wilson R, Taylor A, Huang G, Singh P, Wong C, Zheng S, Roberts J, Garcia J, Lewis J, Thomas S, Miller S
+
+# Person type scores (intentionally set to 0; education year evidence now handles this)
+strategy.personTypeScoringStrategy.personTypeScore-academic-faculty-weillfulltime=0
+strategy.personTypeScoringStrategy.personTypeScore-student-md-new-york=0
+
+# Name suffixes to exclude from matching
+nameScoringStrategy-excludedSuffixes=Jr,Jr.,MD PhD,MD-PhD,PhD,MD,III,III.,II,II.,Sr,Sr.
+
+
+#### Identity scoring: Strategy toggles ####
+
 strategy.email=true
 strategy.department=true
 strategy.journalcategory=true
 strategy.known.relationship=true
 strategy.affiliation=true
-strategy.scopus.common.affiliation=true
 strategy.grant=true
 strategy.article.size=true
 strategy.persontype=true
@@ -108,58 +143,9 @@ strategy.gender=true
 strategy.nameFrequency=true
 strategy.education.year.discrepancy=true
 
-#Feedback toggle options
-aws.s3.feedback.score.bucketName=feedbackscoring
 
-#Feedback score sections
-strategy.feedback.score.orcid=true
-strategy.feedback.score.journal=true
-strategy.feedback.score.year=true
-strategy.feedback.score.targetAuthorName=true
-strategy.feedback.score.orcidCoAuthor=true
-strategy.feedback.score.keyword=true
-strategy.feedback.score.institution=true
-strategy.feedback.score.email=true
-strategy.feedback.score.coauthorName=true
-strategy.feedback.score.organization=true
-strategy.feedback.score.journalsubfield=true
-## Scoring is not required for journalField and Journal Domain. Hence, Value should be always false. 
-strategy.feedback.score.journalfield=false 
-strategy.feedback.score.journaldomain=false 
-strategy.feedback.score.cites=true
-strategy.feedback.score.bibliographiccoupling=true
-strategy.feedback.score.textSimilarity=true
-strategy.feedback.score.journalTitleSimilarity=true
+#### Identity scoring: Name evidence ####
 
-#### Retrieval ####
-
-## Usage: controls the maximum number of results returned under "lenient" and "strict" retrieval. 
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#Retrieving-candidate-records-from-PubMed
-searchStrategy-leninent-threshold=2000
-searchStrategy-strict-threshold=1000
- 
-
-#### Clustering ####
-
-## Goal: control how aggressive clustering is. 
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#Create-clusters
-
-## This value speaks to the proportion of evidence that must be shared between two articles 
-## the system is considering for clustering.
-cluster.similarity.threshold.score=0.28
-
-## This value excludes from consideration for this strategy, certain candidate articles that have more 
-## than this many indexed grants.
-clusteringGrants-threshold=12
-
-
-
-#### Scoring ####
-
-### Name evidence ###
-
-## Each candidate targetAuthor is scored individually for similarity to the person of interest.
-## For more, see https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#Name-evidence
 nameMatchFirstType.full-exact=1.852
 nameMatchFirstType.inferredInitials-exact=0.441
 nameMatchFirstType.full-fuzzy=-0.75
@@ -189,89 +175,170 @@ nameMatchModifier.identitySubstringOfArticle-middleName=-0.804
 nameMatchModifier.identitySubstringOfArticle-firstMiddleName=0.804
 nameMatchModifier.combinedMiddleNameLastName=0
 
-## Include all name suffixes seperated by comma. All the name suffixes will be checked for with following expression ,<space><suffix> and <space><suffix>
-nameScoringStrategy-excludedSuffixes=Jr,Jr.,MD PhD,MD-PhD,PhD,MD,III,III.,II,II.,Sr,Sr.
 
-## These author names are so common that they were messing up clustering. 
-## This list comes from Torvik et al. https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2805000/figure/F8/ and Vishnyakova et al. https://www.ncbi.nlm.nih.gov/pubmed/30958542
-## Format is Last Name <space> First Initial
-namesIgnoredCoauthors=Zhang Y, Lee J, Wang J, Kim J, Wang X, Chen Y, Li J, Zhang J, Kim H, Chen J, Wang L, Liu J, Wang Z, Zhang H, Wang S, Wang C, Lee H, Li H, Chen H, Zhang Z, Yang Y, Li L, Li Z, Park S, Yang J, Lee Y, Li S, Lee C, Chen L, Smith J, Kim S, Lee S
-## As an alternative, here is a revised, more aggressive approach. These are the top 500 most common names in PubMed and represent ~7.5% of PubMed authors.
-## namesIgnoredCoauthors=Wang Y, Zhang Y, Li Y, Wang J, Wang X, Liu Y, Li J, Lee J, Zhang X, Chen Y, Zhang J, Li X, Kim J, Lee S, Wang H, Kim S, Wang L, Liu J, Chen J, Zhang L, Liu X, Wang Z, Zhang H, Kim H, Li H, Wang S, Chen X, Wang C, Kim Y, Zhang Z, Yang Y, Li Z, Chen C, Li L, Chen H, Li S, Liu H, Yang J, Lee H, Chen S, Chen L, Wang W, Li C, Zhang W, Liu Z, Park J, Zhao Y, Wu Y, Zhang S, Huang Y, Li W, Wu J, Liu C, Park S, Lee K, Lee Y, Liu S, Chen Z, Liu L, Yang X, Wang Q, Zhang C, Lee C, Xu Y, Chen W, Li M, Zhou Y, Kim D, Kim K, Zhang Q, Xu J, Wang M, Li Q, Wang D, Sun Y, Yang H, Kim M, Liu W, Wu X, Xu X, Zhang M, Huang J, Lee M, Zhao J, Yang L, Yang S, Lin Y, Zhou J, Lin C, Chen M, Li D, Zhou X, Zhu Y, Wang T, Wang G, Wu C, Li G, Yang C, Wang F, Zhao X, Huang C, Yu J, Lu Y, Wu H, Yang Z, Lee D, Wang B, Hu Y, Huang X, Xu H, Lin J, Zhang D, Li B, Sun J, Smith J, Liu Q, Liu M, Sun X, Wang P, Gao Y, Huang H, Xu L, Jiang Y, Zhu J, Choi J, Guo Y, Zhang B, Wu S, Zhang G, Park H, Zhu X, Yu Y, Chen G, Ma Y, Liu B, Wang R, Yu H, Li F, Wang K, Liu D, Huang S, Ma J, Song Y, Chang C, Xu Z, Li T, Kim C, Lin S, Singh S, Liu F, He Y, Zhang F, Liu G, Zhao L, Hu J, Lee W, Zhao H, Lin H, Wu Z, Li P, Zheng Y, Chen D, Kumar A, Chen Q, Han J, Zhou H, Lu J, Kim B, Kumar S, Zhang R, Zhang T, Choi S, Yang W, Smith M, Huang L, Chen T, Kim T, Hu X, Liu T, Yu X, Smith R, He J, Shi Y, Wu L, Park Y, Smith D, Zhou L, Smith A, Huang W, Song J, Sun L, Chang Y, Ma X, Li R, Sun H, Wu W, Guo X, Chen K, Zhou Z, Yang M, Chen P, Park K, Lee B, Zhang P, Zhu H, Chen B, Jiang H, Xu W, Guo J, Wu M, Cheng Y, Lee T, Han S, Zhu L, Zhao Z, Lu X, Gupta S, Jiang X, Miller J, Tang Y, Shen Y, Kim E, Huang Z, Lee E, Sharma S, He X, Choi Y, Smith S, Jiang J, Smith C, Brown J, Chen F, Gao X, Chang S, Yu L, Yu S, Cao Y, Singh A, Luo Y, Ma L, Han Y, Suzuki K, Park C, Hong S, Liu P, Kang S, Gao J, Johnson J, Li K, Khan M, Williams J, Zhang K, Li N, Liu K, Yu C, Xu C, Chang J, Xu S, Martin J, Cho S, Johnson M, Chen R, Jones R, Sharma A, Yang D, Wu D, Feng Y, Liu R, Yang G, Shi J, Cheng J, Tang J, Kim W, Jiang L, Xie Y, Lu H, Chang H, Zheng X, Zheng J, Yang Q, Choi H, Lin L, Zhao S, Sun Z, Wei Y, Kang J, Lu C, Zhu Z, Williams R, Gupta A, Zhao W, Yang F, Kumar R, Liang Y, Luo J, Singh R, Zhou Q, Zhou W, Khan A, Wilson J, Yu Z, Lee A, Shen J, Guo L, Miller M, Smith G, Hu Z, Wang N, Lin X, Watanabe K, Anderson J, Wu T, Nguyen T, Xu M, Song H, Ding Y, Guo H, Sun S, Tang X, Shi X, Sun W, Jones D, Miller D, Zhao C, Yuan Y, Williams D, Miller R, Brown R, Lu Z, Brown M, Xu Q, Ma H, Kang H, Guo Z, Johnson R, Taylor J, Johnson D, Han X, Davis J, Cheng C, Jones J, Zhao Q, Yang T, Huang M, Zhao M, Zhu W, Thompson J, Khan S, Cho Y, Lin W, Lin M, Gupta R, Fu Y, Yan J, Lin Z, Pan Y, Hu S, Park M, Oh S, Thomas J, Lim S, Lu L, Luo X, Yan Y, Das S, Xu D, Peng Y, Jones M, Xu G, Brown D, Cohen M, Shin J, Smith P, Cui Y, Cheng H, Xu B, Feng J, Lu S, Hong J, Smith K, Anderson R, Zheng H, Ma C, Patel S, Wang A, Jiang S, Hu C, Smith T, Yu M, Cho J, Zhang N, Hu W, Huang T, Shah S, Cao J, Wei J, Du Y, Yang K, Shi L, Sharma R, Yang P, Yao Y, Zhu S, Lee P, Brown S, Zhou M, Johnson A, Cohen J, Smith L, Williams M, Lim J, Zhu C, Lee G, Kato T, Moore J, Brown C, Song S, Patel A, Hwang S, Ghosh S, Smith B, Yuan J, Jung S, Johnson C, Brown A, Martin M, Fan J, Kumar P, Shin S, Kim I, Chan K, Chung J, Wilson M, Jones A, Shen H, Jones C, Tang H, Martin R, Cheng L, Hwang J, Sun M, Smith E, Lee R, Li A, Kim G, Singh M, Cho H, Williams A, Fang Y, Cheng S, Johnson S, Jones S, Yu D, Chan C, Kumar V, Williams S, Young J, Miller A, Bai Y, Kang Y, Thomas D, Tang L, White J, Wright J, Wilson D, Cohen S, Chen A, Tang S, Zheng W, Thomas M, Kim N, Shen X, Martin C, Tan Y, Jiang C, Tang C, Oh J, Tang W, Johnson K, Martin A, Williams C, Wei L, Scott J, Yoon S, Lu M, Yao J, Jung H, Ye J, Shah A, Wilson R, Taylor A, Huang G, Singh P, Wong C, Zheng S, Roberts J, Garcia J, Lewis J, Thomas S, Miller S
+#### Identity scoring: Email evidence ####
 
-### Organizational unit evidence ###
-
-## Goal: reward cases where an author's known affiliation appears in the affiliation statement.
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#Organizational-unit-evidence
-strategy.orgUnitScoringStrategy.organizationalUnitDepartmentMatchingScore=0.6
-
-## Some org units (e.g., Medicine) are so common that we give them a lower score.
-strategy.orgUnitScoringStrategy.organizationalUnitModifier=Medicine
-strategy.orgUnitScoringStrategy.organizationalUnitModifierScore=0
-
-## At least at Weill Cornell, org units of type "program" are relatively rare, so they get a higher score.
-## We define program in identity.organizationalUnits.organizationalUnitType
-## If an org unit is not a program, we score it as we would a department.
-strategy.orgUnitScoringStrategy.organizationalUnitProgramMatchingScore=1.083
-
-## Org units go by a lot of different names. This is important to get right.
-## Note the proper use of the "," and "|" delimiters.
-strategy.orgUnitScoringStrategy.organizationalUnitSynonym=strategy.orgUnitScoringStrategy.organizationalUnitSynonym=Anaesthesiology|Anesthesiology|Anesthesia,Anesthesiology And Critical Care|Anesthesiology and Critical Care Medicine,Anesthesiology and Intensive Care Medicine|Anesthesiology and Intensive Care|Anesthesiology And Critical Care,Biochemistry|Bioquímica,Biologia|Biology|Biological Science|Biological Sciences,Brain and Mind Research Institute|Neuroscience|Feil Family Brain and Mind Research Institute,Cancer|Meyer Cancer Center|Meyers Cancer Center|Sandra and Edward Meyer Cancer Center|Sandra & Edward Meyer Cancer Center,Cardiac Surgery|Cardiothoracic Surgery,Chemical and Biomolecular Engineering|Chemical and Biological Engineering,Chemistry And Biochemistry|Chemistry and Chemical Biology,Chemistry|Chimica|Quimica,Cirugía|Surgery,Clinical Research|Clinical Science,Critical Care Medicine|Critical Care,Ecology and Evolutionary Biology|Ecology and Evolution,Endocrine|Endocrinology,Environmental Health|Environmental Health Science,Environmental Science|Environmental Sciences,Food Science|Food Science and Technology,Health Informatics|Quality and Medical Informatics,Hematology/Oncology|Hematology and Oncology|Hematology and Medical Oncology,Histopathology|Histology,Infectious Diseases|Infectious Disease,Institute for Computational Biomedicine|HRH Prince Alwaleed Bin Talal Bin,Library|Library Science|Samuel J. Wood|Library and Information Science|Information Science|Wood Library,Life Science|Life Sciences,Materials Science|Materials Science and Engineering,Meyer Cancer Center|Meyers Cancer Center|Sandra and Edward Meyer Cancer Center|Sandra & Edward Meyer Cancer Center,Microbiología|Microbiology,Microbiology and Immunology|Microbiology|Immunology,Nephrology and Hypertension|Nephrology,Neurological Science|Neurology|Neurological Sciences,Neurological Surgery|Neurosurgery,Nutrition|Nutritional Science|Food Science and Human Nutrition|Food and Nutrition,Obstetrics and Gynecology|Obstetrics,Ophthalmology and Visual Sciences|Ophthalmology and Visual Science|Ophthalmology|Ophthalmology and Visual Science,Oral and Maxillofacial Surgery|Oral Surgery,Orthopaedic Surgery|Orthopedics|Orthopedic Surgery,Orthopaedics|Orthopedics|Orthopaedics and Trauma,Otolaryngology|Head and Neck Surgery|Ear Nose & Throat|Otolaryngology-Head and Neck Surgery|Otorhinolaryngology|Ear Nose and Throat|ENT,Paediatrics|Pediatrics,Pathology and Laboratory Medicine|Pathology,Pediatrics|Phyllis and David Komansky|Paediatrics,Pharmaceutics|Pharmaceutical Science|Pharmaceutical Science,Pharmacology and Therapeutics|Pharmacology,Pharmacy Practice|Pharmacy,Physics|Física,Physiological Science|Physiology|Physiological Sciences|Physiology and Biophysics|Physiology|Fisiología,Plant|Plant Science,Plastic and Reconstructive Surgery|Plastic Surgery,Population Health Sciences|Epidemiology and Population Health|Population Health|Public Health|Public Health Science|Public Health Sciences|Public Health Programs|Healthcare Policy and Research|Health Policy|Healthcare Policy & Research|Public Health|Health Care Policy & Research|Healthcare Policy and Research|Community Public Health|Epidemiology and Biostatistics|Epidemiology & Biostatistics|Epidemiology|Health Policy,Psychiatry and Behavioral Sciences|Psychiatry and Behavioral Science,Psychological Science|Psychological Sciences|Psychology,Pulmonary and Critical Care Medicine|Pulmonary and Critical Care,Pulmonary Medicine and Critical Care|Pulmonary & Critical Care Medicine|Pulmonary and Critical Care Medicine,Radiology and Radiological Science|Radiology,Radiology|Imaging|Diagnostic Imaging,Rehabilitation Medicine|Physical Medicine|Rehabilitation,Rehabilitation|Rehabilitation Medicine|Rehabilitation|Rehabilitation Medicine,Reproductive Medicine|Ronald O. Perelman and Claudia Cohen Center for Reproductive Medicine|Center for Reproductive Medicine,Surgical Research|Surgical Science|Surgical Sciences|Cirugía|Surgery,Thoracic and CardioVascular Surgery|Cardiothoracic Surgery,Veterans Affairs Medical Center|Veterans Affairs,Veterinary Clinical Science|Veterinary Clinical Sciences|Veterinary Science
- 
-
-### Email evidence ###
-
-## Goal: see whether mail subdomains co-occur with a given target person's UID. For example: "paa2013" + "@nyp.org"
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#Email-evidence
-strategy.email.default.suffixes=@med.cornell.edu,@mail.med.cornell.edu,@weill.cornell.edu,@nyp.org
 strategy.email.emailMatchScore=8
 strategy.email.emailNoMatchScore=-1
- 
 
-### Journal category evidence ###
 
-## Goal: compare target individuals' known org units against any possible journal category matches in 
-## the ScienceMetrixDepartmentCategory table. Updating this table can improve the accuracy 
-## of scores for researchers working in certain smaller specialties.
+#### Identity scoring: Organizational unit evidence ####
 
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#journal-category-evidence
-strategy.journalCategoryScore.journalSubfieldFactorScore=0.470
-strategy.journalCategoryScore.journalSubfieldScore=-0.470
- 
+# Score for department-level match
+strategy.orgUnitScoringStrategy.organizationalUnitDepartmentMatchingScore=0.6
 
-### Affiliation evidence ###
+# Higher score for program-level match (programs are rarer than departments)
+strategy.orgUnitScoringStrategy.organizationalUnitProgramMatchingScore=1.083
 
-## Goal: account for the extent to which affiliation of all authors affects the likelihood 
-## a given targetAuthor authored an article
 
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#affiliation-evidence
+#### Identity scoring: Affiliation evidence ####
 
+# Target author affiliation scores
 strategy.authorAffiliationScoringStrategy.targetAuthor-institutionalAffiliation-matchType-positiveMatch-individual-score=1.8
 strategy.authorAffiliationScoringStrategy.targetAuthor-institutionalAffiliation-matchType-positiveMatch-institution-score=1.0
 strategy.authorAffiliationScoringStrategy.targetAuthor-institutionalAffiliation-matchType-null-score=0
 strategy.authorAffiliationScoringStrategy.targetAuthor-institutionalAffiliation-matchType-noMatch-score=-0.8
 
-## Consistently remove certain stopwords from both identity and article metadata.
-strategy.authorAffiliationScoringStrategy.institutionStopwords=of, the, for, and, to
 
-## For target author, we search the PubMed affiliation statement for groups of terms suggesting 
-## this is your home institution.
-## Note the proper use of the "," and "|" delimiters.
-strategy.authorAffiliationScoringStrategy.homeInstitution-keywords=weil|cornell, weill|cornell, weill|medicine, cornell|medicine, cornell|medical, weill|medical, weill|bugando, weill|graduate, cornell|presbyterian, weill|presbyterian, 10065|cornell, 10065|presbyterian, 10021|cornell, 10021|presbyterian, weill|qatar, cornell|qatar, @med.cornell.edu, @qatar-med.cornell.edu, tri-institutional|md-phd, memorial|sloan|kettering, rockefeller|university, hospital|special|surgery
+#### Identity scoring: Relationship evidence ####
 
-## Used only for output purposes.
-strategy.authorAffiliationScoringStrategy.homeInstitution-label=Weill Cornell Medicine / NewYork-Presbyterian Hospital
+strategy.knownrelationships.relationshipMatchingScore=0.52
+strategy.knownrelationships.relationshipVerboseMatchModifier=1.68
+strategy.knownrelationships.relationshipMatchModifier-Mentor=0.522
+strategy.knownrelationships.relationshipMatchModifier-Mentor-SeniorAuthor=0
+strategy.knownrelationships.relationshipMatchModifier-Manager=1.01
+strategy.knownrelationships.relationshipMatchModifier-Manager-SeniorAuthor=0
+strategy.knownrelationships.relationshipMinimumTotalScore=-1.592
+strategy.knownrelationships.relationshipNonMatchScore=-0.048
 
-## If Scopus is configured, attempt to match Scopus institution IDs to any of the authors.
-## Used for both targetAuthor and nonTargetAuthors.
+
+#### Identity scoring: Grant evidence ####
+
+strategy.grant.grantMatchScore=2.253
+
+
+#### Identity scoring: Gender evidence ####
+
+strategy.genderStrategyScore.minimumScore=-1.36
+strategy.genderStrategyScore.rangeScore=1.6
+
+
+#### Identity scoring: Education year evidence ####
+
+# Degree year to score mapping (year_difference|score pairs, from -99 to +100)
+strategy.discrepancyDegreeYear.degreeYearDiscrepancyScore=-99|-12.6,-98|-12.5,-97|-12.4,-96|-12.3,-95|-12.2,-94|-12.1,-93|-12,-92|-11.9,-91|-11.8,-90|-11.7,-89|-11.6,-88|-11.5,-87|-11.4,-86|-11.3,-85|-11.2,-84|-11.1,-83|-11,-82|-10.9,-81|-10.8,-80|-10.7,-79|-10.6,-78|-10.5,-77|-10.4,-76|-10.3,-75|-10.2,-74|-10.1,-73|-10,-72|-9.9,-71|-9.8,-70|-9.7,-69|-9.6,-68|-9.5,-67|-9.4,-66|-9.3,-65|-9.2,-64|-9.1,-63|-9,-62|-8.9,-61|-8.8,-60|-8.7,-59|-8.6,-58|-8.5,-57|-8.4,-56|-8.3,-55|-8.2,-54|-8.1,-53|-8,-52|-7.9,-51|-7.8,-50|-7.7,-49|-7.6,-48|-7.5,-47|-7.4,-46|-7.3,-45|-7.2,-44|-7.1,-43|-7,-42|-6.9,-41|-6.8,-40|-6.7,-39|-6.6,-38|-6.5,-37|-6.4,-36|-6.3,-35|-6.2,-34|-6.1,-33|-6,-32|-5.9,-31|-5.8,-30|-5.7,-29|-5.6,-28|-5.5,-27|-5.4,-26|-5.3,-25|-5.2,-24|-5.1,-23|-5,-22|-4.9,-21|-4.8,-20|-4.7,-19|-4.6,-18|-4.5,-17|-4.4,-16|-4.3,-15|-4.2,-14|-4.1,-13|-4,-12|-3.78,-11|-3.56,-10|-3.34,-9|-3.12,-8|-2.9,-7|-2.68,-6|-2.46,-5|-2.24,-4|-2.02,-3|-1.8,-2|-1.58,-1|-1.36,0|-1.16,1|-0.96,2|-0.76,3|-0.56,4|-0.36,5|-0.175,6|0.01,7|0.195,8|0.38,9|0.55,10|0.72,11|0.89,12|0.9,13|0.9,14|0.9,15|0.9,16|0.9,17|0.9,18|0.9,19|0.9,20|0.9,21|0.9,22|0.9,23|0.9,24|0.9,25|0.9,26|0.9,27|0.9,28|0.9,29|0.9,30|0.9,31|0.9,32|0.9,33|0.9,34|0.9,35|0.9,36|0.9,37|0.9,38|0.9,39|0.9,40|0.9,41|0.9,42|0.9,43|0.9,44|0.9,45|0.9,46|0.9,47|0.9,48|0.89,49|0.88,50|0.86,51|0.85,52|0.83,53|0.81,54|0.8,55|0.77,56|0.75,57|0.73,58|0.7,59|0.68,60|0.65,61|0.62,62|0.59,63|0.56,64|0.53,65|0.49,66|0.45,67|0.42,68|0.38,69|0.34,70|0.3,71|0.25,72|0.21,73|0.16,74|0.12,75|0.07,76|0.02,77|-0.04,78|-0.09,79|-0.14,80|-0.2,81|-0.26,82|-0.31,83|-0.37,84|-0.43,85|-0.5,86|-0.56,87|-0.63,88|-0.69,89|-0.76,90|-0.83,91|-0.9,92|-0.98,93|-1.05,94|-1.12,95|-1.2,96|-1.28,97|-1.36,98|-1.44,99|-1.52,100|-1.61
+
+# Weight applied when only bachelor's degree year is available (doctoral year ~ bachelor + 7)
+strategy.discrepancyDegreeYear.bachelorYearWeight=-7
+
+
+#### Identity scoring: Article count evidence ####
+
+# If this many candidate articles, score for this strategy = 0
+strategy.articleCountScoringStrategy.articleCountThresholdScore=800
+
+# Increasing this decreases the weight of the strategy
+strategy.articleCountScoringStrategy.articleCountWeight=583.9
+
+# Median number of authors for baseline likelihood calculation
+strategy.articleCountScoringStrategy.authorCountThreshold=6
+
+# Scaling factor (gamma) for author count adjustment
+strategy.articleCountScoringStrategy.authorCountAdjustmentGamma=2.6
+
+# Coefficients for likelihood formula
+strategy.articleCountScoringStrategy.lnCoefficient=-0.2461
+strategy.articleCountScoringStrategy.constantCoefficient=1.98
+
+
+#### Identity scoring: Journal category evidence ####
+
+strategy.journalCategoryScore.journalSubfieldFactorScore=0.470
+strategy.journalCategoryScore.journalSubfieldScore=-0.470
+
+
+#### Feedback scoring: Strategy toggles ####
+
+strategy.feedback.score.orcid=true
+strategy.feedback.score.journal=true
+strategy.feedback.score.year=true
+strategy.feedback.score.targetAuthorName=true
+strategy.feedback.score.orcidCoAuthor=true
+strategy.feedback.score.keyword=true
+strategy.feedback.score.institution=true
+strategy.feedback.score.email=true
+strategy.feedback.score.coauthorName=true
+strategy.feedback.score.organization=true
+strategy.feedback.score.journalsubfield=true
+# journalfield and journaldomain scoring not implemented; must remain false
+strategy.feedback.score.journalfield=false
+strategy.feedback.score.journaldomain=false
+strategy.feedback.score.cites=true
+strategy.feedback.score.bibliographiccoupling=true
+strategy.feedback.score.textSimilarity=true
+strategy.feedback.score.journalTitleSimilarity=true
+
+
+#### Feedback scoring: Keyword parameters ####
+
+# Baseline keyword count for weighting calculation
+strategy.feedback.keywordCountBaseline=1319351
+
+# Logarithmic base for keyword factor calculation
+strategy.feedback.keywordLogBase=25
+
+# Constant offset added to the logarithmic result
+strategy.feedback.keywordOffset=0.4
+
+
+#### Feedback scoring: Informed absence ####
+
+# Penalize feedback attributes never seen among accepted/rejected articles
+strategy.feedback.informedAbsence.enabled=true
+strategy.feedback.informedAbsence.scale=10.0
+
+# Per-feature strength (higher = more aggressive penalty; based on zero-rate among accepted articles)
+# targetAuthorName: 0.4% zero-rate (safest to penalize)
+strategy.feedback.informedAbsence.targetAuthorName.strength=1.0
+# coAuthorName: 2.3%, keyword: 3.4%
+strategy.feedback.informedAbsence.coAuthorName.strength=0.9
+strategy.feedback.informedAbsence.keyword.strength=0.9
+# journal: 5.1%, journalSubField: 4.3%
+strategy.feedback.informedAbsence.journal.strength=0.7
+strategy.feedback.informedAbsence.journalSubField.strength=0.7
+# institution: 8.6%, cites: 9.2%, organization: 10.9%
+strategy.feedback.informedAbsence.institution.strength=0.5
+strategy.feedback.informedAbsence.cites.strength=0.5
+strategy.feedback.informedAbsence.bibliographiccoupling.strength=0.5
+strategy.feedback.informedAbsence.organization.strength=0.5
+# email: 16.1%, orcid: 16.4%
+strategy.feedback.informedAbsence.email.strength=0.3
+strategy.feedback.informedAbsence.orcid.strength=0.3
+
+
+#### Feedback scoring: S3 bucket ####
+
+aws.s3.feedback.score.bucketName=feedbackscoring
+
+
+#### Scopus (optional) ####
+## Scopus enriches articles with disambiguated organization names and more complete author
+## names. Recent research suggests it has a minimal effect on accuracy. If you do not have
+## a Scopus API key, set use.scopus.articles=false and strategy.scopus.common.affiliation=false.
+
+# Master toggle for Scopus article enrichment
+use.scopus.articles=true
+
+# Enable Scopus-based non-target-author affiliation scoring
+strategy.scopus.common.affiliation=true
+
+# Scopus institution IDs for home institution
 strategy.authorAffiliationScoringStrategy.homeInstitution-scopusInstitutionIDs=60007997,105529809,108567977,60019868,60000247,60072750,60109878,60026978,60025849,105533257,105529809,100315705,120474126,100370280,115325844,60011045,107923633,112568533,117155719,60009343,60026827,60022875,118363394,109378892,60104858,118197089,126361147,120163969,112627712,126185471,114308448,106543182,126269335,105455582,101996631,100361301,122917640,108960262,60009656,126208061,109784927,123171596,126598090,106087453,109854037,123278324,125813951,101019046,126569819,127416979,117953990,126209228,112743895,112651838,107138783,124947167,106167999,118611789,126140916,123187312,124678793,112805461,126267592,126291601,127328905,102020098,117898168,112684684,116739393,112625535,121645847,126789206,128316808,123643846,123953277,125305204,114850318,123854989,126155466,126155728,126384844,123888058,126490784,127790532,120167334,127026077,125303244,108477936,126232598,128252749,127074522,112890978,60005676,115296805,115806170,119862316,128024060,119003489,116516911,128218578,113546601,113384516,101778222,105184720,60138910,125316739,126961696,120409098,100520080,122214686,115630826,108092594,105771528,118724684,109488938,106541996,101633292,116150182,122604316,123730906,106537581,113913820,113207685,107163477,60012732,126269126,126272114,127419075,127567119,127863145,128462600,122033412,108364787,124041467,105800915,106582936,113734633
 
+# Scopus institution IDs for collaborating institutions
 strategy.authorAffiliationScoringStrategy.collaboratingInstitutions-scopusInstitutionIDs=60007776,60010570,60026827,60025849,60012732,60018043,60008981,60022875,60019970,60025879,60009343,60009656,60072743,60072746,60104769,60012981,60000764,60004670,60014933,60022377,60005705,60003158,60027954,60003711,60103484,60029961,60031841,60005208,60002388,60024099,60030304,60029652,60026273,60024541,60023247,60007555,60017027,60002896,60011605,60027565,60032105,100654821,60013574,60021784,60030162
 
-## Attempt to match these groups of keywords to the affiliation of the targetAuthor in PubMed.
-strategy.authorAffiliationScoringStrategy.collaboratingInstitutions-keywords=new|york|presbyterian, rockefeller|university, HSS, hospital|special|surgery, North|Shore|hospital, Long|Island|Jewish, memorial|sloan, sloan|kettering, hamad, mount|sinai, methodist|houston, National|Institute|Mental|Health, beth israel, University|Pennsylvania|Medicine, Merck|Research, New|York|Medical|College, Medicine|Dentistry|New|Jersey, Montefiore, Lenox|Hill, Cold|Spring|Harbor, St|Luke|Roosevelt, New|York|University|Medicine, Langone, SUNY|Downstate, Albert|Einstein|Medicine, Yeshiva, UMDNJ, Icahn|Medicine, Mount|Sinai, columbia|medical, columbia|physicians
- 
-## The following non-target author scores are implemented only for Scopus affiliations rather than PubMed affiliations.
+# Non-target author affiliation scores (used only when Scopus data is available)
 strategy.authorAffiliationScoringStrategy.nonTargetAuthor-institutionalAffiliation-matchType-positiveMatch-individual-score=0.598
 strategy.authorAffiliationScoringStrategy.nonTargetAuthor-institutionalAffiliation-matchType-positiveMatch-institution-score=0.299
 strategy.authorAffiliationScoringStrategy.nonTargetAuthor-institutionalAffiliation-matchType-null-score=0
@@ -280,191 +347,22 @@ strategy.authorAffiliationScoringStrategy.nonTargetAuthor-institutionalAffiliati
 strategy.authorAffiliationScoringStrategy.nonTargetAuthor-institutionalAffiliation-maxScore=0.897
 
 
-### Relationship evidence ###
+#### Output & API ####
 
-## Goal: use institutionally tracked relationships (e.g., two people are on the same grant) 
-## to increase article scores where such individuals' names appear as co-authors on an article.
-
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#relationship-evidence
-
-strategy.knownrelationships.relationshipMatchingScore=0.52
-
-## Provide extra credit if first name is exact match.
-strategy.knownrelationships.relationshipVerboseMatchModifier=1.68
-
-## Provide extra credit if relationship is of type mentor. Individuals with mentors tend to
-## author fewer articles.
-strategy.knownrelationships.relationshipMatchModifier-Mentor=0.522
-
-## Provide extra credit if mentor is listed as a senior author, which is quite common.
-strategy.knownrelationships.relationshipMatchModifier-Mentor-SeniorAuthor=0
-
-## Provide extra credit if relationship is of type manager.
-strategy.knownrelationships.relationshipMatchModifier-Manager=1.01
-
-## Provide extra credit if relationship is of type manager and is listed a senior author.
-strategy.knownrelationships.relationshipMatchModifier-Manager-SeniorAuthor=0
-
-## Minimum score for relationship strategy when number of authors is huge and non match is high.
-strategy.knownrelationships.relationshipMinimumTotalScore=-1.592
-## Score for each non matching relationship for non target author
-strategy.knownrelationships.relationshipNonMatchScore=-0.048
- 
-
-### Grant evidence ###
-
-## Goal: see whether NIH grant IDs from identity.grants match those indexed in articles.
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#Grant-evidence
-strategy.grant.grantMatchScore=2.253
-
-### Gender evidence ###
-## For more, see: https://github.com/wcmc-its/ReCiter/issues/357
-
-strategy.genderStrategyScore.minimumScore=-1.36
-strategy.genderStrategyScore.rangeScore=1.6
-
-### Education year evidence ###
-
-## Goal: down-weight candidate articles where candidate articles are published relatively early
-## in a scholar's academic career as benchmarked against known years of degree.
-
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#education-year-evidence
-
-strategy.discrepancyDegreeYear.degreeYearDiscrepancyScore=-99|-12.6,-98|-12.5,-97|-12.4,-96|-12.3,-95|-12.2,-94|-12.1,-93|-12,-92|-11.9,-91|-11.8,-90|-11.7,-89|-11.6,-88|-11.5,-87|-11.4,-86|-11.3,-85|-11.2,-84|-11.1,-83|-11,-82|-10.9,-81|-10.8,-80|-10.7,-79|-10.6,-78|-10.5,-77|-10.4,-76|-10.3,-75|-10.2,-74|-10.1,-73|-10,-72|-9.9,-71|-9.8,-70|-9.7,-69|-9.6,-68|-9.5,-67|-9.4,-66|-9.3,-65|-9.2,-64|-9.1,-63|-9,-62|-8.9,-61|-8.8,-60|-8.7,-59|-8.6,-58|-8.5,-57|-8.4,-56|-8.3,-55|-8.2,-54|-8.1,-53|-8,-52|-7.9,-51|-7.8,-50|-7.7,-49|-7.6,-48|-7.5,-47|-7.4,-46|-7.3,-45|-7.2,-44|-7.1,-43|-7,-42|-6.9,-41|-6.8,-40|-6.7,-39|-6.6,-38|-6.5,-37|-6.4,-36|-6.3,-35|-6.2,-34|-6.1,-33|-6,-32|-5.9,-31|-5.8,-30|-5.7,-29|-5.6,-28|-5.5,-27|-5.4,-26|-5.3,-25|-5.2,-24|-5.1,-23|-5,-22|-4.9,-21|-4.8,-20|-4.7,-19|-4.6,-18|-4.5,-17|-4.4,-16|-4.3,-15|-4.2,-14|-4.1,-13|-4,-12|-3.78,-11|-3.56,-10|-3.34,-9|-3.12,-8|-2.9,-7|-2.68,-6|-2.46,-5|-2.24,-4|-2.02,-3|-1.8,-2|-1.58,-1|-1.36,0|-1.16,1|-0.96,2|-0.76,3|-0.56,4|-0.36,5|-0.175,6|0.01,7|0.195,8|0.38,9|0.55,10|0.72,11|0.89,12|0.9,13|0.9,14|0.9,15|0.9,16|0.9,17|0.9,18|0.9,19|0.9,20|0.9,21|0.9,22|0.9,23|0.9,24|0.9,25|0.9,26|0.9,27|0.9,28|0.9,29|0.9,30|0.9,31|0.9,32|0.9,33|0.9,34|0.9,35|0.9,36|0.9,37|0.9,38|0.9,39|0.9,40|0.9,41|0.9,42|0.9,43|0.9,44|0.9,45|0.9,46|0.9,47|0.9,48|0.89,49|0.88,50|0.86,51|0.85,52|0.83,53|0.81,54|0.8,55|0.77,56|0.75,57|0.73,58|0.7,59|0.68,60|0.65,61|0.62,62|0.59,63|0.56,64|0.53,65|0.49,66|0.45,67|0.42,68|0.38,69|0.34,70|0.3,71|0.25,72|0.21,73|0.16,74|0.12,75|0.07,76|0.02,77|-0.04,78|-0.09,79|-0.14,80|-0.2,81|-0.26,82|-0.31,83|-0.37,84|-0.43,85|-0.5,86|-0.56,87|-0.63,88|-0.69,89|-0.76,90|-0.83,91|-0.9,92|-0.98,93|-1.05,94|-1.12,95|-1.2,96|-1.28,97|-1.36,98|-1.44,99|-1.52,100|-1.61
-
-
-## If a scholar does not have a doctoral year degree, we look for year of bachelor degree. 
-## If a scholar has a bachelors degree of 2000, and this value is -7, this is functionally equivalent to a scholar having a 
-## doctoral degree of 2007.
-strategy.discrepancyDegreeYear.bacherlorYearWeight=-7
-
-
-### Person type evidence ###
-
-## Goal: downweight or upweight individual articles depending on person types in identity.personTypes.
-## Upweight individual articles when they come from a small corpus of candidate articles.
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#person-type-evidence
-## Update: the recent change to "education year evidence" (see above) obviates the need for person type evidence. 
-## In the interests of simplicity, these values are being set to 0. 
-
-## Upweight this person type where the person type is "academic-faculty-weillfulltime."
-strategy.personTypeScoringStrategy.personTypeScore-academic-faculty-weillfulltime=0
-
-## Downweight this person type.
-strategy.personTypeScoringStrategy.personTypeScore-student-md-new-york=0
- 
-
-### Article count evidence ###
-
-## Goal: reward each candidate article in which there are few articles retrieved and penalizes cases
-## in which a lot of articles are retrieved. This is consistent with Bayesian insights about probability.
-
-## For more, see: https://github.com/wcmc-its/ReCiter/wiki/How-ReCiter-works#article-count-evidence
-
-## If this number of candidate articles, score for this strategy would be 0.
-strategy.articleCountScoringStrategy.articleCountThresholdScore=800
-
-## Increasing this value decreases the weight of this strategy. Decreasing this value, increases the weight.
-strategy.articleCountScoringStrategy.articleCountWeight=583.9
-
-## eSearch count is now stored during retrieval (in ESearchResult.eSearchCount field).
-## ArticleSizeStrategy uses the stored count automatically — no config needed.
-
-## Median number of authors for baseline likelihood calculation
-strategy.articleCountScoringStrategy.authorCountThreshold=6
-
-## Scaling factor (gamma) for author count adjustment
-strategy.articleCountScoringStrategy.authorCountAdjustmentGamma=2.6
-
-## Coefficients for likelihood formula
-strategy.articleCountScoringStrategy.lnCoefficient=-0.2461
-strategy.articleCountScoringStrategy.constantCoefficient=1.98
-
-
-## Threshold for keyword baseline likelihood calculation
-## This is the baseline keyword count around which the weighting is calculated.
-strategy.feedback.keywordCountBaseline=1319351
- 
-
-## Logarithmic base for keyword factor calculation
-## This determines the base of the logarithmic scale applied to the keyword count.
-strategy.feedback.keywordLogBase=25
- 
-## Adjustment offset for keyword factor calculation
-## This is a constant added to the logarithmic result to shift the final factor.
-strategy.feedback.keywordOffset=0.4
-
-## Informed absence penalty: when a feedback attribute value (e.g., author name)
-## has never been seen among accepted or rejected articles, but the researcher has
-## substantial acceptance history, apply a negative penalty instead of neutral 0.0.
-## strength controls penalty magnitude per feature (0=off, 1=full); scale controls
-## how quickly penalty ramps with total accepted count.
-strategy.feedback.informedAbsence.enabled=true
-strategy.feedback.informedAbsence.scale=10.0
-## Strength per feature: based on accepted zero-rate (lower = safer to penalize)
-## targetAuthorName: 0.4% of accepted are zero — safest
-strategy.feedback.informedAbsence.targetAuthorName.strength=1.0
-## coAuthorName: 2.3%, keyword: 3.4%
-strategy.feedback.informedAbsence.coAuthorName.strength=0.9
-strategy.feedback.informedAbsence.keyword.strength=0.9
-## journal: 5.1%, journalSubField: 4.3%
-strategy.feedback.informedAbsence.journal.strength=0.7
-strategy.feedback.informedAbsence.journalSubField.strength=0.7
-## institution: 8.6%, cites: 9.2%, organization: 10.9%
-strategy.feedback.informedAbsence.institution.strength=0.5
-strategy.feedback.informedAbsence.cites.strength=0.5
-strategy.feedback.informedAbsence.bibliographiccoupling.strength=0.5
-strategy.feedback.informedAbsence.organization.strength=0.5
-## email: 16.1%, orcid: 16.4%
-strategy.feedback.informedAbsence.email.strength=0.3
-strategy.feedback.informedAbsence.orcid.strength=0.3
-
-
-#### Scoring ####
-
-## If an admin does not select any global score, we default to this score(0 to 100).
+# Default authorship likelihood score threshold (0-100) when none specified
 authorshipLikelihoodScore=70
 
-## Penalty factor (%) applied to predicted scores when no target author is identified (targetAuthorCount = 0).
-## Example: A value of 35 reduces the predicted score by 65% (authorshipLikelihoodScore * 0.35).
+# Penalty factor (%) when no target author identified (score *= this/100)
 targetAuthorMissingPenaltyPercent=35
- 
-## Use this property to set a lower limit for storing ReCiter's output in the "Analysis" DynamoDB table. 
-## (Make sure to set aws.s3.use=true, see above, if you wish to store larger objects in s3.)(0-100)
+
+# Minimum score to store in DynamoDB Analysis table (0-100)
 reciter.minimumStorageThreshold=30
 
-### Keywords ###
-## This sets the maximum number of keywords to return in the Feature Generator API.
+# Maximum keywords returned by Feature Generator API
 reciter.feature.generator.keywordCountMax=10
 
-### API Parameters Configuration ###
-## Maximum count for unique identifiers allowed for feature-generator Group API ##
-# Takes Integer the higher the value higher the response time of the api #
+# Maximum UIDs allowed in the group feature-generator endpoint
 reciter.feature.generator.group.uids.maxCount=100
 
-##Cognito Configuration
-aws.congito.userpool.region=us-east-1
-
-##Secret Manager Name
-aws.secretsmanager.consumer.secretName=prod/reciter-consumer/apikey
-
-##Consumer API Logs Bucket Name
-aws.s3.consumer.api.logs.bucketName=logsconsumerapi
-
-# Mandatory fields that should be present when inserting or updating Identity in DynamoDB
+# Mandatory identity fields for DynamoDB insert/update
 identity.dynamodb.mandatory.fields=uid,firstName,firstInitial,lastName
-
-#aws.lambda.region
-aws.lambda.region=us-east-1
-
-#aws.secretsmanager.region
-aws.secretsmanager.region=us-east-1
-
-#ReCiterScoring Secret Name
-aws.secretsmanager.reciterscoring.secretName=reciterscore
-
-#ReciterScoring service port number
-aws.reciterscoring.service.portNo=9000
-
-#ReCiterScoring Local/Dev Lambda function URL
-local.lambda.function.invocation.url=/2015-03-31/functions/function/invocations


### PR DESCRIPTION
## Summary
- **PmidProvenance table**: new `(uid, pmid)` composite key table tracking when each article was first discovered for a user and by which retrieval strategy. Uses set-difference approach for efficient writes (only genuinely new PMIDs). Auto-created on startup via DynamoDbConfig.
- **ESearchCount always-write**: below-threshold users now get `ESearchCount` records (additive — threshold-exceeding users keep raw PubMed count until Phase 2)
- **ORCID inference**: scans accepted articles using 19-step TargetAuthorSelection cascade to infer ORCID, persists to Identity for future retrieval runs
- **Build fix**: Lombok 1.18.44 + maven-compiler-plugin 3.11.0 for JDK 17.0.18 compatibility
- **Typo fixes**: `congito→cognito`, `leninent→lenient`, `bacherlorYear→bachelorYear`, `inCoefficent→lnCoefficient`
- **Dependency**: requires `reciter-article-model` 2.0.33-SNAPSHOT (PR #22 in Article Model repo)

## New files
- `PmidProvenance.java` — DynamoDB model with `@DynamoDBRangeKey`
- `PmidProvenanceService.java` — service interface (save, conditional save, query by uid, healing)
- `PmidProvenanceServiceImpl.java` — implementation using DynamoDBMapper with `attribute_not_exists` guards

## Test plan
- [x] `mvn clean package -DskipTests` builds successfully
- [ ] Deploy to dev, verify `PmidProvenance` table auto-created in DynamoDB
- [ ] Port-forward, run `feature-generator/by/uid?uid=meb7002`, verify provenance records written
- [ ] Run one full batch cycle, confirm all active users have provenance records
- [ ] Run backfill script for historical data, validate with comparison script

🤖 Generated with [Claude Code](https://claude.com/claude-code)