### PR TITLE
Phase 33-01: write ArticleProvenance on every retrieval strategy hit

### DIFF
--- a/src/main/java/reciter/service/ArticleProvenanceService.java
+++ b/src/main/java/reciter/service/ArticleProvenanceService.java
@@ -1,0 +1,44 @@
+package reciter.service;
+
+/**
+ * Writes provenance records to the {@code ArticleProvenance} DynamoDB table.
+ *
+ * <p>ArticleProvenance has the schema {@code (uid: S [PK], articleId: S [SK])}
+ * with attributes:
+ * <ul>
+ *   <li>{@code rs}  — primary retrieval strategy code (first strategy to find this PMID for this uid)</li>
+ *   <li>{@code frd} — first retrieval date, epoch seconds</li>
+ *   <li>{@code ads} — additional strategy codes (String Set), grows as new strategies re-find this PMID</li>
+ *   <li>{@code src} — provenance source: PM, MAN, CTSC, MAN_FROM_PM, MAN_FROM_CTSC (owned by curator/CTSC paths, not retrieval)</li>
+ * </ul>
+ *
+ * <p>This service writes only the retrieval-side fields ({@code rs}, {@code frd}, {@code ads}).
+ * It uses raw {@code AmazonDynamoDB.updateItem} (not DynamoDBMapper) to access expression
+ * features ({@code if_not_exists}, {@code ADD} on String Sets) that DynamoDBMapper does
+ * not support cleanly. Phase 33 D-02/D-03/D-04 govern these semantics.
+ */
+public interface ArticleProvenanceService {
+
+    /**
+     * Upsert retrieval provenance for one (uid, pmid) pair.
+     *
+     * <p>Behavior:
+     * <ul>
+     *   <li>{@code rs} is set to {@code strategyCode} only if {@code rs} is currently absent
+     *       (first strategy wins; preserves original retrieval attribution on re-runs).</li>
+     *   <li>{@code frd} is set to {@code epochSeconds} only if currently absent (preserves
+     *       the original first-retrieval-date).</li>
+     *   <li>{@code ads} always grows: {@code strategyCode} is ADDed to the String Set.</li>
+     *   <li>{@code src} is NOT touched (owned by curator/CTSC paths per Phase 33 D-04).</li>
+     * </ul>
+     *
+     * <p>Errors are logged but never thrown — provenance write failures must not break
+     * retrieval. Callers can fire-and-forget.
+     *
+     * @param uid          person identifier
+     * @param pmid         PubMed ID
+     * @param strategyCode retrieval strategy code (e.g. {@code "PUBMED_NAME_AFFIL"})
+     * @param epochSeconds first-retrieval-date as epoch seconds (typically {@code now})
+     */
+    void upsertRetrievalProvenance(String uid, long pmid, String strategyCode, long epochSeconds);
+}

