### PR TITLE
Phase 33-02: write FeedbackLog + apply ArticleProvenance D-11/D-13 on curator actions

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -152,7 +152,8 @@ public class ReCiterController {
     @RequestMapping(value = "/reciter/goldstandard", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody
     public ResponseEntity updateGoldStandard(@RequestBody GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
-    		@RequestParam(value = "source", required = false) String provenanceSource) {
+    		@RequestParam(value = "source", required = false) String provenanceSource,
+    		@RequestParam(value = "entryPath", required = false) String entryPathParam) {
         StopWatch stopWatch = new StopWatch("Update GoldStandard");
         stopWatch.start("Update GoldStandard");
     	if(goldStandard == null) {
@@ -160,15 +161,16 @@ public class ReCiterController {
     	} else if(goldStandard != null && goldStandard.getUid() == null) {
     		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The api requires a valid uid to be passed with GoldStandard model");
     	}
+    	reciter.feedback.EntryPath entryPath = reciter.feedback.EntryPath.fromString(entryPathParam);
     	if(goldStandardUpdateFlag == null ||
     			goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE || goldStandardUpdateFlag == GoldStandardUpdateFlag.DELETE) {
     		if(goldStandardUpdateFlag == null) {
-    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource);
+    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource, entryPath);
     		} else {
-    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource);
+    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
     		}
     	} else {
-    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource);
+    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource, entryPath);
         }
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
@@ -188,18 +190,20 @@ public class ReCiterController {
     @RequestMapping(value = "/reciter/goldstandard", method = RequestMethod.PUT, produces = "application/json")
     @ResponseBody
     public ResponseEntity<List<GoldStandard>> updateGoldStandard(@RequestBody List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
-    		@RequestParam(value = "source", required = false) String provenanceSource) {
+    		@RequestParam(value = "source", required = false) String provenanceSource,
+    		@RequestParam(value = "entryPath", required = false) String entryPathParam) {
         StopWatch stopWatch = new StopWatch("Update GoldStandard with List");
         stopWatch.start("Update GoldStandard with List");
+    	reciter.feedback.EntryPath entryPath = reciter.feedback.EntryPath.fromString(entryPathParam);
     	if(goldStandardUpdateFlag == null ||
     			goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE || goldStandardUpdateFlag == GoldStandardUpdateFlag.DELETE) {
     		if(goldStandardUpdateFlag == null) {
-    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource);
+    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource, entryPath);
     		} else {
-    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource);
+    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
     		}
     	} else {
-    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource);
+    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource, entryPath);
         }
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");

--- a/src/main/java/reciter/feedback/EntryPath.java
+++ b/src/main/java/reciter/feedback/EntryPath.java
@@ -1,0 +1,37 @@
+package reciter.feedback;
+
+/**
+ * Discriminator for how a curator action originated in Publication Manager.
+ *
+ * <p>Phase 33 D-14: PM UI emits this on every feedback action so the Java
+ * write path can distinguish auto-retrieved-candidate curation from
+ * curator-driven PubMed search.
+ *
+ * <ul>
+ *   <li>{@link #CANDIDATE_LIST} — curator clicked ACCEPT/REJECT/PENDING on a row in
+ *       the auto-retrieved candidate list. The PMID is already (or will be)
+ *       attributed via Phase 33-01's retrieval write path.</li>
+ *   <li>{@link #PUBMED_SEARCH} — curator queried PubMed inside PM's UI and accepted
+ *       (or rejected) a result. The Java write path treats this as its own
+ *       retrieval strategy with {@code rs='PM_UI_SEARCH'} (D-13).</li>
+ * </ul>
+ */
+public enum EntryPath {
+    CANDIDATE_LIST,
+    PUBMED_SEARCH;
+
+    /**
+     * Resolve a string to {@link EntryPath} with case-insensitive matching.
+     * Returns {@link #CANDIDATE_LIST} (the default) for null, empty, or unrecognized values.
+     */
+    public static EntryPath fromString(String s) {
+        if (s == null || s.isEmpty()) {
+            return CANDIDATE_LIST;
+        }
+        try {
+            return EntryPath.valueOf(s.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return CANDIDATE_LIST;
+        }
+    }
+}

--- a/src/main/java/reciter/service/ArticleProvenanceService.java
+++ b/src/main/java/reciter/service/ArticleProvenanceService.java
@@ -1,5 +1,7 @@
 package reciter.service;
 
+import reciter.feedback.EntryPath;
+
 /**
  * Writes provenance records to the {@code ArticleProvenance} DynamoDB table.
  *
@@ -41,4 +43,39 @@ public interface ArticleProvenanceService {
      * @param epochSeconds first-retrieval-date as epoch seconds (typically {@code now})
      */
     void upsertRetrievalProvenance(String uid, long pmid, String strategyCode, long epochSeconds);
+
+    /**
+     * Upsert provenance for a curator action (Phase 33 D-11 / D-13).
+     *
+     * <p>Implements the unified D-11 transition rule: regardless of feedback value
+     * (ACCEPTED, REJECTED, PENDING), the {@code src} field is updated according to
+     * the existing src per the table:
+     *
+     * <pre>
+     *   existing src              →  new src
+     *   ──────────────────────────────────────────
+     *   absent or 'GS'            →  'MAN'
+     *   'PM'                      →  'MAN_FROM_PM'
+     *   'CTSC'                    →  'MAN_FROM_CTSC'
+     *   'MAN' / 'MAN_FROM_*'      →  unchanged (no-op)
+     * </pre>
+     *
+     * <p>{@code frd} is preserved if set; otherwise written as {@code epochSeconds}.
+     *
+     * <p>If {@code entryPath == PUBMED_SEARCH} (D-13), an additional retrieval-style
+     * write happens FIRST: {@code rs = if_not_exists(rs, 'PM_UI_SEARCH')},
+     * {@code src = if_not_exists(src, 'PM')}, {@code ADD ads :PM_UI_SEARCH_set}.
+     * This ensures the curator-search-via-PubMed origin is recorded; the subsequent
+     * D-11 transition then lifts {@code src=PM} to {@code MAN_FROM_PM}.
+     *
+     * <p>Implementation uses GetItem-then-conditional-UpdateItem with one retry on
+     * concurrent-write CCE; if the second attempt also fails, log WARN and continue
+     * (D-12). Provenance writes never block PM UI requests.
+     *
+     * @param uid          person identifier
+     * @param pmid         PubMed ID
+     * @param entryPath    PM UI entry path (CANDIDATE_LIST or PUBMED_SEARCH)
+     * @param epochSeconds curator action time, epoch seconds
+     */
+    void upsertCuratorAction(String uid, long pmid, EntryPath entryPath, long epochSeconds);
 }

