### PR TITLE
Add DELETE endpoints for external validation cleanup

### DIFF
--- a/src/main/java/reciter/controller/IdentityController.java
+++ b/src/main/java/reciter/controller/IdentityController.java
@@ -28,6 +28,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StopWatch;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -203,6 +204,34 @@ public class IdentityController {
         return new ResponseEntity<>(identities, HttpStatus.OK);
     }
     
+    @ApiOperation(value = "Delete an identity by uid", notes = "This api deletes a single identity from the Identity table by uid.")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Identity deletion successful"),
+            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
+            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    })
+    @RequestMapping(value = "/reciter/identity/{uid}", method = RequestMethod.DELETE, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity deleteIdentity(@PathVariable String uid) {
+        StopWatch stopWatch = new StopWatch("Delete identity by uid");
+        stopWatch.start("Delete identity by uid");
+        Identity identity = identityService.findByUid(uid);
+        if (identity == null) {
+            stopWatch.stop();
+            log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body("The uid '" + uid + "' was not found in the Identity table");
+        }
+        identityService.delete(uid);
+        stopWatch.stop();
+        log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+        return ResponseEntity.ok().build();
+    }
+
     public String[] getMandatoryFields() {
         return mandatoryFields.split(",");
     }

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -227,6 +227,108 @@ public class ReCiterController {
         return ResponseEntity.ok(goldStandard);
     }
 
+    @ApiOperation(value = "Delete a gold standard record by uid", notes = "This api deletes a gold standard record from the GoldStandard table by uid.")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "GoldStandard deletion successful"),
+            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
+            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    })
+    @RequestMapping(value = "/reciter/goldstandard/{uid}", method = RequestMethod.DELETE, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity deleteGoldStandard(@PathVariable String uid) {
+        StopWatch stopWatch = new StopWatch("Delete gold standard by uid");
+        stopWatch.start("Delete gold standard by uid");
+        dynamoDbGoldStandardService.delete(uid);
+        stopWatch.stop();
+        log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation(value = "Delete an analysis output by uid", notes = "This api deletes an analysis output record from the AnalysisOutput table by uid.")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "AnalysisOutput deletion successful"),
+            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
+            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    })
+    @RequestMapping(value = "/reciter/analysis/{uid}", method = RequestMethod.DELETE, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity deleteAnalysis(@PathVariable String uid) {
+        StopWatch stopWatch = new StopWatch("Delete analysis by uid");
+        stopWatch.start("Delete analysis by uid");
+        analysisService.delete(uid);
+        stopWatch.stop();
+        log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation(value = "Delete an ESearchResult by uid", notes = "This api deletes an ESearchResult record by uid.")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "ESearchResult deletion successful"),
+            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
+            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    })
+    @RequestMapping(value = "/reciter/esearchresult/{uid}", method = RequestMethod.DELETE, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity deleteESearchResult(@PathVariable String uid) {
+        StopWatch stopWatch = new StopWatch("Delete ESearchResult by uid");
+        stopWatch.start("Delete ESearchResult by uid");
+        eSearchResultService.delete(uid);
+        stopWatch.stop();
+        log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+        return ResponseEntity.ok().build();
+    }
+
+    @ApiOperation(value = "Bulk cleanup: delete records from all UID-keyed tables", notes = "Deletes Identity, GoldStandard, AnalysisOutput, and ESearchResult records for a list of UIDs. Intended for external validation cleanup.")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Bulk cleanup successful"),
+            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
+            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden")
+    })
+    @RequestMapping(value = "/reciter/cleanup/by/uids", method = RequestMethod.POST, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity cleanupByUids(@RequestBody List<String> uids) {
+        StopWatch stopWatch = new StopWatch("Bulk cleanup by uids");
+        stopWatch.start("Bulk cleanup by uids");
+        Map<String, Integer> results = new HashMap<>();
+
+        int analysisCount = 0;
+        int esearchCount = 0;
+        int goldStandardCount = 0;
+        int identityCount = 0;
+
+        for (String uid : uids) {
+            try { analysisService.delete(uid); analysisCount++; } catch (Exception e) { log.warn("Failed to delete analysis for uid={}: {}", uid, e.getMessage()); }
+            try { eSearchResultService.delete(uid); esearchCount++; } catch (Exception e) { log.warn("Failed to delete esearchresult for uid={}: {}", uid, e.getMessage()); }
+            try { dynamoDbGoldStandardService.delete(uid); goldStandardCount++; } catch (Exception e) { log.warn("Failed to delete goldstandard for uid={}: {}", uid, e.getMessage()); }
+            try { identityService.delete(uid); identityCount++; } catch (Exception e) { log.warn("Failed to delete identity for uid={}: {}", uid, e.getMessage()); }
+        }
+
+        results.put("analysisOutput", analysisCount);
+        results.put("eSearchResult", esearchCount);
+        results.put("goldStandard", goldStandardCount);
+        results.put("identity", identityCount);
+        results.put("totalUids", uids.size());
+
+        stopWatch.stop();
+        log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+        return new ResponseEntity<>(results, HttpStatus.OK);
+    }
+
     @ApiOperation(value = "Retrieve Articles for all UID in Identity Table", response = ResponseEntity.class, notes = "This API retrieves candidate articles for all uid in Identity Table from pubmed and its complementing articles from scopus")
     @ApiImplicitParams({
     	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)

--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -320,6 +320,11 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 		return goldStanards;
 	}
 
+	@Override
+	public void delete(String uid) {
+		dynamoDbGoldStandardRepository.deleteById(uid);
+	}
+
 	/**
 	 * Build audit log entries by diffing incoming PMIDs against existing.
 	 * Only creates entries for genuinely new acceptances/rejections.

--- a/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
@@ -10,4 +10,5 @@ public interface IDynamoDbGoldStandardService {
     void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource);
     GoldStandard findByUid(String uid);
     List<GoldStandard> findByUids(List<String> uid);
+    void delete(String uid);
 }


### PR DESCRIPTION
## Summary

- Add DELETE endpoints for Identity, GoldStandard, AnalysisOutput, and ESearchResult (all UID-keyed tables)
- Add bulk cleanup endpoint (`POST /reciter/cleanup/by/uids`) that deletes across all 4 tables in one call
- Add `delete(uid)` method to GoldStandard service (Identity, Analysis, ESearchResult already had it)

These endpoints enable the external validation Python tooling to clean up after a run without needing direct DynamoDB/boto3 access — making the workflow portable to any machine that can reach the ReCiter API.

## Endpoints Added

| Method | Path | Purpose |
|--------|------|---------|
| DELETE | `/reciter/identity/{uid}` | Delete one identity record |
| DELETE | `/reciter/goldstandard/{uid}` | Delete one gold standard record |
| DELETE | `/reciter/analysis/{uid}` | Delete one analysis output record |
| DELETE | `/reciter/esearchresult/{uid}` | Delete one ESearchResult record |
| POST | `/reciter/cleanup/by/uids` | Bulk delete from all 4 tables (JSON array of UIDs) |

All endpoints require the `api-key` header (admin-only).

## Test plan

- [ ] `mvn compile -DskipTests` passes (verified locally)
- [ ] Deploy to dev, create a test identity, then DELETE it — confirm 200 and record removed
- [ ] Test bulk cleanup with 2-3 prefixed UIDs — confirm all 4 tables cleaned
- [ ] Verify existing endpoints still work (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)