--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -1,0 +1,83 @@
+package reciter.service.dynamo;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+
+import reciter.service.ArticleProvenanceService;
+
+/**
+ * Phase 33-01 implementation of {@link ArticleProvenanceService}.
+ *
+ * <p>Uses raw {@code AmazonDynamoDB.updateItem} so the {@code UpdateExpression} can
+ * combine {@code if_not_exists(...)} with {@code ADD ads :strategySet} in a single
+ * request. {@link com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper}
+ * does not support this expression shape directly.
+ *
+ * <p>Single-round-trip semantics: no read-then-write, no race; concurrent retrieval
+ * strategies on the same PMID are safe because String Set ADD is commutative and
+ * {@code if_not_exists} is atomic per UpdateItem.
+ */
+@Service
+public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
+
+    private static final Logger log = LoggerFactory.getLogger(ArticleProvenanceServiceImpl.class);
+    private static final String TABLE_NAME = "ArticleProvenance";
+
+    private final AmazonDynamoDB amazonDynamoDB;
+
+    public ArticleProvenanceServiceImpl(AmazonDynamoDB amazonDynamoDB) {
+        this.amazonDynamoDB = amazonDynamoDB;
+    }
+
+    @Override
+    public void upsertRetrievalProvenance(String uid, long pmid, String strategyCode, long epochSeconds) {
+        if (uid == null || uid.isEmpty()) {
+            log.warn("upsertRetrievalProvenance called with null/empty uid; skipping (pmid={})", pmid);
+            return;
+        }
+        if (strategyCode == null || strategyCode.isEmpty()) {
+            log.warn("upsertRetrievalProvenance called with null/empty strategyCode; skipping (uid={} pmid={})",
+                    uid, pmid);
+            return;
+        }
+
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("uid", new AttributeValue().withS(uid));
+        key.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":strategy", new AttributeValue().withS(strategyCode));
+        values.put(":now", new AttributeValue().withN(String.valueOf(epochSeconds)));
+        values.put(":strategySet", new AttributeValue().withSS(Collections.singletonList(strategyCode)));
+
+        UpdateItemRequest req = new UpdateItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withUpdateExpression(
+                        "SET rs = if_not_exists(rs, :strategy), " +
+                        "    frd = if_not_exists(frd, :now) " +
+                        "ADD ads :strategySet")
+                .withExpressionAttributeValues(values);
+
+        try {
+            amazonDynamoDB.updateItem(req);
+        } catch (AmazonDynamoDBException e) {
+            // Provenance failures must not break retrieval. Log and continue.
+            log.warn("ArticleProvenance upsert failed for uid={} pmid={} strategy={}: {}",
+                    uid, pmid, strategyCode, e.getMessage());
+        } catch (RuntimeException e) {
+            log.warn("ArticleProvenance upsert unexpected error for uid={} pmid={} strategy={}: {}",
+                    uid, pmid, strategyCode, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -45,6 +45,7 @@ import reciter.model.identity.PubMedAlias;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.model.scopus.ScopusArticle;
 import reciter.database.dynamodb.model.PmidProvenance;
+import reciter.service.ArticleProvenanceService;
 import reciter.service.ESearchCountService;
 import reciter.service.ESearchResultService;
 import reciter.service.PmidProvenanceService;
@@ -77,6 +78,9 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 
 	@Autowired
 	private PmidProvenanceService pmidProvenanceService;
+
+	@Autowired
+	private ArticleProvenanceService articleProvenanceService;
 
 	public enum IdentityNameType {
 		ORIGINAL,
@@ -866,14 +870,32 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	}
 
 	/**
-	 * Track newly discovered PMIDs for provenance recording.
-	 * For each PMID in the articles map, if it's not already known (from existingPmids or newPmidStrategy),
-	 * record which strategy first discovered it. Also heal any backfill provenance records.
+	 * Track PMIDs returned by a retrieval strategy.
+	 *
+	 * <p>Two effects per PMID:
+	 * <ol>
+	 *   <li><b>Legacy {@code PmidProvenance} attribution</b>: if the PMID is genuinely new
+	 *       (not in {@code existingPmids} nor already attributed in {@code newPmidStrategy}),
+	 *       record this strategy as the first finder. The contents of {@code newPmidStrategy}
+	 *       are batch-written to {@code PmidProvenance} after all strategies finish.
+	 *       Backfill-tagged PMIDs are healed via {@link PmidProvenanceService#updateStrategyIfBackfill}.</li>
+	 *   <li><b>Phase 33 {@code ArticleProvenance} write</b>: for EVERY PMID returned by the
+	 *       strategy (not just new ones), upsert the {@code ArticleProvenance} row with
+	 *       {@code rs}/{@code frd}/{@code ads}. Uses {@code if_not_exists} so original
+	 *       attribution is preserved on re-runs; {@code ads} grows as new strategies re-find
+	 *       this PMID. The {@code src} field is NOT touched here (curator/CTSC paths own it).
+	 *       This closes the established-user gap where PmidProvenance was never written
+	 *       because all PMIDs were already known.</li>
+	 * </ol>
+	 *
+	 * <p>Phase 33-01 D-01..D-04. Provenance write failures never propagate (logged in service).
 	 */
 	private void trackNewPmids(Map<Long, ?> articles, String strategyName,
 			String uid, Set<Long> existingPmids, Map<Long, String> newPmidStrategy,
 			Set<Long> backfillPmids) {
+		long nowEpochSeconds = System.currentTimeMillis() / 1000L;
 		for (Long pmid : articles.keySet()) {
+			// Legacy PmidProvenance attribution (new-only)
 			if (!existingPmids.contains(pmid) && !newPmidStrategy.containsKey(pmid)) {
 				newPmidStrategy.put(pmid, strategyName);
 			}
@@ -881,6 +903,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				pmidProvenanceService.updateStrategyIfBackfill(uid, pmid, strategyName);
 				backfillPmids.remove(pmid);
 			}
+			// Phase 33-01: ArticleProvenance upsert for EVERY retrieved PMID
+			articleProvenanceService.upsertRetrievalProvenance(uid, pmid, strategyName, nowEpochSeconds);
 		}
 	}
 

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -1,0 +1,166 @@
+package reciter.service.dynamo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+
+/**
+ * Unit tests for {@link ArticleProvenanceServiceImpl}.
+ *
+ * <p>Verifies Phase 33-01 D-01..D-04 invariants:
+ * <ul>
+ *   <li>UpdateExpression uses {@code if_not_exists(rs, ...)} so the first retrieval strategy wins</li>
+ *   <li>UpdateExpression uses {@code if_not_exists(frd, ...)} so first-retrieval-date is preserved</li>
+ *   <li>UpdateExpression uses {@code ADD ads :strategySet} for additional-strategy tracking</li>
+ *   <li>UpdateExpression does NOT touch {@code src} (curator/CTSC paths own it)</li>
+ *   <li>DynamoDB exceptions are logged but not thrown (provenance must not break retrieval)</li>
+ *   <li>Null/empty {@code uid} or {@code strategyCode} short-circuit safely</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ArticleProvenanceServiceImplTest {
+
+    @Mock
+    private AmazonDynamoDB amazonDynamoDB;
+
+    private ArticleProvenanceServiceImpl service;
+
+    @Before
+    public void setUp() {
+        service = new ArticleProvenanceServiceImpl(amazonDynamoDB);
+    }
+
+    private UpdateItemRequest captureRequest() {
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void testUpsert_TableNameAndKey_MatchSchema() {
+        service.upsertRetrievalProvenance("ajg9004", 12345L, "PUBMED_NAME_AFFIL", 1700000000L);
+
+        UpdateItemRequest req = captureRequest();
+        assertEquals("ArticleProvenance", req.getTableName());
+
+        Map<String, AttributeValue> key = req.getKey();
+        assertEquals("ajg9004", key.get("uid").getS());
+        assertEquals("12345", key.get("articleId").getS());
+    }
+
+    @Test
+    public void testUpsert_PreservesExistingRsFrd_OnRewrite() {
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+        UpdateItemRequest req = captureRequest();
+
+        String expr = req.getUpdateExpression();
+        assertTrue("UpdateExpression must use if_not_exists(rs, :strategy): " + expr,
+                expr.contains("rs = if_not_exists(rs, :strategy)"));
+        assertTrue("UpdateExpression must use if_not_exists(frd, :now): " + expr,
+                expr.contains("frd = if_not_exists(frd, :now)"));
+    }
+
+    @Test
+    public void testUpsert_AddsStrategyToAds() {
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+        UpdateItemRequest req = captureRequest();
+
+        String expr = req.getUpdateExpression();
+        assertTrue("UpdateExpression must contain ADD ads :strategySet: " + expr,
+                expr.contains("ADD ads :strategySet"));
+
+        AttributeValue ssVal = req.getExpressionAttributeValues().get(":strategySet");
+        assertNotNull(":strategySet must be present", ssVal);
+        assertNotNull(":strategySet must be a String Set", ssVal.getSS());
+        assertEquals(1, ssVal.getSS().size());
+        assertEquals("STRAT_A", ssVal.getSS().get(0));
+    }
+
+    @Test
+    public void testUpsert_DoesNotTouchSrc() {
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+        UpdateItemRequest req = captureRequest();
+
+        String expr = req.getUpdateExpression();
+        // Phase 33 D-04: retrieval path never writes src.
+        assertTrue("UpdateExpression must not contain 'src': " + expr,
+                !expr.contains("src"));
+    }
+
+    @Test
+    public void testUpsert_ExpressionAttributeValues_HaveCorrectTypes() {
+        service.upsertRetrievalProvenance("uid1", 100L, "PUBMED_GRANT", 1700000000L);
+        UpdateItemRequest req = captureRequest();
+
+        Map<String, AttributeValue> values = req.getExpressionAttributeValues();
+        assertEquals("PUBMED_GRANT", values.get(":strategy").getS());
+        assertEquals("1700000000", values.get(":now").getN());
+        assertEquals(1, values.get(":strategySet").getSS().size());
+        assertEquals("PUBMED_GRANT", values.get(":strategySet").getSS().get(0));
+    }
+
+    @Test
+    public void testUpsert_DynamoDbExceptionLogged_NotThrown() {
+        when(amazonDynamoDB.updateItem(any(UpdateItemRequest.class)))
+                .thenThrow(new AmazonDynamoDBException("simulated DDB failure"));
+
+        // Must not throw — provenance failures must not break retrieval.
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+
+        // updateItem was called once and the exception was swallowed.
+        verify(amazonDynamoDB).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_RuntimeExceptionLogged_NotThrown() {
+        when(amazonDynamoDB.updateItem(any(UpdateItemRequest.class)))
+                .thenThrow(new IllegalStateException("simulated unexpected failure"));
+
+        // Must not throw — even unexpected runtime exceptions are swallowed.
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+
+        verify(amazonDynamoDB).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_NullUid_SkipsCallEntirely() {
+        service.upsertRetrievalProvenance(null, 100L, "STRAT_A", 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_EmptyUid_SkipsCallEntirely() {
+        service.upsertRetrievalProvenance("", 100L, "STRAT_A", 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_NullStrategyCode_SkipsCallEntirely() {
+        service.upsertRetrievalProvenance("uid1", 100L, null, 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_EmptyStrategyCode_SkipsCallEntirely() {
+        service.upsertRetrievalProvenance("uid1", 100L, "", 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 33-01 of v7.0 (Article Provenance & Feedback Log). Wires retrieval strategies to write the new `ArticleProvenance` DynamoDB table.

- New `ArticleProvenanceService` interface + `ArticleProvenanceServiceImpl` using raw `AmazonDynamoDB.updateItem`. The schema needs `ADD ads :strategySet` on a String Set in the same expression as `if_not_exists(rs, ...)` and `if_not_exists(frd, ...)` — DynamoDBMapper does not support that shape, so this service goes to the SDK directly.
- `AliasReCiterRetrievalEngine.trackNewPmids()` now upserts `ArticleProvenance` for **every** PMID a retrieval strategy returns, not just new ones (the existing `PmidProvenance` attribution path is preserved). Established users currently get zero PmidProvenance writes on refresh because all their PMIDs are already known; this change makes the new ArticleProvenance writes durable across re-runs.
- Provenance writes are fire-and-forget: SDK exceptions are logged at WARN but do NOT propagate, so retrieval is never blocked by a degraded DynamoDB.
- `src` is NOT touched by retrieval (per Phase 33 D-04). Only `rs` / `frd` / `ads` are written. The `src` field is owned by the curator/CTSC paths (Phase 33-02).
- `if_not_exists(rs, ...)` ensures the FIRST strategy to find a PMID gets attribution; subsequent re-finds grow `ads` via DynamoDB String Set ADD semantics.

## Test plan

- [x] `mvn compile` clean (264 source files)
- [x] 11 new Mockito JUnit cases in `ArticleProvenanceServiceImplTest` cover: table name + key shape, `if_not_exists` rs/frd, ADD ads, src-not-touched, expression attribute value types, both `AmazonDynamoDBException` and generic `RuntimeException` swallowed, null/empty uid + strategyCode short-circuit
- [x] Full `mvn test` shows 39+ existing tests + 11 new pass; pre-existing `TargetAuthorSelectionTest` NPEs unchanged (unrelated)
- [ ] Local end-to-end smoke against dev DynamoDB (recommend running before approval)
- [ ] Dev EKS deploy via `ReCiter` CodePipeline ManualApproval
- [ ] Dev validation: trigger `feature-generator/by/uid` for the four continuity uids (ajg9004, sfs2002, rsb2005, meb7002) and confirm `ArticleProvenance.rs/frd/ads` populated for retrieval-attributable PMIDs (use `scripts/spot_check_feedback_log.py --strict` from the ReCiter Research repo)

## Notes

This PR is the foundation for Phase 33-02 (FeedbackLog + curator-action D-11 transitions), which is up next as a stacked follow-up. PmidProvenance writes are intentionally preserved for the 2-week soak window per Phase 33 D-15/D-16; that cleanup will land in a separate PR after the soak.