--- a/src/main/java/reciter/service/FeedbackLogService.java
+++ b/src/main/java/reciter/service/FeedbackLogService.java
@@ -1,0 +1,42 @@
+package reciter.service;
+
+/**
+ * Writes curator action records to the {@code FeedbackLog} DynamoDB table.
+ *
+ * <p>Schema (Phase 32 D-01, D-02):
+ * <ul>
+ *   <li>{@code uid} (S, PK)</li>
+ *   <li>{@code sk} (S, SK) = {@code "<epoch_seconds>#<8-hex-digit-suffix>"}</li>
+ *   <li>{@code articleId} (S)</li>
+ *   <li>{@code feedback} (S) ∈ {ACCEPTED, REJECTED, PENDING}</li>
+ *   <li>{@code curatedBy} (N) — userID from PM</li>
+ *   <li>{@code src} (S) = "MAN" (PM UI is the only source for this table going forward)</li>
+ *   <li>{@code createTimestamp} (N), {@code modifyTimestamp} (N)</li>
+ * </ul>
+ *
+ * <p>The 8-hex-digit suffix is derived from {@code System.nanoTime()} and gives
+ * uniqueness within a single Java process; the conditional {@code attribute_not_exists(sk)}
+ * catches cross-process collisions and the caller retries with a fresh suffix.
+ */
+public interface FeedbackLogService {
+
+    /**
+     * Curator action feedback values. See Phase 32 D-04.
+     */
+    enum Feedback {
+        ACCEPTED, REJECTED, PENDING
+    }
+
+    /**
+     * Record a single curator action.
+     *
+     * @param uid                 person identifier
+     * @param pmid                PubMed ID
+     * @param feedback            ACCEPTED, REJECTED, or PENDING
+     * @param curatedBy           userID of the curator (or 0 if unknown — e.g., when the
+     *                            action is inferred from a GoldStandard list-replace API call
+     *                            that doesn't carry a userID)
+     * @param actionEpochSeconds  curator action time, epoch seconds (used in sk and timestamps)
+     */
+    void recordAction(String uid, long pmid, Feedback feedback, int curatedBy, long actionEpochSeconds);
+}

--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -11,8 +11,12 @@ import org.springframework.stereotype.Service;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
 
