### PR TITLE
fix(retrieval): chunked GoldStandard queries + threshold raise + dedup wiring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -1093,6 +1093,8 @@ public class ReCiterController {
         try {
         	eSearchResults = eSearchResultService.findByUid(uid);
             if (eSearchResults == null) {
+                log.warn("No ESearchResult for uid={}; upgrading requested flag={} to ALL_PUBLICATIONS",
+                         uid, retrievalRefreshFlag);
                 retrieveArticlesByUid(uid, RetrievalRefreshFlag.ALL_PUBLICATIONS);
                 eSearchResults = eSearchResultService.findByUid(uid);
             } else if(eSearchResults != null && (retrievalRefreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS || retrievalRefreshFlag == RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)) {

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -53,6 +53,7 @@ import reciter.utils.AuthorNameSanitizationUtils;
 import reciter.utils.AuthorNameUtils;
 import reciter.utils.ThreadDelay;
 import reciter.xml.retriever.pubmed.AbstractRetrievalStrategy.RetrievalResult;
+import reciter.xml.retriever.pubmed.PubMedQueryType;
 
 @Component("aliasReCiterRetrievalEngine")
 public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine {
@@ -166,52 +167,17 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			queryType = QueryType.STRICT_COMPOUND_NAME_LOOKUP;
 		}
 
-		//Retreive by GoldStandard
-		Map<Long, PubMedArticle> pubMedArticles = null;
+		// Initialize as an empty map up front so all strategies use putAll uniformly.
+		// (Phase 36 FIX-05) GoldStandard retrieval now runs LAST after Email/FNI/Aff/Dept/Grant/etc.
+		// have populated uniquePmids, so the GS dedup filter has full coverage. ORCID inference
+		// and the ORCID retrieval strategy also move to after GS-last so they still see GS-retrieved
+		// articles in pubMedArticles when inferOrcidFromAcceptedArticles runs.
+		Map<Long, PubMedArticle> pubMedArticles = new HashMap<>();
 		GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(identity.getUid().trim());
-		//if(goldStandard != null && goldStandard.getKnownPmids() != null && !goldStandard.getKnownPmids().isEmpty()) {
-			RetrievalResult goldStandardRetrievalResult = goldStandardRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
-			pubMedArticles = goldStandardRetrievalResult.getPubMedArticles();
-			savePubMedArticles(pubMedArticles.values(), uid, goldStandardRetrievalStrategy.getRetrievalStrategyName(), goldStandardRetrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
-			uniquePmids.addAll(pubMedArticles.keySet());
-			trackNewPmids(pubMedArticles, goldStandardRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
-		//}
-
-		// Retrieve by ORCID (asserted from Identity, or inferred from accepted articles).
-		String orcidForRetrieval = null;
-		if (identity.getOrcid() != null && !identity.getOrcid().isEmpty()
-				&& !"NOT SET".equalsIgnoreCase(identity.getOrcid().trim())) {
-			orcidForRetrieval = identity.getOrcid().trim();
-			slf4jLogger.info("Using asserted ORCID [{}] for uid=[{}]", orcidForRetrieval, uid);
-		}
-		if (orcidForRetrieval == null) {
-			orcidForRetrieval = inferOrcidFromAcceptedArticles(pubMedArticles, goldStandard, identity);
-			if (orcidForRetrieval != null) {
-				slf4jLogger.info("Inferred ORCID [{}] from accepted articles for uid=[{}]",
-						orcidForRetrieval, uid);
-				// Set in-memory so OrcidRetrievalStrategy.constructOrcidQuery() can read it.
-				// Do NOT persist to DynamoDB — Identity.orcid is for human-asserted ORCIDs only.
-				identity.setOrcid(orcidForRetrieval);
-				slf4jLogger.info("Using inferred ORCID [{}] (in-memory only) for retrieval, uid=[{}]",
-						orcidForRetrieval, uid);
-			}
-		}
-		if (orcidForRetrieval != null) {
-			// Strategy reads identity.getOrcid() directly (thread-safe).
-			RetrievalResult orcidResult = orcidRetrievalStrategy.retrievePubMedArticles(
-					identity, identityNames, useStrictQueryOnly);
-			pubMedArticles.putAll(orcidResult.getPubMedArticles());
-			savePubMedArticles(orcidResult.getPubMedArticles().values(), uid,
-					orcidRetrievalStrategy.getRetrievalStrategyName(),
-					orcidResult.getPubMedQueryResults(), queryType, refreshFlag);
-			uniquePmids.addAll(orcidResult.getPubMedArticles().keySet());
-			nonGsStrategyPmids.addAll(orcidResult.getPubMedArticles().keySet());
-			trackNewPmids(orcidResult.getPubMedArticles(), orcidRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
-		}
 
 		// Retrieve by email.
 		RetrievalResult retrievalResult = emailRetrievalStrategy.retrievePubMedArticles(identity, identityNames, useStrictQueryOnly);
-		pubMedArticles = retrievalResult.getPubMedArticles();
+		pubMedArticles.putAll(retrievalResult.getPubMedArticles());
 		slf4jLogger.info("pubMedArticles in retrieveData section without date range****"+pubMedArticles.size());
 		/*if (pubMedArticles.size() > 0) {
 			Map<Long, AuthorName> aliasSet = AuthorNameUtils.calculatePotentialAlias(identity, pubMedArticles.values());
@@ -355,6 +321,60 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 
 		}
 
+		// Phase 36 FIX-05: GoldStandard retrieval runs LAST so it can dedup against the
+		// uniquePmids accumulated by every prior name/email/affiliation/grant strategy.
+		// The chunked GS query builder from Plan 36-01 batches PMIDs in groups of 100;
+		// the dedup filter strips any knownPmid already retrieved by another strategy.
+		// Net effect: zero redundant eutils traffic for PMIDs already in hand.
+		List<PubMedQueryType> gsQueries = goldStandardRetrievalStrategy.buildQueryGoldStandard(identity, uniquePmids);
+		RetrievalResult goldStandardRetrievalResult =
+				goldStandardRetrievalStrategy.retrievePubMedArticlesUsingQueries(identity, gsQueries, useStrictQueryOnly);
+		pubMedArticles.putAll(goldStandardRetrievalResult.getPubMedArticles());
+		savePubMedArticles(goldStandardRetrievalResult.getPubMedArticles().values(), uid,
+				goldStandardRetrievalStrategy.getRetrievalStrategyName(),
+				goldStandardRetrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
+		uniquePmids.addAll(goldStandardRetrievalResult.getPubMedArticles().keySet());
+		trackNewPmids(goldStandardRetrievalResult.getPubMedArticles(),
+				goldStandardRetrievalStrategy.getRetrievalStrategyName(),
+				uid, existingPmids, newPmidStrategy, backfillPmids);
+
+		// Retrieve by ORCID (asserted from Identity, or inferred from accepted articles).
+		// Inference walks GoldStandard.knownPmids against pubMedArticles, so it must run
+		// AFTER GS retrieval has populated those PMIDs. The ORCID strategy then runs
+		// against either the asserted or inferred ORCID and adds any new articles.
+		String orcidForRetrieval = null;
+		if (identity.getOrcid() != null && !identity.getOrcid().isEmpty()
+				&& !"NOT SET".equalsIgnoreCase(identity.getOrcid().trim())) {
+			orcidForRetrieval = identity.getOrcid().trim();
+			slf4jLogger.info("Using asserted ORCID [{}] for uid=[{}]", orcidForRetrieval, uid);
+		}
+		if (orcidForRetrieval == null) {
+			orcidForRetrieval = inferOrcidFromAcceptedArticles(pubMedArticles, goldStandard, identity);
+			if (orcidForRetrieval != null) {
+				slf4jLogger.info("Inferred ORCID [{}] from accepted articles for uid=[{}]",
+						orcidForRetrieval, uid);
+				// Set in-memory so OrcidRetrievalStrategy.constructOrcidQuery() can read it.
+				// Do NOT persist to DynamoDB — Identity.orcid is for human-asserted ORCIDs only.
+				identity.setOrcid(orcidForRetrieval);
+				slf4jLogger.info("Using inferred ORCID [{}] (in-memory only) for retrieval, uid=[{}]",
+						orcidForRetrieval, uid);
+			}
+		}
+		if (orcidForRetrieval != null) {
+			// Strategy reads identity.getOrcid() directly (thread-safe).
+			RetrievalResult orcidResult = orcidRetrievalStrategy.retrievePubMedArticles(
+					identity, identityNames, useStrictQueryOnly);
+			pubMedArticles.putAll(orcidResult.getPubMedArticles());
+			savePubMedArticles(orcidResult.getPubMedArticles().values(), uid,
+					orcidRetrievalStrategy.getRetrievalStrategyName(),
+					orcidResult.getPubMedQueryResults(), queryType, refreshFlag);
+			uniquePmids.addAll(orcidResult.getPubMedArticles().keySet());
+			nonGsStrategyPmids.addAll(orcidResult.getPubMedArticles().keySet());
+			trackNewPmids(orcidResult.getPubMedArticles(),
+					orcidRetrievalStrategy.getRetrievalStrategyName(),
+					uid, existingPmids, newPmidStrategy, backfillPmids);
+		}
+
 		// Phase 1: Save ESearchCount for users who didn't already get a threshold-path
 		// count (line 275). For threshold-exceeding users, the raw PubMed count is
 		// the correct value for ArticleSizeStrategy's log(count) scoring formula.
@@ -478,52 +498,15 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			queryType = QueryType.STRICT_COMPOUND_NAME_LOOKUP;
 		}
 
-		Map<Long, PubMedArticle> pubMedArticles = null;
-		//Retreive by GoldStandard
+		// (Phase 36 FIX-05) GoldStandard retrieval moved to AFTER the other strategies so it
+		// can dedup against uniquePmids. ORCID inference + ORCID-strategy moved with it so
+		// inference still sees GS-retrieved articles in pubMedArticles when it runs.
+		Map<Long, PubMedArticle> pubMedArticles = new HashMap<>();
 		GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(identity.getUid().trim());
-		//if(goldStandard != null && goldStandard.getKnownPmids() != null && !goldStandard.getKnownPmids().isEmpty()) {
-			RetrievalResult goldStandardRetrievalResult = goldStandardRetrievalStrategy.retrievePubMedArticles(identity, identityNames, startDate, endDate, useStrictQueryOnly);
-			pubMedArticles = goldStandardRetrievalResult.getPubMedArticles();
-			savePubMedArticles(pubMedArticles.values(), uid, goldStandardRetrievalStrategy.getRetrievalStrategyName(), goldStandardRetrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
-			uniquePmids.addAll(pubMedArticles.keySet());
-			trackNewPmids(pubMedArticles, goldStandardRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
-		//}
-
-		// Retrieve by ORCID (asserted from Identity, or inferred from accepted articles).
-		String orcidForRetrieval = null;
-		if (identity.getOrcid() != null && !identity.getOrcid().isEmpty()
-				&& !"NOT SET".equalsIgnoreCase(identity.getOrcid().trim())) {
-			orcidForRetrieval = identity.getOrcid().trim();
-			slf4jLogger.info("Using asserted ORCID [{}] for uid=[{}]", orcidForRetrieval, uid);
-		}
-		if (orcidForRetrieval == null) {
-			orcidForRetrieval = inferOrcidFromAcceptedArticles(pubMedArticles, goldStandard, identity);
-			if (orcidForRetrieval != null) {
-				slf4jLogger.info("Inferred ORCID [{}] from accepted articles for uid=[{}]",
-						orcidForRetrieval, uid);
-				// Set in-memory so OrcidRetrievalStrategy.constructOrcidQuery() can read it.
-				// Do NOT persist to DynamoDB — Identity.orcid is for human-asserted ORCIDs only.
-				identity.setOrcid(orcidForRetrieval);
-				slf4jLogger.info("Using inferred ORCID [{}] (in-memory only) for retrieval, uid=[{}]",
-						orcidForRetrieval, uid);
-			}
-		}
-		if (orcidForRetrieval != null) {
-			// Strategy reads identity.getOrcid() directly (thread-safe).
-			RetrievalResult orcidResult = orcidRetrievalStrategy.retrievePubMedArticles(
-					identity, identityNames, startDate, endDate, useStrictQueryOnly);
-			pubMedArticles.putAll(orcidResult.getPubMedArticles());
-			savePubMedArticles(orcidResult.getPubMedArticles().values(), uid,
-					orcidRetrievalStrategy.getRetrievalStrategyName(),
-					orcidResult.getPubMedQueryResults(), queryType, refreshFlag);
-			uniquePmids.addAll(orcidResult.getPubMedArticles().keySet());
-			trackNewPmids(orcidResult.getPubMedArticles(), orcidRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
-		}
 
 		// Retrieve by email.
 		RetrievalResult retrievalResult = emailRetrievalStrategy.retrievePubMedArticles(identity, identityNames, startDate, endDate, useStrictQueryOnly);
-		//Map<Long, PubMedArticle> emailPubMedArticles = retrievalResult.getPubMedArticles();
-		pubMedArticles = retrievalResult.getPubMedArticles();
+		pubMedArticles.putAll(retrievalResult.getPubMedArticles());
 		slf4jLogger.info("pubMedArticles in retrieveData section with date range****"+pubMedArticles.size());
 		/*if (pubMedArticles.size() > 0) {
 			Map<Long, AuthorName> aliasSet = AuthorNameUtils.calculatePotentialAlias(identity, pubMedArticles.values());
@@ -654,6 +637,53 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			savePubMedArticles(r8.getPubMedArticles().values(), uid, secondIntialRetrievalStrategy.getRetrievalStrategyName(), r8.getPubMedQueryResults(), queryType, refreshFlag);
 			uniquePmids.addAll(r8.getPubMedArticles().keySet());
 			trackNewPmids(r8.getPubMedArticles(), secondIntialRetrievalStrategy.getRetrievalStrategyName(), uid, existingPmids, newPmidStrategy, backfillPmids);
+		}
+
+		// Phase 36 FIX-05: GoldStandard runs LAST with dedup against uniquePmids.
+		// Date-range variant uses the dateRange-aware buildQuery overload internally —
+		// here we keep the no-args buildQueryGoldStandard helper because date-range and
+		// PMID-list semantics don't compose: a PMID is a unique identifier, not a temporal
+		// query, so we want all knownPmids retrievable regardless of date window.
+		List<PubMedQueryType> gsQueries = goldStandardRetrievalStrategy.buildQueryGoldStandard(identity, uniquePmids);
+		RetrievalResult goldStandardRetrievalResult =
+				goldStandardRetrievalStrategy.retrievePubMedArticlesUsingQueries(identity, gsQueries, useStrictQueryOnly);
+		pubMedArticles.putAll(goldStandardRetrievalResult.getPubMedArticles());
+		savePubMedArticles(goldStandardRetrievalResult.getPubMedArticles().values(), uid,
+				goldStandardRetrievalStrategy.getRetrievalStrategyName(),
+				goldStandardRetrievalResult.getPubMedQueryResults(), queryType, refreshFlag);
+		uniquePmids.addAll(goldStandardRetrievalResult.getPubMedArticles().keySet());
+		trackNewPmids(goldStandardRetrievalResult.getPubMedArticles(),
+				goldStandardRetrievalStrategy.getRetrievalStrategyName(),
+				uid, existingPmids, newPmidStrategy, backfillPmids);
+
+		// Retrieve by ORCID — inference now sees GS articles in pubMedArticles (FIX-05).
+		String orcidForRetrieval = null;
+		if (identity.getOrcid() != null && !identity.getOrcid().isEmpty()
+				&& !"NOT SET".equalsIgnoreCase(identity.getOrcid().trim())) {
+			orcidForRetrieval = identity.getOrcid().trim();
+			slf4jLogger.info("Using asserted ORCID [{}] for uid=[{}]", orcidForRetrieval, uid);
+		}
+		if (orcidForRetrieval == null) {
+			orcidForRetrieval = inferOrcidFromAcceptedArticles(pubMedArticles, goldStandard, identity);
+			if (orcidForRetrieval != null) {
+				slf4jLogger.info("Inferred ORCID [{}] from accepted articles for uid=[{}]",
+						orcidForRetrieval, uid);
+				identity.setOrcid(orcidForRetrieval);
+				slf4jLogger.info("Using inferred ORCID [{}] (in-memory only) for retrieval, uid=[{}]",
+						orcidForRetrieval, uid);
+			}
+		}
+		if (orcidForRetrieval != null) {
+			RetrievalResult orcidResult = orcidRetrievalStrategy.retrievePubMedArticles(
+					identity, identityNames, startDate, endDate, useStrictQueryOnly);
+			pubMedArticles.putAll(orcidResult.getPubMedArticles());
+			savePubMedArticles(orcidResult.getPubMedArticles().values(), uid,
+					orcidRetrievalStrategy.getRetrievalStrategyName(),
+					orcidResult.getPubMedQueryResults(), queryType, refreshFlag);
+			uniquePmids.addAll(orcidResult.getPubMedArticles().keySet());
+			trackNewPmids(orcidResult.getPubMedArticles(),
+					orcidRetrievalStrategy.getRetrievalStrategyName(),
+					uid, existingPmids, newPmidStrategy, backfillPmids);
 		}
 
 		// Phase 1: Write provenance records for newly discovered PMIDs (no ESearchCount always-save for date-range runs)

--- a/src/main/java/reciter/xml/retriever/pubmed/AbstractRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/AbstractRetrievalStrategy.java
@@ -125,7 +125,7 @@ public abstract class AbstractRetrievalStrategy implements RetrievalStrategy {
 		return retrievePubMedArticles(identity, pubMedQueries);
 	}*/
 
-	private RetrievalResult retrievePubMedArticles(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames, List<PubMedQueryType> pubMedQueries, boolean useStrictQueryOnly) throws IOException {
+	protected RetrievalResult retrievePubMedArticles(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames, List<PubMedQueryType> pubMedQueries, boolean useStrictQueryOnly) throws IOException {
 
 		Map<Long, PubMedArticle> pubMedArticles = new HashMap<Long, PubMedArticle>();
 

--- a/src/main/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategy.java
@@ -74,7 +74,14 @@ public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
 
 	public List<PubMedQueryType> buildQueryGoldStandard(Identity identity, Set<Long> uniquePmids) {
 		String uid = requireValidUid(identity);
-		List<Long> pmids = loadGoldStandardPmids(uid, false);
+		// Include BOTH knownPmids and rejectedPmids — the engine's analysis metric
+		// `inGoldStandardButNotRetrieved` counts any GS PMID (known OR rejected) that
+		// wasn't retrieved, so excluding rejected from the dedup variant causes a
+		// regression in the metric for users with non-trivial rejectedPmids
+		// counts (e.g., rsb2005: 156 rejected → +132 missing in dev smoke retest).
+		// Dedup is about avoiding redundant eutils traffic for PMIDs already
+		// retrieved by other strategies, not about which GS subset to query.
+		List<Long> pmids = loadGoldStandardPmids(uid, true);
 		if (uniquePmids != null && !uniquePmids.isEmpty()) {
 			pmids.removeAll(uniquePmids);
 		}

--- a/src/main/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategy.java
@@ -20,6 +20,7 @@ package reciter.xml.retriever.pubmed;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -71,13 +72,29 @@ public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
 		return buildChunkedQueries(pmids, startDate, endDate, true);
 	}
 
-	protected List<PubMedQueryType> buildQueryGoldStandard(Identity identity, Set<Long> uniquePmids) {
+	public List<PubMedQueryType> buildQueryGoldStandard(Identity identity, Set<Long> uniquePmids) {
 		String uid = requireValidUid(identity);
 		List<Long> pmids = loadGoldStandardPmids(uid, false);
 		if (uniquePmids != null && !uniquePmids.isEmpty()) {
 			pmids.removeAll(uniquePmids);
 		}
 		return buildChunkedQueries(pmids, null, null, false);
+	}
+
+	/**
+	 * Retrieve PubMed articles for an explicit list of pre-built queries.
+	 * Used by {@code AliasReCiterRetrievalEngine} after it builds chunked GoldStandard
+	 * queries via {@link #buildQueryGoldStandard(Identity, Set)} so the engine can
+	 * dedup against {@code uniquePmids} accumulated by prior strategies (FIX-05).
+	 *
+	 * <p>Delegates to the parent's protected {@code retrievePubMedArticles} helper —
+	 * same threshold gating, lenient/strict logic, and PubMed eutils calls as the
+	 * standard retrieval path. Identity names map is empty because GS queries are
+	 * PMID-list based and do not consult name evidence.
+	 */
+	public RetrievalResult retrievePubMedArticlesUsingQueries(Identity identity,
+			List<PubMedQueryType> pubMedQueries, boolean useStrictQueryOnly) throws IOException {
+		return retrievePubMedArticles(identity, Collections.emptyMap(), pubMedQueries, useStrictQueryOnly);
 	}
 
 	/**

--- a/src/main/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategy.java
@@ -19,10 +19,11 @@
 package reciter.xml.retriever.pubmed;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.time.LocalDate;
-import java.util.*;
-import java.util.Map.Entry;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -30,19 +31,23 @@ import org.springframework.stereotype.Component;
 import reciter.database.dynamodb.model.GoldStandard;
 import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
-import reciter.model.pubmed.PubMedArticle;
-import reciter.pubmed.retriever.PubMedArticleRetriever;
 import reciter.pubmed.retriever.PubMedQuery;
 import reciter.service.dynamo.IDynamoDbGoldStandardService;
 import reciter.xml.retriever.engine.AliasReCiterRetrievalEngine.IdentityNameType;
-import reciter.xml.retriever.pubmed.AbstractRetrievalStrategy.RetrievalResult;
 import reciter.xml.retriever.pubmed.PubMedQueryType.PubMedQueryBuilder;
 
 @Component("goldStandardRetrievalStrategy")
 public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
-	
+
 	private static final String retrievalStrategyName = "GoldStandardRetrievalStrategy";
-	
+
+	/**
+	 * Maximum number of PMIDs per chunked PubMed query. Sized to keep the encoded
+	 * query string well under PubMed's ~2000-character URL ceiling. PMIDs are 8-digit
+	 * comma-separated tokens, so 100 PMIDs ~= 900 chars of payload.
+	 */
+	static final int PMID_BATCH_SIZE = 100;
+
 	@Autowired
 	private IDynamoDbGoldStandardService dynamoDbGoldStandardService;
 
@@ -50,95 +55,107 @@ public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
 	public String getRetrievalStrategyName() {
 		return retrievalStrategyName;
 	}
-	
-	protected List<PubMedQueryType> buildQueryGoldStandard(Identity identity, Set<Long> unqiuePmids) {
-		List<PubMedQueryType> pubMedQueries = new ArrayList<PubMedQueryType>();
-		List<Long> goldStandardPmids = dynamoDbGoldStandardService.findByUid(identity.getUid().trim()).getKnownPmids();
-		PubMedQueryBuilder pubMedQueryBuilder = new PubMedQueryBuilder();
-		goldStandardPmids.removeAll(unqiuePmids);
-		PubMedQuery goldStandardQuery = pubMedQueryBuilder.buildPmids(goldStandardPmids);
-
-		PubMedQueryType pubMedQueryType = new PubMedQueryType();
-		pubMedQueryType.setLenientQuery(new PubMedQueryResult(goldStandardQuery));
-		pubMedQueryType.setStrictQuery(new PubMedQueryResult(goldStandardQuery));
-		pubMedQueries.add(pubMedQueryType);
-
-		return pubMedQueries;
-	}
-	
 
 	@Override
 	protected List<PubMedQueryType> buildQuery(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames) {
-		List<PubMedQueryType> pubMedQueries = new ArrayList<PubMedQueryType>();
-
-		PubMedQueryBuilder pubMedQueryBuilder = new PubMedQueryBuilder();
-		List<Long> goldStandardPmids = new ArrayList<Long>();
-		GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(identity.getUid().trim());
-		if(goldStandard != null 
-				&& 
-				goldStandard.getKnownPmids() != null 
-				&& 
-				goldStandard.getKnownPmids().size() > 0) {
-			goldStandardPmids = goldStandard.getKnownPmids();
-		}
-		
-		if(goldStandard != null 
-				&&
-				goldStandard.getRejectedPmids() != null
-				&&
-				goldStandard.getRejectedPmids().size() > 0) {
-			goldStandardPmids.addAll(goldStandard.getRejectedPmids());
-		}
-		
-		PubMedQuery goldStandardQuery = pubMedQueryBuilder.buildPmids(goldStandardPmids);
-
-		PubMedQueryType pubMedQueryType = new PubMedQueryType();
-		pubMedQueryType.setLenientQuery(new PubMedQueryResult(goldStandardQuery));
-		pubMedQueryType.setStrictQuery(new PubMedQueryResult(goldStandardQuery));
-		pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(goldStandardQuery));
-		pubMedQueryType.setStrictCountQuery(new PubMedQueryResult(goldStandardQuery));
-		pubMedQueries.add(pubMedQueryType);
-
-		return pubMedQueries;
+		String uid = requireValidUid(identity);
+		List<Long> pmids = loadGoldStandardPmids(uid, true);
+		return buildChunkedQueries(pmids, null, null, true);
 	}
 
 	@Override
-	protected List<PubMedQueryType> buildQuery(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames, Date startDate, Date endDate) {
-		List<PubMedQueryType> pubMedQueries = new ArrayList<PubMedQueryType>();
-		
-		List<Long> goldStandardPmids = new ArrayList<Long>();
-		GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(identity.getUid().trim());
-		if(goldStandard != null 
-				&& 
-				goldStandard.getKnownPmids() != null 
-				&& 
-				goldStandard.getKnownPmids().size() > 0) {
-			goldStandardPmids = goldStandard.getKnownPmids();
+	protected List<PubMedQueryType> buildQuery(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames,
+			Date startDate, Date endDate) {
+		String uid = requireValidUid(identity);
+		List<Long> pmids = loadGoldStandardPmids(uid, true);
+		return buildChunkedQueries(pmids, startDate, endDate, true);
+	}
+
+	protected List<PubMedQueryType> buildQueryGoldStandard(Identity identity, Set<Long> uniquePmids) {
+		String uid = requireValidUid(identity);
+		List<Long> pmids = loadGoldStandardPmids(uid, false);
+		if (uniquePmids != null && !uniquePmids.isEmpty()) {
+			pmids.removeAll(uniquePmids);
 		}
-		
-		if(goldStandard != null 
-				&&
-				goldStandard.getRejectedPmids() != null
-				&&
-				goldStandard.getRejectedPmids().size() > 0) {
-			goldStandardPmids.addAll(goldStandard.getRejectedPmids());
+		return buildChunkedQueries(pmids, null, null, false);
+	}
+
+	/**
+	 * Build one {@link PubMedQueryType} per chunk of up to {@link #PMID_BATCH_SIZE} PMIDs.
+	 *
+	 * @param pmids             the PMIDs to encode (chunked); may be null/empty (returns an empty list)
+	 * @param startDate         optional date-range start applied to TERM queries only; null means no date-range
+	 * @param endDate           optional date-range end applied to TERM queries only
+	 * @param includeCountQuery when true, a date-less count query is attached to each chunk
+	 *                          (count queries omit the date range so the threshold gate sees the
+	 *                          full author result count, not a date-restricted subset).
+	 */
+	private List<PubMedQueryType> buildChunkedQueries(List<Long> pmids, Date startDate, Date endDate,
+			boolean includeCountQuery) {
+		List<PubMedQueryType> queries = new ArrayList<>();
+		if (pmids == null || pmids.isEmpty()) {
+			return queries;
 		}
 
-		PubMedQueryBuilder pubMedQueryBuilder = new PubMedQueryBuilder()
-				.dateRange(true, startDate, endDate);
-		PubMedQuery goldStandardQuery = pubMedQueryBuilder.buildPmids(goldStandardPmids);
-		
-		PubMedQueryBuilder pubMedQueryBuilderCount = new PubMedQueryBuilder();
-		PubMedQuery goldStandardCountQuery = pubMedQueryBuilderCount.buildPmids(goldStandardPmids);
+		boolean withDateRange = (startDate != null && endDate != null);
+		for (int i = 0; i < pmids.size(); i += PMID_BATCH_SIZE) {
+			List<Long> chunk = pmids.subList(i, Math.min(i + PMID_BATCH_SIZE, pmids.size()));
 
-		PubMedQueryType pubMedQueryType = new PubMedQueryType();
-		pubMedQueryType.setLenientQuery(new PubMedQueryResult(goldStandardQuery));
-		pubMedQueryType.setStrictQuery(new PubMedQueryResult(goldStandardQuery));
-		pubMedQueryType.setStrictCountQuery(new PubMedQueryResult(goldStandardCountQuery));
-		pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(goldStandardCountQuery));
-		pubMedQueries.add(pubMedQueryType);
+			PubMedQueryBuilder termBuilder = withDateRange
+					? new PubMedQueryBuilder().dateRange(true, startDate, endDate)
+					: new PubMedQueryBuilder();
+			PubMedQuery termQuery = termBuilder.buildPmids(chunk);
+			// PubMedQueryBuilder.buildPmids does not propagate startDate/endDate to the
+			// returned PubMedQuery; apply them here so PubMedQuery.toString() emits the [DP]/[EDAT] window.
+			if (withDateRange) {
+				termQuery.setStart(startDate);
+				termQuery.setEnd(endDate);
+			}
 
-		return pubMedQueries;
+			PubMedQueryType pubMedQueryType = new PubMedQueryType();
+			pubMedQueryType.setLenientQuery(new PubMedQueryResult(termQuery));
+			pubMedQueryType.setStrictQuery(new PubMedQueryResult(termQuery));
+
+			if (includeCountQuery) {
+				PubMedQuery countQuery = new PubMedQueryBuilder().buildPmids(chunk);
+				pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(countQuery));
+				pubMedQueryType.setStrictCountQuery(new PubMedQueryResult(countQuery));
+			}
+
+			queries.add(pubMedQueryType);
+		}
+		return queries;
+	}
+
+	private String requireValidUid(Identity identity) {
+		if (identity == null || identity.getUid() == null || identity.getUid().trim().isEmpty()) {
+			throw new IllegalArgumentException("Identity UID is missing or blank.");
+		}
+		return identity.getUid().trim();
+	}
+
+	/**
+	 * Defensive-copy the GoldStandard PMID list so callers can mutate the result
+	 * (e.g. remove unique PMIDs) without polluting the DynamoDB-cached entity.
+	 *
+	 * @param uid               the resolved (trimmed) identity UID
+	 * @param includeRejected   when true, append rejectedPmids to the returned list
+	 *                          (the no-args and dateRange overloads target the full GS;
+	 *                          the dedup overload targets known PMIDs only).
+	 */
+	private List<Long> loadGoldStandardPmids(String uid, boolean includeRejected) {
+		List<Long> pmids = new ArrayList<>();
+		GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(uid);
+		if (goldStandard == null) {
+			return pmids;
+		}
+		if (goldStandard.getKnownPmids() != null) {
+			pmids.addAll(goldStandard.getKnownPmids());
+		}
+		if (includeRejected && goldStandard.getRejectedPmids() != null) {
+			pmids.addAll(goldStandard.getRejectedPmids());
+		}
+		return pmids;
 	}
 
 	@Override

--- a/src/main/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategy.java
@@ -61,7 +61,7 @@ public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
 	protected List<PubMedQueryType> buildQuery(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames) {
 		String uid = requireValidUid(identity);
 		List<Long> pmids = loadGoldStandardPmids(uid, true);
-		return buildChunkedQueries(pmids, null, null, true);
+		return buildChunkedQueries(pmids, null, null);
 	}
 
 	@Override
@@ -69,7 +69,7 @@ public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
 			Date startDate, Date endDate) {
 		String uid = requireValidUid(identity);
 		List<Long> pmids = loadGoldStandardPmids(uid, true);
-		return buildChunkedQueries(pmids, startDate, endDate, true);
+		return buildChunkedQueries(pmids, startDate, endDate);
 	}
 
 	public List<PubMedQueryType> buildQueryGoldStandard(Identity identity, Set<Long> uniquePmids) {
@@ -78,7 +78,7 @@ public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
 		if (uniquePmids != null && !uniquePmids.isEmpty()) {
 			pmids.removeAll(uniquePmids);
 		}
-		return buildChunkedQueries(pmids, null, null, false);
+		return buildChunkedQueries(pmids, null, null);
 	}
 
 	/**
@@ -100,15 +100,18 @@ public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
 	/**
 	 * Build one {@link PubMedQueryType} per chunk of up to {@link #PMID_BATCH_SIZE} PMIDs.
 	 *
-	 * @param pmids             the PMIDs to encode (chunked); may be null/empty (returns an empty list)
-	 * @param startDate         optional date-range start applied to TERM queries only; null means no date-range
-	 * @param endDate           optional date-range end applied to TERM queries only
-	 * @param includeCountQuery when true, a date-less count query is attached to each chunk
-	 *                          (count queries omit the date range so the threshold gate sees the
-	 *                          full author result count, not a date-restricted subset).
+	 * <p>Count queries are ALWAYS set (date-less, even when the term query carries a date
+	 * range) — required because {@code AbstractRetrievalStrategy.retrievePubMedArticles}
+	 * unconditionally reads {@code getLenientCountQuery().getQuery()} on every emitted
+	 * {@link PubMedQueryType} and would NPE otherwise. Date-restricting the count query
+	 * is intentionally avoided so the threshold gate sees the full author result count,
+	 * not a date-restricted subset (see PR-spec-goldstandard-chunking.md line 232).
+	 *
+	 * @param pmids     the PMIDs to encode (chunked); may be null/empty (returns an empty list)
+	 * @param startDate optional date-range start applied to TERM queries only; null means no date-range
+	 * @param endDate   optional date-range end applied to TERM queries only
 	 */
-	private List<PubMedQueryType> buildChunkedQueries(List<Long> pmids, Date startDate, Date endDate,
-			boolean includeCountQuery) {
+	private List<PubMedQueryType> buildChunkedQueries(List<Long> pmids, Date startDate, Date endDate) {
 		List<PubMedQueryType> queries = new ArrayList<>();
 		if (pmids == null || pmids.isEmpty()) {
 			return queries;
@@ -129,15 +132,14 @@ public class GoldStandardRetrievalStrategy extends AbstractRetrievalStrategy {
 				termQuery.setEnd(endDate);
 			}
 
+			// Date-less count query always set — see Javadoc for the NPE-avoidance rationale.
+			PubMedQuery countQuery = new PubMedQueryBuilder().buildPmids(chunk);
+
 			PubMedQueryType pubMedQueryType = new PubMedQueryType();
 			pubMedQueryType.setLenientQuery(new PubMedQueryResult(termQuery));
 			pubMedQueryType.setStrictQuery(new PubMedQueryResult(termQuery));
-
-			if (includeCountQuery) {
-				PubMedQuery countQuery = new PubMedQueryBuilder().buildPmids(chunk);
-				pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(countQuery));
-				pubMedQueryType.setStrictCountQuery(new PubMedQueryResult(countQuery));
-			}
+			pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(countQuery));
+			pubMedQueryType.setStrictCountQuery(new PubMedQueryResult(countQuery));
 
 			queries.add(pubMedQueryType);
 		}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -78,8 +78,8 @@ local.lambda.function.invocation.url=/2015-03-31/functions/function/invocations
 #### Retrieval ####
 
 # Maximum PubMed results before switching from lenient to strict retrieval
-searchStrategy-lenient-threshold=2000
-searchStrategy-strict-threshold=1000
+searchStrategy-lenient-threshold=3000
+searchStrategy-strict-threshold=1500
 
 
 

--- a/src/test/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategyTest.java
+++ b/src/test/java/reciter/xml/retriever/pubmed/GoldStandardRetrievalStrategyTest.java
@@ -1,0 +1,154 @@
+package reciter.xml.retriever.pubmed;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import reciter.database.dynamodb.model.GoldStandard;
+import reciter.model.identity.Identity;
+import reciter.service.dynamo.IDynamoDbGoldStandardService;
+
+public class GoldStandardRetrievalStrategyTest {
+
+	@Mock
+	private IDynamoDbGoldStandardService dynamoDbGoldStandardService;
+
+	private GoldStandardRetrievalStrategy strategy;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		strategy = new GoldStandardRetrievalStrategy();
+		ReflectionTestUtils.setField(strategy, "dynamoDbGoldStandardService", dynamoDbGoldStandardService);
+	}
+
+	// Test 1 (spec: buildQuery_emptyGoldStandard_returnsEmptyList)
+	@Test
+	public void testEmptyGoldStandard() {
+		when(dynamoDbGoldStandardService.findByUid("u1")).thenReturn(new GoldStandard());
+		List<PubMedQueryType> qs = strategy.buildQuery(identity("u1"), Collections.emptyMap());
+		assertTrue("Empty GoldStandard should produce no queries", qs.isEmpty());
+	}
+
+	// Test 2 (spec: buildQuery_under100Pmids_singleChunk)
+	@Test
+	public void testSingleChunk() {
+		GoldStandard gs = goldStandardWithKnownPmids(50);
+		when(dynamoDbGoldStandardService.findByUid("u1")).thenReturn(gs);
+		List<PubMedQueryType> qs = strategy.buildQuery(identity("u1"), Collections.emptyMap());
+		assertEquals("50 PMIDs should fit in 1 chunk", 1, qs.size());
+		assertEquals("Total PMIDs across chunks", 50, countPmidsAcross(qs));
+	}
+
+	// Test 3 (spec: buildQuery_2060Pmids_chunksTo21Queries — using 2056 to match Phase 35 baseline)
+	@Test
+	public void testShariatScale2056Pmids() {
+		GoldStandard gs = goldStandardWithKnownPmids(2056);
+		when(dynamoDbGoldStandardService.findByUid("sfs2002")).thenReturn(gs);
+		List<PubMedQueryType> qs = strategy.buildQuery(identity("sfs2002"), Collections.emptyMap());
+		assertEquals("2056 PMIDs should produce 21 chunks (20*100 + 1*56)", 21, qs.size());
+		for (PubMedQueryType qt : qs) {
+			int n = countPmidsInChunk(qt);
+			assertTrue("Each chunk must have <= 100 PMIDs (got " + n + ")", n <= 100);
+		}
+		assertEquals("Total PMIDs across chunks", 2056, countPmidsAcross(qs));
+	}
+
+	// Test 4 (spec: buildQueryGoldStandard_dedupesAgainstUniquePmids)
+	@Test
+	public void testDedupesAgainstUniquePmids() {
+		GoldStandard gs = goldStandardWithKnownPmids(150);
+		when(dynamoDbGoldStandardService.findByUid("u1")).thenReturn(gs);
+		Set<Long> already = LongStream.range(0, 50).boxed().collect(Collectors.toSet());
+		List<PubMedQueryType> qs = strategy.buildQueryGoldStandard(identity("u1"), already);
+		assertEquals("150 known minus 50 already-retrieved = 100", 100, countPmidsAcross(qs));
+	}
+
+	// Test 5 (spec: buildQuery_dateRangeVariant_appliesDateRangeOnlyToTermNotCount)
+	@Test
+	public void testDateRangeVariant() throws Exception {
+		GoldStandard gs = goldStandardWithKnownPmids(50);
+		when(dynamoDbGoldStandardService.findByUid("u1")).thenReturn(gs);
+		SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
+		Date start = fmt.parse("2026-01-01");
+		Date end = fmt.parse("2026-04-30");
+		List<PubMedQueryType> qs = strategy.buildQuery(identity("u1"), Collections.emptyMap(), start, end);
+		assertEquals(1, qs.size());
+		PubMedQueryType qt = qs.get(0);
+		assertNotNull("term query should have start date applied",
+				qt.getLenientQuery().getQuery().getStart());
+		assertNull("count query should NOT have date applied (would trigger threshold gate)",
+				qt.getLenientCountQuery().getQuery().getStart());
+	}
+
+	// Test 6 (spec: buildQuery_blankUid_throws)
+	@Test(expected = IllegalArgumentException.class)
+	public void testBlankUidThrows() {
+		Identity i = new Identity();
+		i.setUid("");
+		strategy.buildQuery(i, Collections.emptyMap());
+	}
+
+	// Test 7 (spec: rejected PMIDs included in no-args buildQuery)
+	@Test
+	public void testRejectedPmidsIncluded() {
+		GoldStandard gs = new GoldStandard();
+		gs.setKnownPmids(new ArrayList<>(Arrays.asList(111L, 222L)));
+		gs.setRejectedPmids(new ArrayList<>(Arrays.asList(333L)));
+		when(dynamoDbGoldStandardService.findByUid("u1")).thenReturn(gs);
+		List<PubMedQueryType> qs = strategy.buildQuery(identity("u1"), Collections.emptyMap());
+		assertFalse("At least one query expected", qs.isEmpty());
+		String q = qs.get(0).getLenientQuery().getQuery().getStrategyQuery();
+		assertTrue("query should contain known PMID 111", q.contains("111"));
+		assertTrue("query should contain known PMID 222", q.contains("222"));
+		assertTrue("query should contain rejected PMID 333", q.contains("333"));
+	}
+
+	// Test 8 (OPTIONAL — defensive guard against URL-length regression)
+	@Test
+	public void testQueryLengthUnder2000Chars() {
+		GoldStandard gs = goldStandardWithKnownPmids(100);
+		when(dynamoDbGoldStandardService.findByUid("u1")).thenReturn(gs);
+		List<PubMedQueryType> qs = strategy.buildQuery(identity("u1"), Collections.emptyMap());
+		for (PubMedQueryType qt : qs) {
+			int len = qt.getLenientQuery().getQuery().getStrategyQuery().length();
+			assertTrue("Chunk query exceeded 2000 chars (len=" + len + ")", len < 2000);
+		}
+	}
+
+	// --- helpers ---
+
+	private Identity identity(String uid) {
+		Identity i = new Identity();
+		i.setUid(uid);
+		return i;
+	}
+
+	private GoldStandard goldStandardWithKnownPmids(int n) {
+		GoldStandard gs = new GoldStandard();
+		gs.setKnownPmids(LongStream.range(0, n).boxed().collect(Collectors.toList()));
+		return gs;
+	}
+
+	private int countPmidsAcross(List<PubMedQueryType> qs) {
+		return qs.stream().mapToInt(this::countPmidsInChunk).sum();
+	}
+
+	private int countPmidsInChunk(PubMedQueryType qt) {
+		String q = qt.getLenientQuery().getQuery().getStrategyQuery();
+		if (q == null || q.isEmpty()) {
+			return 0;
+		}
+		return q.split(",").length;
+	}
+}


### PR DESCRIPTION
## Summary

Drew flagged a population of missing articles for several researchers during a recent audit. Tracing it down, the dominant cause was a 2000-character URL truncation in `GoldStandardRetrievalStrategy`: when a researcher's GoldStandard had more than ~150 known PMIDs, the comma-separated PMID list overflowed PubMed's eutils URL limit and the retrieval silently dropped most of the list. For prolific authors this cost ~85% of their priority PMIDs.

This bundle is four narrow fixes that together recover the bulk of the missing-articles backlog. Verified end-to-end on `reciter-dev`.

## Dev verification (this branch)

6-UID smoke test on dev (sfs2002 + 5 representatives spanning the in-GS-not-retrieved distribution):

| UID | Before | After (dev) | Δ | Notes |
|-----|--------|-------------|---|-------|
| sfs2002 (2060 GS PMIDs) | 1915 | 8 | **−99.6%** | residual 8 are PubMed-invalid (deleted/withdrawn — verified live) |
| rsb2005 (440 known + 156 rejected) | 36 | 36 | 0 | preserved baseline |
| abj9004 | 12 | 12 | 0 | preserved |
| jak2043 | 6 | 6 | 0 | preserved |
| acp9008 | 1 | 1 | 0 | preserved |
| inp2002 | 1 | 1 | 0 | preserved |

Pattern: dramatic recovery for users whose GoldStandard exceeds the chunking threshold; no-op preservation for users with small GS. **No regressions on any UID tested.**

Lambda errors during the smoke test: 0. The new `log.warn` for silent `ALL_PUBLICATIONS` upgrade fires correctly on the affected code path.

## Changes (7 commits)

- **`fix(retrieval): chunk GoldStandard PMID queries into batches of 100`** (`2b29bd75`)
  - `GoldStandardRetrievalStrategy.buildChunkedQueries()` emits one `PubMedQueryType` per 100-PMID chunk. All three `buildQuery*` overloads (no-args, dateRange, dedup) delegate to it.
  - Adds 8 unit tests (`GoldStandardRetrievalStrategyTest`).
  - Adds `junit-vintage-engine` to `pom.xml` so JUnit 4 tests are discoverable by Surefire (also unblocks the pre-existing `DegreeYearStrategyUtilsTest` which was silently un-run).
- **`fix(retrieval): raise thresholds to 3000/1500 and log silent ALL_PUBLICATIONS upgrade`** (`cffc6a81`)
  - `application.properties`: `searchStrategy-lenient-threshold` 2000→3000, `searchStrategy-strict-threshold` 1000→1500. Conservative bump (room to widen later if metrics support it).
  - `ReCiterController.java`: adds `log.warn` immediately before the silent `retrieveArticlesByUid(uid, ALL_PUBLICATIONS)` substitution at line 1095. Eliminates the audit blind spot.
- **`fix(retrieval): wire deduping GoldStandard retrieval into engine`** (`a8542586`)
  - `AliasReCiterRetrievalEngine.retrieveData` (and the date-range overload) now run GoldStandard retrieval LAST, after Email/FNI/Affiliation/Department/Grant/FullName/KnownRel/SecondInitial have populated `uniquePmids`.
  - `buildQueryGoldStandard(identity, uniquePmids)` strips already-retrieved PMIDs to avoid redundant eutils calls.
  - ORCID inference and the ORCID retrieval strategy moved with GS so `inferOrcidFromAcceptedArticles` still sees GS articles in `pubMedArticles` when it runs.
  - Visibility: `AbstractRetrievalStrategy.retrievePubMedArticles` private→protected; `GoldStandardRetrievalStrategy.buildQueryGoldStandard` protected→public; new public `retrievePubMedArticlesUsingQueries` wrapper.
  - Side effect (improvement): `pubMedArticles` is now consistently populated across all strategies via `putAll` instead of the old reassignment-in-the-middle pattern. The Scopus DOI fallback at line ~404 will now find DOIs for GS+ORCID PMIDs that previously returned `null`.
- **`fix(retrieval): always set count queries in GoldStandard chunks`** (`a5b50347`)
  - NPE fix discovered during dev smoke test. `buildChunkedQueries` now always sets `lenientCountQuery`/`strictCountQuery` on every emitted chunk. The parent `AbstractRetrievalStrategy.retrievePubMedArticles` reads `getLenientCountQuery().getQuery()` unconditionally and would NPE otherwise. Latent issue exposed by the new dedup-wiring path.
- **`fix(retrieval): include rejectedPmids in dedup-variant GS retrieval`** (`8b05cc30`)
  - Second smoke-test follow-up. The dedup variant was loading only `knownPmids`, but the analysis metric `inGoldStandardButNotRetrieved` counts both known + rejected. Resulted in a metric regression for users with non-trivial rejectedPmids count (rsb2005: 36 → 168). Fix: include rejectedPmids; dedup intent (skip what's already retrieved) is preserved via `removeAll(uniquePmids)`.

## Test plan

- [x] `mvn test -Dtest=GoldStandardRetrievalStrategyTest` → 8/8 pass on `development`
- [x] `mvn test` (full suite) → 36/36 pass excluding 2 pre-existing `TargetAuthorSelectionTest` failures (NPE in `@Spy` initialization, present on `master` baseline before this PR — latent test debt unrelated to this work, surfaced now that `junit-vintage-engine` makes JUnit 4 tests discoverable)
- [x] `mvn compile` clean
- [x] Dev `reciter-dev` deploy + 6-UID smoke test (above)
- [ ] **Reviewer**: approve the bundled deploy; `ReCiter-Production` CodePipeline will pick up on master push and pause at its `ManualApproval` stage for prod deploy
- [ ] **Post-deploy**: spot-check sfs2002 on prod — `inGoldStandardButNotRetrieved` should drop from its current ~1915 baseline to single digits

## Notes

- The companion inst-client batch-date determinism fix has already landed on `master_corretto11` in `wcmc-its/ReCiter-Institutional-Client` via @ved4006's commit `06d2f3b`. The two changes are independent at the deploy level.
- `reciter-inst-client` cronjob is currently running (resumed yesterday). It will start using the new chunked retrieval automatically as soon as this lands on prod and the pods roll over.
- The two pre-existing `TargetAuthorSelectionTest` failures (`testCheckEmailMatch:66`, `testCheckExactLastMiddleFirstNameMatch:74`) are confirmed identical on the `master` baseline — not caused by this PR. Worth a separate cleanup ticket; do not block this merge.