### PR TITLE
Add pmc-release date extraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
 	    <dependency>
 	    	<groupId>edu.cornell.weill.reciter</groupId>
 	    	<artifactId>reciter-article-model</artifactId>
-	    	<version>2.0.35</version>
+	    	<version>2.0.36</version>
 	    </dependency>
 	    <dependency>
 	    	<groupId>edu.cornell.weill.reciter</groupId>

--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -351,8 +351,39 @@ public class ArticleTranslator {
         		reCiterArticle.setDatePublicationAddedToEntrez(df.format(date));
         	}
         }
-        		
-        
+
+        //Populate datePublicationAddedToPMC if it exists in pubmed
+        if(pubmedArticle.getPubmeddata() != null
+        		&&
+        		pubmedArticle.getPubmeddata().getHistory() != null
+        		&&
+        		pubmedArticle.getPubmeddata().getHistory().getPubmedPubDate() != null
+        		&& pubmedArticle.getPubmeddata().getHistory().getPubmedPubDate().size() > 0) {
+        	PubMedPubDate pubmedPubDatePmcRelease = pubmedArticle.getPubmeddata().getHistory().getPubmedPubDate().
+        			stream().filter(pubmedPubDate -> pubmedPubDate.getPubStatus().equalsIgnoreCase("pmc-release")).
+        			findAny().orElse(null);
+        	if(pubmedPubDatePmcRelease != null) {
+        		String pmcDateMonth = null;
+            	String pmcDateDay = null;
+            	if(pubmedPubDatePmcRelease.getPubMedPubDate().getMonth() == null) {
+            		pmcDateMonth = "01";
+            	} else {
+            		pmcDateMonth = pubmedPubDatePmcRelease.getPubMedPubDate().getMonth();
+            	}
+
+            	if(pubmedPubDatePmcRelease.getPubMedPubDate().getDay() == null) {
+            		pmcDateDay = "01";
+            	} else {
+            		pmcDateDay = pubmedPubDatePmcRelease.getPubMedPubDate().getDay();
+            	}
+        		LocalDate localDate = new LocalDate(Integer.parseInt(pubmedPubDatePmcRelease.getPubMedPubDate().getYear()),
+                        Integer.parseInt(pmcDateMonth),
+                        Integer.parseInt(pmcDateDay));
+                Date date = localDate.toDate();
+                DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        		reCiterArticle.setDatePublicationAddedToPMC(df.format(date));
+        	}
+        }
 
         // Update PubMed's authors' first name from Scopus Article. Logic is as follows:
         // 1. First compare last name if match:

--- a/src/main/java/reciter/engine/ReCiterFeatureGenerator.java
+++ b/src/main/java/reciter/engine/ReCiterFeatureGenerator.java
@@ -195,7 +195,12 @@ public class ReCiterFeatureGenerator {
             if(reCiterArticle.getDatePublicationAddedToEntrez() != null) {
             	reCiterArticleFeature.setDatePublicationAddedToEntrez(reCiterArticle.getDatePublicationAddedToEntrez());
             }
-            
+
+            //datePublicationAddedToPMC
+            if(reCiterArticle.getDatePublicationAddedToPMC() != null) {
+            	reCiterArticleFeature.setDatePublicationAddedToPMC(reCiterArticle.getDatePublicationAddedToPMC());
+            }
+
             //Publication type
             ReCiterArticlePublicationType reCiterPublicationType = ReCiterArticlePublicationType.builder().build();
             


### PR DESCRIPTION
## Summary
- Extract `pmc-release` date from PubMed History and populate `datePublicationAddedToPMC` field
- Add extraction logic in `ArticleTranslator` (mirrors existing `datePublicationAddedToEntrez` pattern)
- Wire through `ReCiterFeatureGenerator` so it appears in the API output JSON
- Update `reciter-article-model` to 2.0.36

## Context
PubMed XML includes `<PubMedPubDate PubStatus="pmc-release">` for articles in PubMed Central. The PubMed Retrieval Tool already captures this in the History list. This PR promotes it to a named field so ReciterDB can surface it as a column.

## Dependencies
- Requires wcmc-its/ReCiter-Article-Model#25 (adds `datePublicationAddedToPMC` field, version 2.0.36)

## Test plan
- [ ] Build passes (`mvn clean compile`)
- [ ] Run ReCiter for a person with known PMC articles (e.g., PMID 28356292 has `pmc-release: 2018-07-01`)
- [ ] Verify `datePublicationAddedToPMC` appears in the `/reciter/article-features` API response
- [ ] Confirm field is null/absent for articles without PMC entries