+import reciter.feedback.EntryPath;
 import reciter.service.ArticleProvenanceService;
 
 /**
@@ -32,6 +36,13 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
 
     private static final Logger log = LoggerFactory.getLogger(ArticleProvenanceServiceImpl.class);
     private static final String TABLE_NAME = "ArticleProvenance";
+    private static final String PM_UI_SEARCH_RS = "PM_UI_SEARCH";
+    private static final String SRC_PM = "PM";
+    private static final String SRC_CTSC = "CTSC";
+    private static final String SRC_GS_PLACEHOLDER = "GS";
+    private static final String SRC_MAN = "MAN";
+    private static final String SRC_MAN_FROM_PM = "MAN_FROM_PM";
+    private static final String SRC_MAN_FROM_CTSC = "MAN_FROM_CTSC";
 
     private final AmazonDynamoDB amazonDynamoDB;
 
@@ -79,5 +90,140 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
             log.warn("ArticleProvenance upsert unexpected error for uid={} pmid={} strategy={}: {}",
                     uid, pmid, strategyCode, e.getMessage());
         }
+    }
+
+    @Override
+    public void upsertCuratorAction(String uid, long pmid, EntryPath entryPath, long epochSeconds) {
+        if (uid == null || uid.isEmpty()) {
+            log.warn("upsertCuratorAction called with null/empty uid; skipping (pmid={})", pmid);
+            return;
+        }
+        EntryPath path = (entryPath == null) ? EntryPath.CANDIDATE_LIST : entryPath;
+
+        // D-13: PUBMED_SEARCH path writes a retrieval-style record FIRST so D-11
+        // sees src='PM' and lifts to MAN_FROM_PM. CANDIDATE_LIST skips this step.
+        if (path == EntryPath.PUBMED_SEARCH) {
+            writePmUiSearchRecord(uid, pmid, epochSeconds);
+        }
+
+        // D-11 transition with one retry on race
+        try {
+            applyD11Transition(uid, pmid, epochSeconds, /*allowRetry=*/ true);
+        } catch (RuntimeException e) {
+            log.warn("D-11 upsert unexpected error for uid={} pmid={} entryPath={}: {}",
+                    uid, pmid, path, e.getMessage());
+        }
+    }
+
+    private void writePmUiSearchRecord(String uid, long pmid, long epochSeconds) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("uid", new AttributeValue().withS(uid));
+        key.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":rs", new AttributeValue().withS(PM_UI_SEARCH_RS));
+        values.put(":pm", new AttributeValue().withS(SRC_PM));
+        values.put(":ts", new AttributeValue().withN(String.valueOf(epochSeconds)));
+        values.put(":rsSet", new AttributeValue().withSS(Collections.singletonList(PM_UI_SEARCH_RS)));
+
+        UpdateItemRequest req = new UpdateItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withUpdateExpression(
+                        "SET rs  = if_not_exists(rs,  :rs), " +
+                        "    src = if_not_exists(src, :pm), " +
+                        "    frd = if_not_exists(frd, :ts) " +
+                        "ADD ads :rsSet")
+                .withExpressionAttributeValues(values);
+
+        try {
+            amazonDynamoDB.updateItem(req);
+        } catch (AmazonDynamoDBException e) {
+            log.warn("PM_UI_SEARCH retrieval-record write failed for uid={} pmid={}: {}",
+                    uid, pmid, e.getMessage());
+        }
+    }
+
+    private void applyD11Transition(String uid, long pmid, long epochSeconds, boolean allowRetry) {
+        // 1. Read current src
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("uid", new AttributeValue().withS(uid));
+        key.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+
+        GetItemRequest getReq = new GetItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withProjectionExpression("src")
+                .withConsistentRead(true);
+
+        GetItemResult getRes;
+        try {
+            getRes = amazonDynamoDB.getItem(getReq);
+        } catch (AmazonDynamoDBException e) {
+            log.warn("D-11 read failed for uid={} pmid={}: {}", uid, pmid, e.getMessage());
+            return;
+        }
+
+        String existingSrc = null;
+        if (getRes.getItem() != null && getRes.getItem().containsKey("src")) {
+            AttributeValue v = getRes.getItem().get("src");
+            existingSrc = v != null ? v.getS() : null;
+        }
+
+        String newSrc = computeNewSrc(existingSrc);
+
+        // 2. Build conditional UpdateItem
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":new", new AttributeValue().withS(newSrc));
+        values.put(":ts", new AttributeValue().withN(String.valueOf(epochSeconds)));
+
+        UpdateItemRequest req = new UpdateItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withExpressionAttributeValues(values);
+
+        if (existingSrc == null) {
+            // New row: write src + frd, condition on src absence
+            req.withUpdateExpression("SET src = :new, frd = if_not_exists(frd, :ts)")
+               .withConditionExpression("attribute_not_exists(src)");
+        } else if (!newSrc.equals(existingSrc)) {
+            // Transition: condition on observed existing value to detect concurrent write
+            values.put(":existing", new AttributeValue().withS(existingSrc));
+            req.withUpdateExpression("SET src = :new, frd = if_not_exists(frd, :ts)")
+               .withConditionExpression("src = :existing");
+        } else {
+            // No-op on src; ensure frd is present
+            req.withUpdateExpression("SET frd = if_not_exists(frd, :ts)");
+        }
+
+        try {
+            amazonDynamoDB.updateItem(req);
+        } catch (ConditionalCheckFailedException race) {
+            if (allowRetry) {
+                log.info("D-11 race for uid={} pmid={} (existing src changed since GetItem); retrying once",
+                        uid, pmid);
+                applyD11Transition(uid, pmid, epochSeconds, /*allowRetry=*/ false);
+            } else {
+                log.warn("D-11 retry also failed for uid={} pmid={}; giving up (PM UI request continues)",
+                        uid, pmid);
+            }
+        } catch (AmazonDynamoDBException e) {
+            log.warn("D-11 update failed for uid={} pmid={}: {}", uid, pmid, e.getMessage());
+        }
+    }
+
+    /** D-11 transition table. Package-private for testability. */
+    static String computeNewSrc(String existingSrc) {
+        if (existingSrc == null || SRC_GS_PLACEHOLDER.equals(existingSrc)) {
+            return SRC_MAN;
+        }
+        if (SRC_PM.equals(existingSrc)) {
+            return SRC_MAN_FROM_PM;
+        }
+        if (SRC_CTSC.equals(existingSrc)) {
+            return SRC_MAN_FROM_CTSC;
+        }
+        // MAN, MAN_FROM_PM, MAN_FROM_CTSC, or any future value: leave as-is
+        return existingSrc;
     }
 }

--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -23,7 +25,10 @@ import reciter.database.dynamodb.model.GoldStandardAuditLog;
 import reciter.database.dynamodb.model.PmidProvenance;
 import reciter.database.dynamodb.model.PublicationFeedback;
 import reciter.database.dynamodb.repository.DynamoDbGoldStandardRepository;
+import reciter.feedback.EntryPath;
+import reciter.service.ArticleProvenanceService;
 import reciter.service.ESearchResultService;
+import reciter.service.FeedbackLogService;
 import reciter.service.PmidProvenanceService;
 
 @Service("DynamoDbGoldStandardService")
@@ -41,8 +46,33 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     @Autowired
     private PmidProvenanceService pmidProvenanceService;
 
