### PR TITLE
Phase 33-01b: write src=PM on retrieval-found AP items via if_not_exists

### DIFF
--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -70,13 +70,22 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
         values.put(":strategy", new AttributeValue().withS(strategyCode));
         values.put(":now", new AttributeValue().withN(String.valueOf(epochSeconds)));
         values.put(":strategySet", new AttributeValue().withSS(Collections.singletonList(strategyCode)));
+        values.put(":pm", new AttributeValue().withS(SRC_PM));
 
+        // src is set to 'PM' only when currently absent. This matches Phase 31's Python
+        // backfill behavior, which wrote src='PM' for every retrieval-found item. Without
+        // this, brand-new AP rows created by Phase 33-01 would have src absent, and a
+        // subsequent curator action would incorrectly transition src=null -> 'MAN'
+        // (algo-missed) instead of -> 'MAN_FROM_PM' (algo-found, then curator-touched).
+        // The if_not_exists guard preserves existing src values (CTSC, MAN, MAN_FROM_*)
+        // so the curator/CTSC paths retain ownership of src per Phase 33 D-04 intent.
         UpdateItemRequest req = new UpdateItemRequest()
                 .withTableName(TABLE_NAME)
                 .withKey(key)
                 .withUpdateExpression(
                         "SET rs = if_not_exists(rs, :strategy), " +
-                        "    frd = if_not_exists(frd, :now) " +
+                        "    frd = if_not_exists(frd, :now), " +
+                        "    src = if_not_exists(src, :pm) " +
                         "ADD ads :strategySet")
                 .withExpressionAttributeValues(values);
 

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -104,14 +104,18 @@ public class ArticleProvenanceServiceImplTest {
     }
 
     @Test
-    public void testUpsert_DoesNotTouchSrc() {
+    public void testUpsert_PreservesExistingSrc_OnlySetsPmIfAbsent() {
         service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
         UpdateItemRequest req = captureRequest();
 
         String expr = req.getUpdateExpression();
-        // Phase 33 D-04: retrieval path never writes src.
-        assertTrue("UpdateExpression must not contain 'src': " + expr,
-                !expr.contains("src"));
+        // Phase 33-01b: retrieval sets src='PM' only when src is currently absent.
+        // The if_not_exists guard preserves existing src values (CTSC, MAN, MAN_FROM_*)
+        // so the curator/CTSC paths retain ownership of src per D-04 spirit, while
+        // matching Phase 31's behavior of writing src='PM' on retrieval-found items.
+        assertTrue("UpdateExpression must use if_not_exists(src, :pm): " + expr,
+                expr.contains("src = if_not_exists(src, :pm)"));
+        assertEquals("PM", req.getExpressionAttributeValues().get(":pm").getS());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Bug fix on top of #610 (Phase 33-01). Live dev deploy revealed that Phase 33-01's `trackNewPmids()` was creating brand-new ArticleProvenance rows with `rs/frd/ads` but **`src=absent`** — inconsistent with Phase 31's Python backfill, which wrote `src='PM'` for every retrieval-found item.

## Why this matters

The 615 newly-discovered PMIDs we observed on dev today (in ajg9004's `feature-generator` run) all had `src=absent`. If a curator later ACCEPT/REJECT/PENDINGs one of these, the D-11 transition rule sees `src=null` and writes `src='MAN'` (algo-missed), incorrectly attributing the PMID to the "curator added from nothing" cohort. Reality: the algo *did* find it.

Net effect without this fix: the algo-coverage signal (the whole point of the composite-src design) gets silently inflated on the `MAN` side over time as curators interact with newly-retrieved articles.

## The fix

One-line change to the `UpdateExpression` in `ArticleProvenanceServiceImpl.upsertRetrievalProvenance`:

```diff
- "SET rs = if_not_exists(rs, :strategy), frd = if_not_exists(frd, :now) ADD ads :strategySet"
+ "SET rs = if_not_exists(rs, :strategy), frd = if_not_exists(frd, :now), src = if_not_exists(src, :pm) ADD ads :strategySet"
```

`if_not_exists` preserves existing src values (`CTSC`, `MAN`, `MAN_FROM_PM`, `MAN_FROM_CTSC`) so curator/CTSC ownership of src per Phase 33 D-04's spirit is maintained — we're just adding the missing first-time-retrieval case that Phase 31 always handled.

## Dev backfill

The 615 dev items affected by the original Phase 33-01 deploy were backfilled out-of-band via a one-off Python pass (set src=PM where rs present and src absent). 0 residual items with rs+no-src remain in dev.

## Test plan

- [x] `mvn test -Dtest='ArticleProvenanceServiceImplTest,FeedbackLogServiceImplTest'`: 39/39 pass
- [x] Existing `testUpsert_DoesNotTouchSrc` (which was based on the wrong intent) is replaced with `testUpsert_PreservesExistingSrc_OnlySetsPmIfAbsent` asserting the corrected expression
- [ ] Dev cutover via `ReCiter` CodePipeline ManualApproval
- [ ] Spot-check post-deploy: `scripts/spot_check_feedback_log.py --strict` against the 4 continuity uids; trigger a fresh feature-generator on one to verify newly-discovered items now get src=PM

## Notes

This is the only behavior fix needed before opening the `development → master` PR. After this lands and dev is reverified, the production cutover PR will include #610, #611, and #612 in one bundled merge to `master`.