+    @Autowired
+    private FeedbackLogService feedbackLogService;
+
+    @Autowired
+    private ArticleProvenanceService articleProvenanceService;
+
+    // ---- Phase 33-02 4-arg overloads -----------------------------------------------------------
+    // Existing 3-arg save() callers default entryPath to CANDIDATE_LIST. Controllers that want to
+    // distinguish PUBMED_SEARCH actions invoke the 4-arg overload directly.
+
     @Override
     public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource) {
+        save(goldStandard, goldStandardUpdateFlag, provenanceSource, EntryPath.CANDIDATE_LIST);
+    }
+
+    @Override
+    public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource) {
+        save(goldStandard, goldStandardUpdateFlag, provenanceSource, EntryPath.CANDIDATE_LIST);
+    }
+
+    @Override
+    public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+                     String provenanceSource, EntryPath entryPath) {
+        saveInternal(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
+    }
+
+    private void saveInternal(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource, EntryPath entryPath) {
     	// Resolve provenance strategy: caller-supplied source, or default
     	String strategy = (provenanceSource != null && !provenanceSource.isBlank())
     			? provenanceSource : PM_MANUAL_STRATEGY;
@@ -193,6 +223,14 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     					auditLog.addAll(newEntries);
     					goldStandard.setAuditLog(auditLog);
     				}
+    				// Phase 33-02: FeedbackLog rows + ArticleProvenance D-11/D-13 transitions
+    				// for the diff. Inside the same UPDATE branch where existingAccepted/Rejected
+    				// are in scope.
+    				recordFeedbackLogAndArticleProvenance(
+    						goldStandard.getUid(),
+    						incomingAcceptedPmids, incomingRejectedPmids,
+    						existingAccepted, existingRejected,
+    						entryPath);
     			}
     			dynamoDbGoldStandardRepository.save(goldStandard);
     		}
@@ -214,7 +252,12 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     }
 
 	@Override
-	public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource) {
+	public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+	                 String provenanceSource, EntryPath entryPath) {
+		saveListInternal(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
+	}
+
+	private void saveListInternal(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource, EntryPath entryPath) {
 		// Resolve provenance strategy: caller-supplied source, or default
 		String strategy = (provenanceSource != null && !provenanceSource.isBlank())
 				? provenanceSource : PM_MANUAL_STRATEGY;
@@ -296,6 +339,10 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     						auditLog.addAll(newEntries);
     						goldStandardNew.setAuditLog(auditLog);
     					}
+    					// Phase 33-02: per-uid FeedbackLog + ArticleProvenance writes for the diff
+    					recordFeedbackLogAndArticleProvenance(uid,
+    							batchIncomingAccepted, batchIncomingRejected,
+    							existingAccepted, existingRejected, entryPath);
     				}
     			}
     			dynamoDbGoldStandardRepository.saveAll(goldStandard);
@@ -365,6 +412,73 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 		}
 		return entries;
 	}
+	/**
+	 * Phase 33-02: emit FeedbackLog rows + ArticleProvenance D-11/D-13 transitions for
+	 * every curator action implied by the diff between incoming GS state and existing
+	 * GS state. Three buckets:
+	 *
+	 * <ul>
+	 *   <li><b>newly ACCEPTED</b> — pmids in {@code incomingAccepted} not in {@code existingAccepted}</li>
+	 *   <li><b>newly REJECTED</b> — pmids in {@code incomingRejected} not in {@code existingRejected}</li>
+	 *   <li><b>newly PENDING</b> — pmids in {@code (existingAccepted ∪ existingRejected)} that are
+	 *       NOT in {@code (incomingAccepted ∪ incomingRejected)} (state transition to pending)</li>
+	 * </ul>
+	 *
+	 * <p>Each bucket emits one FeedbackLog row per pmid + one ArticleProvenance D-11
+	 * transition. PUBMED_SEARCH entry path additionally writes the rs='PM_UI_SEARCH' record
+	 * before the D-11 transition (D-13). Both services log and continue on failure;
+	 * curator request never blocks.
+	 *
+	 * <p>{@code curatedBy} is set to 0 because the {@code POST /reciter/goldstandard}
+	 * endpoint does not currently carry a userID. Future work: extend the endpoint to
+	 * include curatedBy in the request payload.
+	 */
+	private void recordFeedbackLogAndArticleProvenance(String uid,
+			List<Long> incomingAccepted, List<Long> incomingRejected,
+			List<Long> existingAccepted, List<Long> existingRejected,
+			EntryPath entryPath) {
+		long actionEpoch = System.currentTimeMillis() / 1000L;
+		Set<Long> incomingAccSet = new HashSet<>(incomingAccepted);
+		Set<Long> incomingRejSet = new HashSet<>(incomingRejected);
+		Set<Long> existingAccSet = new HashSet<>(existingAccepted);
+		Set<Long> existingRejSet = new HashSet<>(existingRejected);
+
+		Set<Long> newlyAccepted = new HashSet<>(incomingAccSet);
+		newlyAccepted.removeAll(existingAccSet);
+
+		Set<Long> newlyRejected = new HashSet<>(incomingRejSet);
+		newlyRejected.removeAll(existingRejSet);
+
+		Set<Long> previouslyClassified = new HashSet<>();
+		previouslyClassified.addAll(existingAccSet);
+		previouslyClassified.addAll(existingRejSet);
+		Set<Long> stillClassified = new HashSet<>();
+		stillClassified.addAll(incomingAccSet);
+		stillClassified.addAll(incomingRejSet);
+		Set<Long> newlyPending = new HashSet<>(previouslyClassified);
+		newlyPending.removeAll(stillClassified);
+
+		int total = newlyAccepted.size() + newlyRejected.size() + newlyPending.size();
+		if (total == 0) {
+			return;
+		}
+		log.info("Phase 33-02: feedback diff for uid={} entryPath={}: +{} accepted, +{} rejected, +{} pending",
+				uid, entryPath, newlyAccepted.size(), newlyRejected.size(), newlyPending.size());
+
+		for (Long pmid : newlyAccepted) {
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.ACCEPTED, 0, actionEpoch);
+			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
+		}
+		for (Long pmid : newlyRejected) {
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.REJECTED, 0, actionEpoch);
+			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
+		}
+		for (Long pmid : newlyPending) {
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.PENDING, 0, actionEpoch);
+			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
+		}
+	}
+
 	/**
 	 * Write PmidProvenance records for accepted PMIDs. Uses saveIfNotExists
 	 * so that PMIDs already discovered by automated retrieval strategies

--- a/src/main/java/reciter/service/dynamo/FeedbackLogServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/FeedbackLogServiceImpl.java
@@ -1,0 +1,99 @@
+package reciter.service.dynamo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
+
+import reciter.service.FeedbackLogService;
+
+/**
+ * Phase 33-02 implementation of {@link FeedbackLogService}.
+ *
+ * <p>Uses raw {@code AmazonDynamoDB.putItem} with {@code attribute_not_exists(sk)}
+ * for idempotency. The sk is {@code "<epoch_seconds>#<nano-derived-hex>"} which
+ * gives microsecond-resolution uniqueness within a single process; cross-process
+ * collisions are caught by the conditional and retried with a fresh suffix.
+ *
+ * <p>{@code src='MAN'} on every row — Phase 32 D-03: PM UI is the only source for
+ * this table going forward (CTSC ingestion bypasses PM and writes directly to
+ * GoldStandard).
+ */
+@Service
+public class FeedbackLogServiceImpl implements FeedbackLogService {
+
+    private static final Logger log = LoggerFactory.getLogger(FeedbackLogServiceImpl.class);
+    private static final String TABLE_NAME = "FeedbackLog";
+    private static final String SRC_MAN = "MAN";
+    private static final int SK_RETRY_LIMIT = 5;
+
+    private final AmazonDynamoDB amazonDynamoDB;
+
+    public FeedbackLogServiceImpl(AmazonDynamoDB amazonDynamoDB) {
+        this.amazonDynamoDB = amazonDynamoDB;
+    }
+
+    @Override
+    public void recordAction(String uid, long pmid, Feedback feedback, int curatedBy, long actionEpochSeconds) {
+        if (uid == null || uid.isEmpty()) {
+            log.warn("recordAction called with null/empty uid; skipping (pmid={})", pmid);
+            return;
+        }
+        if (feedback == null) {
+            log.warn("recordAction called with null feedback; skipping (uid={} pmid={})", uid, pmid);
+            return;
+        }
+
+        for (int attempt = 0; attempt < SK_RETRY_LIMIT; attempt++) {
+            String sk = buildSk(actionEpochSeconds);
+            Map<String, AttributeValue> item = new HashMap<>();
+            item.put("uid", new AttributeValue().withS(uid));
+            item.put("sk", new AttributeValue().withS(sk));
+            item.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+            item.put("feedback", new AttributeValue().withS(feedback.name()));
+            item.put("curatedBy", new AttributeValue().withN(String.valueOf(curatedBy)));
+            item.put("src", new AttributeValue().withS(SRC_MAN));
+            item.put("createTimestamp", new AttributeValue().withN(String.valueOf(actionEpochSeconds)));
+            item.put("modifyTimestamp", new AttributeValue().withN(String.valueOf(actionEpochSeconds)));
+
+            PutItemRequest req = new PutItemRequest()
+                    .withTableName(TABLE_NAME)
+                    .withItem(item)
+                    .withConditionExpression("attribute_not_exists(sk)");
+
+            try {
+                amazonDynamoDB.putItem(req);
+                return;
+            } catch (ConditionalCheckFailedException race) {
+                // sk collision (extremely unlikely with 8 hex chars); retry with fresh suffix
+                log.info("FeedbackLog sk collision for uid={} sk={}; retrying (attempt {})",
+                        uid, sk, attempt + 1);
+            } catch (AmazonDynamoDBException e) {
+                log.warn("FeedbackLog write failed for uid={} pmid={}: {}", uid, pmid, e.getMessage());
+                return;
+            }
+        }
+        log.warn("FeedbackLog write hit retry limit for uid={} pmid={}; giving up", uid, pmid);
+    }
+
+    /**
+     * Build a unique sk: epoch + '#' + last 8 hex digits of nanoTime.
+     * Within a single JVM, nanoTime is monotonically increasing, so collisions
+     * within a process are vanishingly rare. Cross-process collisions are caught
+     * by the conditional put.
+     */
+    private String buildSk(long epochSeconds) {
+        long nano = System.nanoTime();
+        // Mask to 32 bits (8 hex digits)
+        String hexSuffix = String.format("%08x", (int) (nano & 0xFFFFFFFFL));
+        return epochSeconds + "#" + hexSuffix;
+    }
+}

--- a/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
@@ -8,6 +8,18 @@ import reciter.database.dynamodb.model.GoldStandard;
 public interface IDynamoDbGoldStandardService {
     void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource);
     void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource);
+
+    /**
+     * Phase 33-02 overload propagating the PM UI entry path so the service can
+     * apply Phase 33 D-13 (PM_UI_SEARCH retrieval write) before the D-11 transition.
+     * Pre-existing 3-arg signatures default {@code entryPath} to
+     * {@link reciter.feedback.EntryPath#CANDIDATE_LIST}.
+     */
+    void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+              String provenanceSource, reciter.feedback.EntryPath entryPath);
+    void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+              String provenanceSource, reciter.feedback.EntryPath entryPath);
+
     GoldStandard findByUid(String uid);
     List<GoldStandard> findByUids(List<String> uid);
     void delete(String uid);

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,10 +18,18 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Collections;
+import java.util.HashMap;
+
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+
+import reciter.feedback.EntryPath;
 
 /**
  * Unit tests for {@link ArticleProvenanceServiceImpl}.
@@ -162,5 +171,176 @@ public class ArticleProvenanceServiceImplTest {
     public void testUpsert_EmptyStrategyCode_SkipsCallEntirely() {
         service.upsertRetrievalProvenance("uid1", 100L, "", 1700000000L);
         verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Phase 33-02: D-11 transition table tests via computeNewSrc + upsertCuratorAction
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    public void testComputeNewSrc_AbsentToMan() {
+        assertEquals("MAN", ArticleProvenanceServiceImpl.computeNewSrc(null));
+    }
+
+    @Test
+    public void testComputeNewSrc_GsToMan() {
+        assertEquals("MAN", ArticleProvenanceServiceImpl.computeNewSrc("GS"));
+    }
+
+    @Test
+    public void testComputeNewSrc_PmToManFromPm() {
+        assertEquals("MAN_FROM_PM", ArticleProvenanceServiceImpl.computeNewSrc("PM"));
+    }
+
+    @Test
+    public void testComputeNewSrc_CtscToManFromCtsc() {
+        assertEquals("MAN_FROM_CTSC", ArticleProvenanceServiceImpl.computeNewSrc("CTSC"));
+    }
+
+    @Test
+    public void testComputeNewSrc_ManIsNoop() {
+        assertEquals("MAN", ArticleProvenanceServiceImpl.computeNewSrc("MAN"));
+    }
+
+    @Test
+    public void testComputeNewSrc_ManFromPmIsNoop() {
+        assertEquals("MAN_FROM_PM", ArticleProvenanceServiceImpl.computeNewSrc("MAN_FROM_PM"));
+    }
+
+    @Test
+    public void testComputeNewSrc_ManFromCtscIsNoop() {
+        assertEquals("MAN_FROM_CTSC", ArticleProvenanceServiceImpl.computeNewSrc("MAN_FROM_CTSC"));
+    }
+
+    private void stubGetItemSrc(String existingSrc) {
+        GetItemResult result = new GetItemResult();
+        if (existingSrc != null) {
+            HashMap<String, AttributeValue> item = new HashMap<>();
+            item.put("src", new AttributeValue().withS(existingSrc));
+            result.setItem(item);
+        }
+        when(amazonDynamoDB.getItem(any(GetItemRequest.class))).thenReturn(result);
+    }
+
+    @Test
+    public void testCuratorAction_NoExisting_CandidateList_WritesSrcMan() {
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        UpdateItemRequest req = captor.getValue();
+        assertEquals("MAN", req.getExpressionAttributeValues().get(":new").getS());
+        assertEquals("attribute_not_exists(src)", req.getConditionExpression());
+        assertTrue("UpdateExpression must SET src and frd: " + req.getUpdateExpression(),
+                req.getUpdateExpression().contains("SET src = :new")
+                        && req.getUpdateExpression().contains("frd = if_not_exists(frd, :ts)"));
+    }
+
+    @Test
+    public void testCuratorAction_ExistingPm_CandidateList_TransitionsToManFromPm() {
+        stubGetItemSrc("PM");
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        UpdateItemRequest req = captor.getValue();
+        assertEquals("MAN_FROM_PM", req.getExpressionAttributeValues().get(":new").getS());
+        assertEquals("PM", req.getExpressionAttributeValues().get(":existing").getS());
+        assertEquals("src = :existing", req.getConditionExpression());
+    }
+
+    @Test
+    public void testCuratorAction_ExistingCtsc_CandidateList_TransitionsToManFromCtsc() {
+        stubGetItemSrc("CTSC");
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        UpdateItemRequest req = captor.getValue();
+        assertEquals("MAN_FROM_CTSC", req.getExpressionAttributeValues().get(":new").getS());
+        assertEquals("CTSC", req.getExpressionAttributeValues().get(":existing").getS());
+    }
+
+    @Test
+    public void testCuratorAction_ExistingManFromPm_CandidateList_NoSrcChangeOnlyFrdMaintenance() {
+        stubGetItemSrc("MAN_FROM_PM");
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        UpdateItemRequest req = captor.getValue();
+        // Should write only frd (idempotent on src)
+        assertTrue("Expression must be only frd if_not_exists: " + req.getUpdateExpression(),
+                req.getUpdateExpression().equals("SET frd = if_not_exists(frd, :ts)"));
+        // No condition (since src is already correct)
+        assertTrue("No conditional needed for noop: " + req.getConditionExpression(),
+                req.getConditionExpression() == null);
+    }
+
+    @Test
+    public void testCuratorAction_PubmedSearch_NewPmid_WritesPmUiSearchThenManFromPm() {
+        stubGetItemSrc(null);
+        // First updateItem call is the PM_UI_SEARCH retrieval-record write (D-13)
+        // Second updateItem call is the D-11 transition (which sees no existing src after the
+        // mock GetItem; in real life GetItem would read what D-13 just wrote, but we control
+        // the mock to verify the two-step sequence).
+        service.upsertCuratorAction("uid1", 100L, EntryPath.PUBMED_SEARCH, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB, times(2)).updateItem(captor.capture());
+        UpdateItemRequest first = captor.getAllValues().get(0);
+        // Step 1: PM_UI_SEARCH retrieval-record write
+        assertTrue("First call must SET rs to PM_UI_SEARCH if absent: " + first.getUpdateExpression(),
+                first.getUpdateExpression().contains("rs  = if_not_exists(rs,  :rs)"));
+        assertEquals("PM_UI_SEARCH", first.getExpressionAttributeValues().get(":rs").getS());
+        assertEquals("PM", first.getExpressionAttributeValues().get(":pm").getS());
+        assertNotNull(first.getExpressionAttributeValues().get(":rsSet"));
+        assertEquals("PM_UI_SEARCH", first.getExpressionAttributeValues().get(":rsSet").getSS().get(0));
+    }
+
+    @Test
+    public void testCuratorAction_PubmedSearch_TwoUpdateItemCallsSequence() {
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.PUBMED_SEARCH, 1700000000L);
+        // PUBMED_SEARCH path: 1 PM_UI_SEARCH write + 1 D-11 transition = 2 updateItem calls
+        verify(amazonDynamoDB, times(2)).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_CandidateList_OneUpdateItemCall() {
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+        // CANDIDATE_LIST path: only the D-11 transition = 1 updateItem call
+        verify(amazonDynamoDB, times(1)).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_NullUid_SkipsCallEntirely() {
+        service.upsertCuratorAction(null, 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+        verify(amazonDynamoDB, never()).getItem(any(GetItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_NullEntryPath_DefaultsCandidateList() {
+        stubGetItemSrc("PM");
+        service.upsertCuratorAction("uid1", 100L, null, 1700000000L);
+        // Should be 1 updateItem call (CANDIDATE_LIST path)
+        verify(amazonDynamoDB, times(1)).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_RaceOnUpdate_RetriesOnce() {
+        stubGetItemSrc("PM");
+        when(amazonDynamoDB.updateItem(any(UpdateItemRequest.class)))
+                .thenThrow(new ConditionalCheckFailedException("race"))
+                .thenReturn(null);  // second attempt succeeds
+
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+        // 2 updateItem invocations: original + 1 retry
+        verify(amazonDynamoDB, times(2)).updateItem(any(UpdateItemRequest.class));
+        // GetItem is called twice (once initial, once on retry)
+        verify(amazonDynamoDB, times(2)).getItem(any(GetItemRequest.class));
     }
 }

--- a/src/test/java/reciter/service/dynamo/FeedbackLogServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/FeedbackLogServiceImplTest.java
@@ -1,0 +1,141 @@
+package reciter.service.dynamo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
+
+import reciter.service.FeedbackLogService;
+import reciter.service.FeedbackLogService.Feedback;
+
+/**
+ * Unit tests for {@link FeedbackLogServiceImpl}.
+ *
+ * <p>Covers Phase 32 D-01 (schema), D-02 (sk format), D-03 (src=MAN), D-04 (feedback enum),
+ * and Phase 33-02 idempotency / retry semantics.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FeedbackLogServiceImplTest {
+
+    @Mock
+    private AmazonDynamoDB amazonDynamoDB;
+
+    private FeedbackLogServiceImpl service;
+
+    @Before
+    public void setUp() {
+        service = new FeedbackLogServiceImpl(amazonDynamoDB);
+    }
+
+    private PutItemRequest captureRequest() {
+        ArgumentCaptor<PutItemRequest> captor = ArgumentCaptor.forClass(PutItemRequest.class);
+        verify(amazonDynamoDB).putItem(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void testRecordAction_TableNameIsFeedbackLog() {
+        service.recordAction("ajg9004", 12345L, Feedback.ACCEPTED, 3, 1700000000L);
+        assertEquals("FeedbackLog", captureRequest().getTableName());
+    }
+
+    @Test
+    public void testRecordAction_ItemHasFullSchema() {
+        service.recordAction("ajg9004", 12345L, Feedback.ACCEPTED, 3, 1700000000L);
+        Map<String, AttributeValue> item = captureRequest().getItem();
+        assertEquals("ajg9004", item.get("uid").getS());
+        assertEquals("12345", item.get("articleId").getS());
+        assertEquals("ACCEPTED", item.get("feedback").getS());
+        assertEquals("3", item.get("curatedBy").getN());
+        assertEquals("MAN", item.get("src").getS());
+        assertEquals("1700000000", item.get("createTimestamp").getN());
+        assertEquals("1700000000", item.get("modifyTimestamp").getN());
+        assertNotNull(item.get("sk"));
+    }
+
+    @Test
+    public void testRecordAction_SkFormat_EpochHashHex() {
+        service.recordAction("uid1", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        String sk = captureRequest().getItem().get("sk").getS();
+        // Format: "<epoch>#<8-hex>"
+        assertTrue("sk should match epoch#hex format: " + sk,
+                sk.matches("^\\d+#[0-9a-f]{8}$"));
+        assertTrue("sk should start with the epoch: " + sk,
+                sk.startsWith("1700000000#"));
+    }
+
+    @Test
+    public void testRecordAction_ConditionExpression_PreventsCollision() {
+        service.recordAction("uid1", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        assertEquals("attribute_not_exists(sk)", captureRequest().getConditionExpression());
+    }
+
+    @Test
+    public void testRecordAction_FeedbackRejected_WritesRejected() {
+        service.recordAction("uid1", 1L, Feedback.REJECTED, 0, 1700000000L);
+        assertEquals("REJECTED", captureRequest().getItem().get("feedback").getS());
+    }
+
+    @Test
+    public void testRecordAction_FeedbackPending_WritesPending() {
+        service.recordAction("uid1", 1L, Feedback.PENDING, 0, 1700000000L);
+        assertEquals("PENDING", captureRequest().getItem().get("feedback").getS());
+    }
+
+    @Test
+    public void testRecordAction_SkCollision_RetriesWithFreshSuffix() {
+        when(amazonDynamoDB.putItem(any(PutItemRequest.class)))
+                .thenThrow(new ConditionalCheckFailedException("collision"))
+                .thenReturn(null);  // second attempt succeeds
+
+        service.recordAction("uid1", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        verify(amazonDynamoDB, times(2)).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    public void testRecordAction_DynamoDbException_LoggedNotThrown() {
+        when(amazonDynamoDB.putItem(any(PutItemRequest.class)))
+                .thenThrow(new AmazonDynamoDBException("simulated"));
+
+        service.recordAction("uid1", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        // Single attempt (non-CCE exceptions are not retried)
+        verify(amazonDynamoDB, times(1)).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    public void testRecordAction_NullUid_SkipsCallEntirely() {
+        service.recordAction(null, 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        verify(amazonDynamoDB, never()).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    public void testRecordAction_EmptyUid_SkipsCallEntirely() {
+        service.recordAction("", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        verify(amazonDynamoDB, never()).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    public void testRecordAction_NullFeedback_SkipsCallEntirely() {
+        service.recordAction("uid1", 1L, null, 0, 1700000000L);
+        verify(amazonDynamoDB, never()).putItem(any(PutItemRequest.class));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 33-02 of v7.0. Stacked on #610 (Phase 33-01). Wires curator actions through `POST/PUT /reciter/goldstandard` to two new sinks:

1. **`FeedbackLog` (DynamoDB)** — one item per curator action with the Phase 32 schema. PutItem with `attribute_not_exists(sk)` for idempotency. sk = `<epoch>#<8-hex-of-nanoTime>`; collisions retry up to 5x with fresh suffix.
2. **`ArticleProvenance` D-11 / D-13 transitions** — read-then-conditional-update with the unified rule:

   | existing src | new src |
   |---|---|
   | absent or `GS` | `MAN` |
   | `PM` | `MAN_FROM_PM` |
   | `CTSC` | `MAN_FROM_CTSC` |
   | `MAN` / `MAN_FROM_*` | unchanged |

   Plus D-13: when the curator action originated from PM UI's PubMed search workflow (`?entryPath=PUBMED_SEARCH`), the service first writes a retrieval-style record with `rs='PM_UI_SEARCH'` and adds the strategy to `ads`, then applies the D-11 transition. The composite `MAN_FROM_PM` value combined with `ads` membership lets analysts later distinguish four cohorts (algo missed entirely / PM UI search rediscovered sub-threshold / regular candidate-list curation / CTSC-touched-by-curator) — see `33-CONTEXT.md` in the planning repo.

## Schema additions

- New `reciter.feedback.EntryPath` enum (`CANDIDATE_LIST` | `PUBMED_SEARCH`) with case-insensitive `fromString()`. Added in this repo (not in `reciter-article-model` JAR) to avoid a cross-repo Maven release.
- `IDynamoDbGoldStandardService.save()` gets 4-arg overloads taking `EntryPath`. Existing 3-arg signatures default to `CANDIDATE_LIST` → backwards-compatible.
- `POST/PUT /reciter/goldstandard` accepts a new optional `?entryPath=CANDIDATE_LIST|PUBMED_SEARCH` query parameter. Default `CANDIDATE_LIST`. PM UI updates to emit this on PubMed-search-originated actions are a follow-up in `wcmc-its/ReCiter-Publication-Manager`.

## Diff logic

`DynamoDbGoldStandardService` now computes three buckets per UPDATE call: newly-accepted, newly-rejected, and **newly-pending** (items in existing accepted/rejected that are no longer in either incoming list — i.e., curator un-accepted or un-rejected to PENDING state). Each bucket emits one FeedbackLog row + one ArticleProvenance D-11 transition. Note `curatedBy=0` because the goldstandard endpoint does not yet carry a userID; future work to plumb that through.

## Test plan

- [x] `mvn compile` clean
- [x] 28 new ArticleProvenanceServiceImpl tests (D-11 transition table via `computeNewSrc`, CANDIDATE_LIST vs PUBMED_SEARCH path semantics, race retry, null/default handling)
- [x] 11 new FeedbackLogServiceImpl tests (schema, sk format, all 3 feedback values, sk collision retry, exception swallowing, null guards)
- [x] Full `mvn test`: 77 total, 39 new tests pass, 0 new failures (pre-existing `TargetAuthorSelectionTest` NPEs unchanged)
- [ ] Local end-to-end smoke (post-merge of #610)
- [ ] Dev EKS deploy via `ReCiter` CodePipeline ManualApproval
- [ ] Dev validation with `scripts/spot_check_feedback_log.py --strict` (extended in the planning repo to assert the new schema invariants)

## Notes

Provenance + FeedbackLog write failures never block the curator request (logged at WARN, swallowed). PmidProvenance writes intentionally preserved for the 2-week soak window per Phase 33 D-15/D-16; cleanup is a separate post-soak PR.