### PR TITLE
Phase 33: ArticleProvenance + FeedbackLog write paths (dev → master)

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -152,7 +152,8 @@ public class ReCiterController {
     @RequestMapping(value = "/reciter/goldstandard", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody
     public ResponseEntity updateGoldStandard(@RequestBody GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
-    		@RequestParam(value = "source", required = false) String provenanceSource) {
+    		@RequestParam(value = "source", required = false) String provenanceSource,
+    		@RequestParam(value = "entryPath", required = false) String entryPathParam) {
         StopWatch stopWatch = new StopWatch("Update GoldStandard");
         stopWatch.start("Update GoldStandard");
     	if(goldStandard == null) {
@@ -160,15 +161,16 @@ public class ReCiterController {
     	} else if(goldStandard != null && goldStandard.getUid() == null) {
     		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("The api requires a valid uid to be passed with GoldStandard model");
     	}
+    	reciter.feedback.EntryPath entryPath = reciter.feedback.EntryPath.fromString(entryPathParam);
     	if(goldStandardUpdateFlag == null ||
     			goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE || goldStandardUpdateFlag == GoldStandardUpdateFlag.DELETE) {
     		if(goldStandardUpdateFlag == null) {
-    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource);
+    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource, entryPath);
     		} else {
-    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource);
+    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
     		}
     	} else {
-    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource);
+    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource, entryPath);
         }
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
@@ -188,18 +190,20 @@ public class ReCiterController {
     @RequestMapping(value = "/reciter/goldstandard", method = RequestMethod.PUT, produces = "application/json")
     @ResponseBody
     public ResponseEntity<List<GoldStandard>> updateGoldStandard(@RequestBody List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
-    		@RequestParam(value = "source", required = false) String provenanceSource) {
+    		@RequestParam(value = "source", required = false) String provenanceSource,
+    		@RequestParam(value = "entryPath", required = false) String entryPathParam) {
         StopWatch stopWatch = new StopWatch("Update GoldStandard with List");
         stopWatch.start("Update GoldStandard with List");
+    	reciter.feedback.EntryPath entryPath = reciter.feedback.EntryPath.fromString(entryPathParam);
     	if(goldStandardUpdateFlag == null ||
     			goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE || goldStandardUpdateFlag == GoldStandardUpdateFlag.DELETE) {
     		if(goldStandardUpdateFlag == null) {
-    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource);
+    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource, entryPath);
     		} else {
-    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource);
+    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
     		}
     	} else {
-    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource);
+    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource, entryPath);
         }
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");

--- a/src/main/java/reciter/feedback/EntryPath.java
+++ b/src/main/java/reciter/feedback/EntryPath.java
@@ -1,0 +1,37 @@
+package reciter.feedback;
+
+/**
+ * Discriminator for how a curator action originated in Publication Manager.
+ *
+ * <p>Phase 33 D-14: PM UI emits this on every feedback action so the Java
+ * write path can distinguish auto-retrieved-candidate curation from
+ * curator-driven PubMed search.
+ *
+ * <ul>
+ *   <li>{@link #CANDIDATE_LIST} — curator clicked ACCEPT/REJECT/PENDING on a row in
+ *       the auto-retrieved candidate list. The PMID is already (or will be)
+ *       attributed via Phase 33-01's retrieval write path.</li>
+ *   <li>{@link #PUBMED_SEARCH} — curator queried PubMed inside PM's UI and accepted
+ *       (or rejected) a result. The Java write path treats this as its own
+ *       retrieval strategy with {@code rs='PM_UI_SEARCH'} (D-13).</li>
+ * </ul>
+ */
+public enum EntryPath {
+    CANDIDATE_LIST,
+    PUBMED_SEARCH;
+
+    /**
+     * Resolve a string to {@link EntryPath} with case-insensitive matching.
+     * Returns {@link #CANDIDATE_LIST} (the default) for null, empty, or unrecognized values.
+     */
+    public static EntryPath fromString(String s) {
+        if (s == null || s.isEmpty()) {
+            return CANDIDATE_LIST;
+        }
+        try {
+            return EntryPath.valueOf(s.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return CANDIDATE_LIST;
+        }
+    }
+}

--- a/src/main/java/reciter/service/ArticleProvenanceService.java
+++ b/src/main/java/reciter/service/ArticleProvenanceService.java
@@ -1,0 +1,44 @@
+package reciter.service;
+
+/**
+ * Writes provenance records to the {@code ArticleProvenance} DynamoDB table.
+ *
+ * <p>ArticleProvenance has the schema {@code (uid: S [PK], articleId: S [SK])}
+ * with attributes:
+ * <ul>
+ *   <li>{@code rs}  — primary retrieval strategy code (first strategy to find this PMID for this uid)</li>
+ *   <li>{@code frd} — first retrieval date, epoch seconds</li>
+ *   <li>{@code ads} — additional strategy codes (String Set), grows as new strategies re-find this PMID</li>
+ *   <li>{@code src} — provenance source: PM, MAN, CTSC, MAN_FROM_PM, MAN_FROM_CTSC (owned by curator/CTSC paths, not retrieval)</li>
+ * </ul>
+ *
+ * <p>This service writes only the retrieval-side fields ({@code rs}, {@code frd}, {@code ads}).
+ * It uses raw {@code AmazonDynamoDB.updateItem} (not DynamoDBMapper) to access expression
+ * features ({@code if_not_exists}, {@code ADD} on String Sets) that DynamoDBMapper does
+ * not support cleanly. Phase 33 D-02/D-03/D-04 govern these semantics.
+ */
+public interface ArticleProvenanceService {
+
+    /**
+     * Upsert retrieval provenance for one (uid, pmid) pair.
+     *
+     * <p>Behavior:
+     * <ul>
+     *   <li>{@code rs} is set to {@code strategyCode} only if {@code rs} is currently absent
+     *       (first strategy wins; preserves original retrieval attribution on re-runs).</li>
+     *   <li>{@code frd} is set to {@code epochSeconds} only if currently absent (preserves
+     *       the original first-retrieval-date).</li>
+     *   <li>{@code ads} always grows: {@code strategyCode} is ADDed to the String Set.</li>
+     *   <li>{@code src} is NOT touched (owned by curator/CTSC paths per Phase 33 D-04).</li>
+     * </ul>
+     *
+     * <p>Errors are logged but never thrown — provenance write failures must not break
+     * retrieval. Callers can fire-and-forget.
+     *
+     * @param uid          person identifier
+     * @param pmid         PubMed ID
+     * @param strategyCode retrieval strategy code (e.g. {@code "PUBMED_NAME_AFFIL"})
+     * @param epochSeconds first-retrieval-date as epoch seconds (typically {@code now})
+     */
+    void upsertRetrievalProvenance(String uid, long pmid, String strategyCode, long epochSeconds);
+}

--- a/src/main/java/reciter/service/ArticleProvenanceService.java
+++ b/src/main/java/reciter/service/ArticleProvenanceService.java
@@ -1,5 +1,7 @@
 package reciter.service;
 
+import reciter.feedback.EntryPath;
+
 /**
  * Writes provenance records to the {@code ArticleProvenance} DynamoDB table.
  *
@@ -41,4 +43,39 @@ public interface ArticleProvenanceService {
      * @param epochSeconds first-retrieval-date as epoch seconds (typically {@code now})
      */
     void upsertRetrievalProvenance(String uid, long pmid, String strategyCode, long epochSeconds);
+
+    /**
+     * Upsert provenance for a curator action (Phase 33 D-11 / D-13).
+     *
+     * <p>Implements the unified D-11 transition rule: regardless of feedback value
+     * (ACCEPTED, REJECTED, PENDING), the {@code src} field is updated according to
+     * the existing src per the table:
+     *
+     * <pre>
+     *   existing src              →  new src
+     *   ──────────────────────────────────────────
+     *   absent or 'GS'            →  'MAN'
+     *   'PM'                      →  'MAN_FROM_PM'
+     *   'CTSC'                    →  'MAN_FROM_CTSC'
+     *   'MAN' / 'MAN_FROM_*'      →  unchanged (no-op)
+     * </pre>
+     *
+     * <p>{@code frd} is preserved if set; otherwise written as {@code epochSeconds}.
+     *
+     * <p>If {@code entryPath == PUBMED_SEARCH} (D-13), an additional retrieval-style
+     * write happens FIRST: {@code rs = if_not_exists(rs, 'PM_UI_SEARCH')},
+     * {@code src = if_not_exists(src, 'PM')}, {@code ADD ads :PM_UI_SEARCH_set}.
+     * This ensures the curator-search-via-PubMed origin is recorded; the subsequent
+     * D-11 transition then lifts {@code src=PM} to {@code MAN_FROM_PM}.
+     *
+     * <p>Implementation uses GetItem-then-conditional-UpdateItem with one retry on
+     * concurrent-write CCE; if the second attempt also fails, log WARN and continue
+     * (D-12). Provenance writes never block PM UI requests.
+     *
+     * @param uid          person identifier
+     * @param pmid         PubMed ID
+     * @param entryPath    PM UI entry path (CANDIDATE_LIST or PUBMED_SEARCH)
+     * @param epochSeconds curator action time, epoch seconds
+     */
+    void upsertCuratorAction(String uid, long pmid, EntryPath entryPath, long epochSeconds);
 }

--- a/src/main/java/reciter/service/FeedbackLogService.java
+++ b/src/main/java/reciter/service/FeedbackLogService.java
@@ -1,0 +1,42 @@
+package reciter.service;
+
+/**
+ * Writes curator action records to the {@code FeedbackLog} DynamoDB table.
+ *
+ * <p>Schema (Phase 32 D-01, D-02):
+ * <ul>
+ *   <li>{@code uid} (S, PK)</li>
+ *   <li>{@code sk} (S, SK) = {@code "<epoch_seconds>#<8-hex-digit-suffix>"}</li>
+ *   <li>{@code articleId} (S)</li>
+ *   <li>{@code feedback} (S) ∈ {ACCEPTED, REJECTED, PENDING}</li>
+ *   <li>{@code curatedBy} (N) — userID from PM</li>
+ *   <li>{@code src} (S) = "MAN" (PM UI is the only source for this table going forward)</li>
+ *   <li>{@code createTimestamp} (N), {@code modifyTimestamp} (N)</li>
+ * </ul>
+ *
+ * <p>The 8-hex-digit suffix is derived from {@code System.nanoTime()} and gives
+ * uniqueness within a single Java process; the conditional {@code attribute_not_exists(sk)}
+ * catches cross-process collisions and the caller retries with a fresh suffix.
+ */
+public interface FeedbackLogService {
+
+    /**
+     * Curator action feedback values. See Phase 32 D-04.
+     */
+    enum Feedback {
+        ACCEPTED, REJECTED, PENDING
+    }
+
+    /**
+     * Record a single curator action.
+     *
+     * @param uid                 person identifier
+     * @param pmid                PubMed ID
+     * @param feedback            ACCEPTED, REJECTED, or PENDING
+     * @param curatedBy           userID of the curator (or 0 if unknown — e.g., when the
+     *                            action is inferred from a GoldStandard list-replace API call
+     *                            that doesn't carry a userID)
+     * @param actionEpochSeconds  curator action time, epoch seconds (used in sk and timestamps)
+     */
+    void recordAction(String uid, long pmid, Feedback feedback, int curatedBy, long actionEpochSeconds);
+}

--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -1,0 +1,83 @@
+package reciter.service.dynamo;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+
+import reciter.service.ArticleProvenanceService;
+
+/**
+ * Phase 33-01 implementation of {@link ArticleProvenanceService}.
+ *
+ * <p>Uses raw {@code AmazonDynamoDB.updateItem} so the {@code UpdateExpression} can
+ * combine {@code if_not_exists(...)} with {@code ADD ads :strategySet} in a single
+ * request. {@link com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper}
+ * does not support this expression shape directly.
+ *
+ * <p>Single-round-trip semantics: no read-then-write, no race; concurrent retrieval
+ * strategies on the same PMID are safe because String Set ADD is commutative and
+ * {@code if_not_exists} is atomic per UpdateItem.
+ */
+@Service
+public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
+
+    private static final Logger log = LoggerFactory.getLogger(ArticleProvenanceServiceImpl.class);
+    private static final String TABLE_NAME = "ArticleProvenance";
+
+    private final AmazonDynamoDB amazonDynamoDB;
+
+    public ArticleProvenanceServiceImpl(AmazonDynamoDB amazonDynamoDB) {
+        this.amazonDynamoDB = amazonDynamoDB;
+    }
+
+    @Override
+    public void upsertRetrievalProvenance(String uid, long pmid, String strategyCode, long epochSeconds) {
+        if (uid == null || uid.isEmpty()) {
+            log.warn("upsertRetrievalProvenance called with null/empty uid; skipping (pmid={})", pmid);
+            return;
+        }
+        if (strategyCode == null || strategyCode.isEmpty()) {
+            log.warn("upsertRetrievalProvenance called with null/empty strategyCode; skipping (uid={} pmid={})",
+                    uid, pmid);
+            return;
+        }
+
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("uid", new AttributeValue().withS(uid));
+        key.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":strategy", new AttributeValue().withS(strategyCode));
+        values.put(":now", new AttributeValue().withN(String.valueOf(epochSeconds)));
+        values.put(":strategySet", new AttributeValue().withSS(Collections.singletonList(strategyCode)));
+
+        UpdateItemRequest req = new UpdateItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withUpdateExpression(
+                        "SET rs = if_not_exists(rs, :strategy), " +
+                        "    frd = if_not_exists(frd, :now) " +
+                        "ADD ads :strategySet")
+                .withExpressionAttributeValues(values);
+
+        try {
+            amazonDynamoDB.updateItem(req);
+        } catch (AmazonDynamoDBException e) {
+            // Provenance failures must not break retrieval. Log and continue.
+            log.warn("ArticleProvenance upsert failed for uid={} pmid={} strategy={}: {}",
+                    uid, pmid, strategyCode, e.getMessage());
+        } catch (RuntimeException e) {
+            log.warn("ArticleProvenance upsert unexpected error for uid={} pmid={} strategy={}: {}",
+                    uid, pmid, strategyCode, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -11,8 +11,12 @@ import org.springframework.stereotype.Service;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
 
+import reciter.feedback.EntryPath;
 import reciter.service.ArticleProvenanceService;
 
 /**
@@ -32,6 +36,13 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
 
     private static final Logger log = LoggerFactory.getLogger(ArticleProvenanceServiceImpl.class);
     private static final String TABLE_NAME = "ArticleProvenance";
+    private static final String PM_UI_SEARCH_RS = "PM_UI_SEARCH";
+    private static final String SRC_PM = "PM";
+    private static final String SRC_CTSC = "CTSC";
+    private static final String SRC_GS_PLACEHOLDER = "GS";
+    private static final String SRC_MAN = "MAN";
+    private static final String SRC_MAN_FROM_PM = "MAN_FROM_PM";
+    private static final String SRC_MAN_FROM_CTSC = "MAN_FROM_CTSC";
 
     private final AmazonDynamoDB amazonDynamoDB;
 
@@ -79,5 +90,140 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
             log.warn("ArticleProvenance upsert unexpected error for uid={} pmid={} strategy={}: {}",
                     uid, pmid, strategyCode, e.getMessage());
         }
+    }
+
+    @Override
+    public void upsertCuratorAction(String uid, long pmid, EntryPath entryPath, long epochSeconds) {
+        if (uid == null || uid.isEmpty()) {
+            log.warn("upsertCuratorAction called with null/empty uid; skipping (pmid={})", pmid);
+            return;
+        }
+        EntryPath path = (entryPath == null) ? EntryPath.CANDIDATE_LIST : entryPath;
+
+        // D-13: PUBMED_SEARCH path writes a retrieval-style record FIRST so D-11
+        // sees src='PM' and lifts to MAN_FROM_PM. CANDIDATE_LIST skips this step.
+        if (path == EntryPath.PUBMED_SEARCH) {
+            writePmUiSearchRecord(uid, pmid, epochSeconds);
+        }
+
+        // D-11 transition with one retry on race
+        try {
+            applyD11Transition(uid, pmid, epochSeconds, /*allowRetry=*/ true);
+        } catch (RuntimeException e) {
+            log.warn("D-11 upsert unexpected error for uid={} pmid={} entryPath={}: {}",
+                    uid, pmid, path, e.getMessage());
+        }
+    }
+
+    private void writePmUiSearchRecord(String uid, long pmid, long epochSeconds) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("uid", new AttributeValue().withS(uid));
+        key.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":rs", new AttributeValue().withS(PM_UI_SEARCH_RS));
+        values.put(":pm", new AttributeValue().withS(SRC_PM));
+        values.put(":ts", new AttributeValue().withN(String.valueOf(epochSeconds)));
+        values.put(":rsSet", new AttributeValue().withSS(Collections.singletonList(PM_UI_SEARCH_RS)));
+
+        UpdateItemRequest req = new UpdateItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withUpdateExpression(
+                        "SET rs  = if_not_exists(rs,  :rs), " +
+                        "    src = if_not_exists(src, :pm), " +
+                        "    frd = if_not_exists(frd, :ts) " +
+                        "ADD ads :rsSet")
+                .withExpressionAttributeValues(values);
+
+        try {
+            amazonDynamoDB.updateItem(req);
+        } catch (AmazonDynamoDBException e) {
+            log.warn("PM_UI_SEARCH retrieval-record write failed for uid={} pmid={}: {}",
+                    uid, pmid, e.getMessage());
+        }
+    }
+
+    private void applyD11Transition(String uid, long pmid, long epochSeconds, boolean allowRetry) {
+        // 1. Read current src
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("uid", new AttributeValue().withS(uid));
+        key.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+
+        GetItemRequest getReq = new GetItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withProjectionExpression("src")
+                .withConsistentRead(true);
+
+        GetItemResult getRes;
+        try {
+            getRes = amazonDynamoDB.getItem(getReq);
+        } catch (AmazonDynamoDBException e) {
+            log.warn("D-11 read failed for uid={} pmid={}: {}", uid, pmid, e.getMessage());
+            return;
+        }
+
+        String existingSrc = null;
+        if (getRes.getItem() != null && getRes.getItem().containsKey("src")) {
+            AttributeValue v = getRes.getItem().get("src");
+            existingSrc = v != null ? v.getS() : null;
+        }
+
+        String newSrc = computeNewSrc(existingSrc);
+
+        // 2. Build conditional UpdateItem
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":new", new AttributeValue().withS(newSrc));
+        values.put(":ts", new AttributeValue().withN(String.valueOf(epochSeconds)));
+
+        UpdateItemRequest req = new UpdateItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withExpressionAttributeValues(values);
+
+        if (existingSrc == null) {
+            // New row: write src + frd, condition on src absence
+            req.withUpdateExpression("SET src = :new, frd = if_not_exists(frd, :ts)")
+               .withConditionExpression("attribute_not_exists(src)");
+        } else if (!newSrc.equals(existingSrc)) {
+            // Transition: condition on observed existing value to detect concurrent write
+            values.put(":existing", new AttributeValue().withS(existingSrc));
+            req.withUpdateExpression("SET src = :new, frd = if_not_exists(frd, :ts)")
+               .withConditionExpression("src = :existing");
+        } else {
+            // No-op on src; ensure frd is present
+            req.withUpdateExpression("SET frd = if_not_exists(frd, :ts)");
+        }
+
+        try {
+            amazonDynamoDB.updateItem(req);
+        } catch (ConditionalCheckFailedException race) {
+            if (allowRetry) {
+                log.info("D-11 race for uid={} pmid={} (existing src changed since GetItem); retrying once",
+                        uid, pmid);
+                applyD11Transition(uid, pmid, epochSeconds, /*allowRetry=*/ false);
+            } else {
+                log.warn("D-11 retry also failed for uid={} pmid={}; giving up (PM UI request continues)",
+                        uid, pmid);
+            }
+        } catch (AmazonDynamoDBException e) {
+            log.warn("D-11 update failed for uid={} pmid={}: {}", uid, pmid, e.getMessage());
+        }
+    }
+
+    /** D-11 transition table. Package-private for testability. */
+    static String computeNewSrc(String existingSrc) {
+        if (existingSrc == null || SRC_GS_PLACEHOLDER.equals(existingSrc)) {
+            return SRC_MAN;
+        }
+        if (SRC_PM.equals(existingSrc)) {
+            return SRC_MAN_FROM_PM;
+        }
+        if (SRC_CTSC.equals(existingSrc)) {
+            return SRC_MAN_FROM_CTSC;
+        }
+        // MAN, MAN_FROM_PM, MAN_FROM_CTSC, or any future value: leave as-is
+        return existingSrc;
     }
 }

--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -70,13 +70,22 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
         values.put(":strategy", new AttributeValue().withS(strategyCode));
         values.put(":now", new AttributeValue().withN(String.valueOf(epochSeconds)));
         values.put(":strategySet", new AttributeValue().withSS(Collections.singletonList(strategyCode)));
+        values.put(":pm", new AttributeValue().withS(SRC_PM));
 
+        // src is set to 'PM' only when currently absent. This matches Phase 31's Python
+        // backfill behavior, which wrote src='PM' for every retrieval-found item. Without
+        // this, brand-new AP rows created by Phase 33-01 would have src absent, and a
+        // subsequent curator action would incorrectly transition src=null -> 'MAN'
+        // (algo-missed) instead of -> 'MAN_FROM_PM' (algo-found, then curator-touched).
+        // The if_not_exists guard preserves existing src values (CTSC, MAN, MAN_FROM_*)
+        // so the curator/CTSC paths retain ownership of src per Phase 33 D-04 intent.
         UpdateItemRequest req = new UpdateItemRequest()
                 .withTableName(TABLE_NAME)
                 .withKey(key)
                 .withUpdateExpression(
                         "SET rs = if_not_exists(rs, :strategy), " +
-                        "    frd = if_not_exists(frd, :now) " +
+                        "    frd = if_not_exists(frd, :now), " +
+                        "    src = if_not_exists(src, :pm) " +
                         "ADD ads :strategySet")
                 .withExpressionAttributeValues(values);
 

--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -23,7 +25,10 @@ import reciter.database.dynamodb.model.GoldStandardAuditLog;
 import reciter.database.dynamodb.model.PmidProvenance;
 import reciter.database.dynamodb.model.PublicationFeedback;
 import reciter.database.dynamodb.repository.DynamoDbGoldStandardRepository;
+import reciter.feedback.EntryPath;
+import reciter.service.ArticleProvenanceService;
 import reciter.service.ESearchResultService;
+import reciter.service.FeedbackLogService;
 import reciter.service.PmidProvenanceService;
 
 @Service("DynamoDbGoldStandardService")
@@ -41,8 +46,33 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     @Autowired
     private PmidProvenanceService pmidProvenanceService;
 
+    @Autowired
+    private FeedbackLogService feedbackLogService;
+
+    @Autowired
+    private ArticleProvenanceService articleProvenanceService;
+
+    // ---- Phase 33-02 4-arg overloads -----------------------------------------------------------
+    // Existing 3-arg save() callers default entryPath to CANDIDATE_LIST. Controllers that want to
+    // distinguish PUBMED_SEARCH actions invoke the 4-arg overload directly.
+
     @Override
     public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource) {
+        save(goldStandard, goldStandardUpdateFlag, provenanceSource, EntryPath.CANDIDATE_LIST);
+    }
+
+    @Override
+    public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource) {
+        save(goldStandard, goldStandardUpdateFlag, provenanceSource, EntryPath.CANDIDATE_LIST);
+    }
+
+    @Override
+    public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+                     String provenanceSource, EntryPath entryPath) {
+        saveInternal(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
+    }
+
+    private void saveInternal(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource, EntryPath entryPath) {
     	// Resolve provenance strategy: caller-supplied source, or default
     	String strategy = (provenanceSource != null && !provenanceSource.isBlank())
     			? provenanceSource : PM_MANUAL_STRATEGY;
@@ -193,6 +223,14 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     					auditLog.addAll(newEntries);
     					goldStandard.setAuditLog(auditLog);
     				}
+    				// Phase 33-02: FeedbackLog rows + ArticleProvenance D-11/D-13 transitions
+    				// for the diff. Inside the same UPDATE branch where existingAccepted/Rejected
+    				// are in scope.
+    				recordFeedbackLogAndArticleProvenance(
+    						goldStandard.getUid(),
+    						incomingAcceptedPmids, incomingRejectedPmids,
+    						existingAccepted, existingRejected,
+    						entryPath);
     			}
     			dynamoDbGoldStandardRepository.save(goldStandard);
     		}
@@ -214,7 +252,12 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     }
 
 	@Override
-	public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource) {
+	public void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+	                 String provenanceSource, EntryPath entryPath) {
+		saveListInternal(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
+	}
+
+	private void saveListInternal(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource, EntryPath entryPath) {
 		// Resolve provenance strategy: caller-supplied source, or default
 		String strategy = (provenanceSource != null && !provenanceSource.isBlank())
 				? provenanceSource : PM_MANUAL_STRATEGY;
@@ -296,6 +339,10 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     						auditLog.addAll(newEntries);
     						goldStandardNew.setAuditLog(auditLog);
     					}
+    					// Phase 33-02: per-uid FeedbackLog + ArticleProvenance writes for the diff
+    					recordFeedbackLogAndArticleProvenance(uid,
+    							batchIncomingAccepted, batchIncomingRejected,
+    							existingAccepted, existingRejected, entryPath);
     				}
     			}
     			dynamoDbGoldStandardRepository.saveAll(goldStandard);
@@ -365,6 +412,73 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 		}
 		return entries;
 	}
+	/**
+	 * Phase 33-02: emit FeedbackLog rows + ArticleProvenance D-11/D-13 transitions for
+	 * every curator action implied by the diff between incoming GS state and existing
+	 * GS state. Three buckets:
+	 *
+	 * <ul>
+	 *   <li><b>newly ACCEPTED</b> — pmids in {@code incomingAccepted} not in {@code existingAccepted}</li>
+	 *   <li><b>newly REJECTED</b> — pmids in {@code incomingRejected} not in {@code existingRejected}</li>
+	 *   <li><b>newly PENDING</b> — pmids in {@code (existingAccepted ∪ existingRejected)} that are
+	 *       NOT in {@code (incomingAccepted ∪ incomingRejected)} (state transition to pending)</li>
+	 * </ul>
+	 *
+	 * <p>Each bucket emits one FeedbackLog row per pmid + one ArticleProvenance D-11
+	 * transition. PUBMED_SEARCH entry path additionally writes the rs='PM_UI_SEARCH' record
+	 * before the D-11 transition (D-13). Both services log and continue on failure;
+	 * curator request never blocks.
+	 *
+	 * <p>{@code curatedBy} is set to 0 because the {@code POST /reciter/goldstandard}
+	 * endpoint does not currently carry a userID. Future work: extend the endpoint to
+	 * include curatedBy in the request payload.
+	 */
+	private void recordFeedbackLogAndArticleProvenance(String uid,
+			List<Long> incomingAccepted, List<Long> incomingRejected,
+			List<Long> existingAccepted, List<Long> existingRejected,
+			EntryPath entryPath) {
+		long actionEpoch = System.currentTimeMillis() / 1000L;
+		Set<Long> incomingAccSet = new HashSet<>(incomingAccepted);
+		Set<Long> incomingRejSet = new HashSet<>(incomingRejected);
+		Set<Long> existingAccSet = new HashSet<>(existingAccepted);
+		Set<Long> existingRejSet = new HashSet<>(existingRejected);
+
+		Set<Long> newlyAccepted = new HashSet<>(incomingAccSet);
+		newlyAccepted.removeAll(existingAccSet);
+
+		Set<Long> newlyRejected = new HashSet<>(incomingRejSet);
+		newlyRejected.removeAll(existingRejSet);
+
+		Set<Long> previouslyClassified = new HashSet<>();
+		previouslyClassified.addAll(existingAccSet);
+		previouslyClassified.addAll(existingRejSet);
+		Set<Long> stillClassified = new HashSet<>();
+		stillClassified.addAll(incomingAccSet);
+		stillClassified.addAll(incomingRejSet);
+		Set<Long> newlyPending = new HashSet<>(previouslyClassified);
+		newlyPending.removeAll(stillClassified);
+
+		int total = newlyAccepted.size() + newlyRejected.size() + newlyPending.size();
+		if (total == 0) {
+			return;
+		}
+		log.info("Phase 33-02: feedback diff for uid={} entryPath={}: +{} accepted, +{} rejected, +{} pending",
+				uid, entryPath, newlyAccepted.size(), newlyRejected.size(), newlyPending.size());
+
+		for (Long pmid : newlyAccepted) {
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.ACCEPTED, 0, actionEpoch);
+			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
+		}
+		for (Long pmid : newlyRejected) {
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.REJECTED, 0, actionEpoch);
+			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
+		}
+		for (Long pmid : newlyPending) {
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.PENDING, 0, actionEpoch);
+			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
+		}
+	}
+
 	/**
 	 * Write PmidProvenance records for accepted PMIDs. Uses saveIfNotExists
 	 * so that PMIDs already discovered by automated retrieval strategies

--- a/src/main/java/reciter/service/dynamo/FeedbackLogServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/FeedbackLogServiceImpl.java
@@ -1,0 +1,99 @@
+package reciter.service.dynamo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
+
+import reciter.service.FeedbackLogService;
+
+/**
+ * Phase 33-02 implementation of {@link FeedbackLogService}.
+ *
+ * <p>Uses raw {@code AmazonDynamoDB.putItem} with {@code attribute_not_exists(sk)}
+ * for idempotency. The sk is {@code "<epoch_seconds>#<nano-derived-hex>"} which
+ * gives microsecond-resolution uniqueness within a single process; cross-process
+ * collisions are caught by the conditional and retried with a fresh suffix.
+ *
+ * <p>{@code src='MAN'} on every row — Phase 32 D-03: PM UI is the only source for
+ * this table going forward (CTSC ingestion bypasses PM and writes directly to
+ * GoldStandard).
+ */
+@Service
+public class FeedbackLogServiceImpl implements FeedbackLogService {
+
+    private static final Logger log = LoggerFactory.getLogger(FeedbackLogServiceImpl.class);
+    private static final String TABLE_NAME = "FeedbackLog";
+    private static final String SRC_MAN = "MAN";
+    private static final int SK_RETRY_LIMIT = 5;
+
+    private final AmazonDynamoDB amazonDynamoDB;
+
+    public FeedbackLogServiceImpl(AmazonDynamoDB amazonDynamoDB) {
+        this.amazonDynamoDB = amazonDynamoDB;
+    }
+
+    @Override
+    public void recordAction(String uid, long pmid, Feedback feedback, int curatedBy, long actionEpochSeconds) {
+        if (uid == null || uid.isEmpty()) {
+            log.warn("recordAction called with null/empty uid; skipping (pmid={})", pmid);
+            return;
+        }
+        if (feedback == null) {
+            log.warn("recordAction called with null feedback; skipping (uid={} pmid={})", uid, pmid);
+            return;
+        }
+
+        for (int attempt = 0; attempt < SK_RETRY_LIMIT; attempt++) {
+            String sk = buildSk(actionEpochSeconds);
+            Map<String, AttributeValue> item = new HashMap<>();
+            item.put("uid", new AttributeValue().withS(uid));
+            item.put("sk", new AttributeValue().withS(sk));
+            item.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+            item.put("feedback", new AttributeValue().withS(feedback.name()));
+            item.put("curatedBy", new AttributeValue().withN(String.valueOf(curatedBy)));
+            item.put("src", new AttributeValue().withS(SRC_MAN));
+            item.put("createTimestamp", new AttributeValue().withN(String.valueOf(actionEpochSeconds)));
+            item.put("modifyTimestamp", new AttributeValue().withN(String.valueOf(actionEpochSeconds)));
+
+            PutItemRequest req = new PutItemRequest()
+                    .withTableName(TABLE_NAME)
+                    .withItem(item)
+                    .withConditionExpression("attribute_not_exists(sk)");
+
+            try {
+                amazonDynamoDB.putItem(req);
+                return;
+            } catch (ConditionalCheckFailedException race) {
+                // sk collision (extremely unlikely with 8 hex chars); retry with fresh suffix
+                log.info("FeedbackLog sk collision for uid={} sk={}; retrying (attempt {})",
+                        uid, sk, attempt + 1);
+            } catch (AmazonDynamoDBException e) {
+                log.warn("FeedbackLog write failed for uid={} pmid={}: {}", uid, pmid, e.getMessage());
+                return;
+            }
+        }
+        log.warn("FeedbackLog write hit retry limit for uid={} pmid={}; giving up", uid, pmid);
+    }
+
+    /**
+     * Build a unique sk: epoch + '#' + last 8 hex digits of nanoTime.
+     * Within a single JVM, nanoTime is monotonically increasing, so collisions
+     * within a process are vanishingly rare. Cross-process collisions are caught
+     * by the conditional put.
+     */
+    private String buildSk(long epochSeconds) {
+        long nano = System.nanoTime();
+        // Mask to 32 bits (8 hex digits)
+        String hexSuffix = String.format("%08x", (int) (nano & 0xFFFFFFFFL));
+        return epochSeconds + "#" + hexSuffix;
+    }
+}

--- a/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
@@ -8,6 +8,18 @@ import reciter.database.dynamodb.model.GoldStandard;
 public interface IDynamoDbGoldStandardService {
     void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource);
     void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource);
+
+    /**
+     * Phase 33-02 overload propagating the PM UI entry path so the service can
+     * apply Phase 33 D-13 (PM_UI_SEARCH retrieval write) before the D-11 transition.
+     * Pre-existing 3-arg signatures default {@code entryPath} to
+     * {@link reciter.feedback.EntryPath#CANDIDATE_LIST}.
+     */
+    void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+              String provenanceSource, reciter.feedback.EntryPath entryPath);
+    void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+              String provenanceSource, reciter.feedback.EntryPath entryPath);
+
     GoldStandard findByUid(String uid);
     List<GoldStandard> findByUids(List<String> uid);
     void delete(String uid);

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -45,6 +45,7 @@ import reciter.model.identity.PubMedAlias;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.model.scopus.ScopusArticle;
 import reciter.database.dynamodb.model.PmidProvenance;
+import reciter.service.ArticleProvenanceService;
 import reciter.service.ESearchCountService;
 import reciter.service.ESearchResultService;
 import reciter.service.PmidProvenanceService;
@@ -77,6 +78,9 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 
 	@Autowired
 	private PmidProvenanceService pmidProvenanceService;
+
+	@Autowired
+	private ArticleProvenanceService articleProvenanceService;
 
 	public enum IdentityNameType {
 		ORIGINAL,
@@ -866,14 +870,32 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	}
 
 	/**
-	 * Track newly discovered PMIDs for provenance recording.
-	 * For each PMID in the articles map, if it's not already known (from existingPmids or newPmidStrategy),
-	 * record which strategy first discovered it. Also heal any backfill provenance records.
+	 * Track PMIDs returned by a retrieval strategy.
+	 *
+	 * <p>Two effects per PMID:
+	 * <ol>
+	 *   <li><b>Legacy {@code PmidProvenance} attribution</b>: if the PMID is genuinely new
+	 *       (not in {@code existingPmids} nor already attributed in {@code newPmidStrategy}),
+	 *       record this strategy as the first finder. The contents of {@code newPmidStrategy}
+	 *       are batch-written to {@code PmidProvenance} after all strategies finish.
+	 *       Backfill-tagged PMIDs are healed via {@link PmidProvenanceService#updateStrategyIfBackfill}.</li>
+	 *   <li><b>Phase 33 {@code ArticleProvenance} write</b>: for EVERY PMID returned by the
+	 *       strategy (not just new ones), upsert the {@code ArticleProvenance} row with
+	 *       {@code rs}/{@code frd}/{@code ads}. Uses {@code if_not_exists} so original
+	 *       attribution is preserved on re-runs; {@code ads} grows as new strategies re-find
+	 *       this PMID. The {@code src} field is NOT touched here (curator/CTSC paths own it).
+	 *       This closes the established-user gap where PmidProvenance was never written
+	 *       because all PMIDs were already known.</li>
+	 * </ol>
+	 *
+	 * <p>Phase 33-01 D-01..D-04. Provenance write failures never propagate (logged in service).
 	 */
 	private void trackNewPmids(Map<Long, ?> articles, String strategyName,
 			String uid, Set<Long> existingPmids, Map<Long, String> newPmidStrategy,
 			Set<Long> backfillPmids) {
+		long nowEpochSeconds = System.currentTimeMillis() / 1000L;
 		for (Long pmid : articles.keySet()) {
+			// Legacy PmidProvenance attribution (new-only)
 			if (!existingPmids.contains(pmid) && !newPmidStrategy.containsKey(pmid)) {
 				newPmidStrategy.put(pmid, strategyName);
 			}
@@ -881,6 +903,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				pmidProvenanceService.updateStrategyIfBackfill(uid, pmid, strategyName);
 				backfillPmids.remove(pmid);
 			}
+			// Phase 33-01: ArticleProvenance upsert for EVERY retrieved PMID
+			articleProvenanceService.upsertRetrievalProvenance(uid, pmid, strategyName, nowEpochSeconds);
 		}
 	}
 

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -1,0 +1,166 @@
+package reciter.service.dynamo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+
+/**
+ * Unit tests for {@link ArticleProvenanceServiceImpl}.
+ *
+ * <p>Verifies Phase 33-01 D-01..D-04 invariants:
+ * <ul>
+ *   <li>UpdateExpression uses {@code if_not_exists(rs, ...)} so the first retrieval strategy wins</li>
+ *   <li>UpdateExpression uses {@code if_not_exists(frd, ...)} so first-retrieval-date is preserved</li>
+ *   <li>UpdateExpression uses {@code ADD ads :strategySet} for additional-strategy tracking</li>
+ *   <li>UpdateExpression does NOT touch {@code src} (curator/CTSC paths own it)</li>
+ *   <li>DynamoDB exceptions are logged but not thrown (provenance must not break retrieval)</li>
+ *   <li>Null/empty {@code uid} or {@code strategyCode} short-circuit safely</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ArticleProvenanceServiceImplTest {
+
+    @Mock
+    private AmazonDynamoDB amazonDynamoDB;
+
+    private ArticleProvenanceServiceImpl service;
+
+    @Before
+    public void setUp() {
+        service = new ArticleProvenanceServiceImpl(amazonDynamoDB);
+    }
+
+    private UpdateItemRequest captureRequest() {
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void testUpsert_TableNameAndKey_MatchSchema() {
+        service.upsertRetrievalProvenance("ajg9004", 12345L, "PUBMED_NAME_AFFIL", 1700000000L);
+
+        UpdateItemRequest req = captureRequest();
+        assertEquals("ArticleProvenance", req.getTableName());
+
+        Map<String, AttributeValue> key = req.getKey();
+        assertEquals("ajg9004", key.get("uid").getS());
+        assertEquals("12345", key.get("articleId").getS());
+    }
+
+    @Test
+    public void testUpsert_PreservesExistingRsFrd_OnRewrite() {
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+        UpdateItemRequest req = captureRequest();
+
+        String expr = req.getUpdateExpression();
+        assertTrue("UpdateExpression must use if_not_exists(rs, :strategy): " + expr,
+                expr.contains("rs = if_not_exists(rs, :strategy)"));
+        assertTrue("UpdateExpression must use if_not_exists(frd, :now): " + expr,
+                expr.contains("frd = if_not_exists(frd, :now)"));
+    }
+
+    @Test
+    public void testUpsert_AddsStrategyToAds() {
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+        UpdateItemRequest req = captureRequest();
+
+        String expr = req.getUpdateExpression();
+        assertTrue("UpdateExpression must contain ADD ads :strategySet: " + expr,
+                expr.contains("ADD ads :strategySet"));
+
+        AttributeValue ssVal = req.getExpressionAttributeValues().get(":strategySet");
+        assertNotNull(":strategySet must be present", ssVal);
+        assertNotNull(":strategySet must be a String Set", ssVal.getSS());
+        assertEquals(1, ssVal.getSS().size());
+        assertEquals("STRAT_A", ssVal.getSS().get(0));
+    }
+
+    @Test
+    public void testUpsert_DoesNotTouchSrc() {
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+        UpdateItemRequest req = captureRequest();
+
+        String expr = req.getUpdateExpression();
+        // Phase 33 D-04: retrieval path never writes src.
+        assertTrue("UpdateExpression must not contain 'src': " + expr,
+                !expr.contains("src"));
+    }
+
+    @Test
+    public void testUpsert_ExpressionAttributeValues_HaveCorrectTypes() {
+        service.upsertRetrievalProvenance("uid1", 100L, "PUBMED_GRANT", 1700000000L);
+        UpdateItemRequest req = captureRequest();
+
+        Map<String, AttributeValue> values = req.getExpressionAttributeValues();
+        assertEquals("PUBMED_GRANT", values.get(":strategy").getS());
+        assertEquals("1700000000", values.get(":now").getN());
+        assertEquals(1, values.get(":strategySet").getSS().size());
+        assertEquals("PUBMED_GRANT", values.get(":strategySet").getSS().get(0));
+    }
+
+    @Test
+    public void testUpsert_DynamoDbExceptionLogged_NotThrown() {
+        when(amazonDynamoDB.updateItem(any(UpdateItemRequest.class)))
+                .thenThrow(new AmazonDynamoDBException("simulated DDB failure"));
+
+        // Must not throw — provenance failures must not break retrieval.
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+
+        // updateItem was called once and the exception was swallowed.
+        verify(amazonDynamoDB).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_RuntimeExceptionLogged_NotThrown() {
+        when(amazonDynamoDB.updateItem(any(UpdateItemRequest.class)))
+                .thenThrow(new IllegalStateException("simulated unexpected failure"));
+
+        // Must not throw — even unexpected runtime exceptions are swallowed.
+        service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
+
+        verify(amazonDynamoDB).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_NullUid_SkipsCallEntirely() {
+        service.upsertRetrievalProvenance(null, 100L, "STRAT_A", 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_EmptyUid_SkipsCallEntirely() {
+        service.upsertRetrievalProvenance("", 100L, "STRAT_A", 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_NullStrategyCode_SkipsCallEntirely() {
+        service.upsertRetrievalProvenance("uid1", 100L, null, 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testUpsert_EmptyStrategyCode_SkipsCallEntirely() {
+        service.upsertRetrievalProvenance("uid1", 100L, "", 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+}

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -104,14 +104,18 @@ public class ArticleProvenanceServiceImplTest {
     }
 
     @Test
-    public void testUpsert_DoesNotTouchSrc() {
+    public void testUpsert_PreservesExistingSrc_OnlySetsPmIfAbsent() {
         service.upsertRetrievalProvenance("uid1", 100L, "STRAT_A", 1700000000L);
         UpdateItemRequest req = captureRequest();
 
         String expr = req.getUpdateExpression();
-        // Phase 33 D-04: retrieval path never writes src.
-        assertTrue("UpdateExpression must not contain 'src': " + expr,
-                !expr.contains("src"));
+        // Phase 33-01b: retrieval sets src='PM' only when src is currently absent.
+        // The if_not_exists guard preserves existing src values (CTSC, MAN, MAN_FROM_*)
+        // so the curator/CTSC paths retain ownership of src per D-04 spirit, while
+        // matching Phase 31's behavior of writing src='PM' on retrieval-found items.
+        assertTrue("UpdateExpression must use if_not_exists(src, :pm): " + expr,
+                expr.contains("src = if_not_exists(src, :pm)"));
+        assertEquals("PM", req.getExpressionAttributeValues().get(":pm").getS());
     }
 
     @Test

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,10 +18,18 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Collections;
+import java.util.HashMap;
+
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+
+import reciter.feedback.EntryPath;
 
 /**
  * Unit tests for {@link ArticleProvenanceServiceImpl}.
@@ -162,5 +171,176 @@ public class ArticleProvenanceServiceImplTest {
     public void testUpsert_EmptyStrategyCode_SkipsCallEntirely() {
         service.upsertRetrievalProvenance("uid1", 100L, "", 1700000000L);
         verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Phase 33-02: D-11 transition table tests via computeNewSrc + upsertCuratorAction
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    public void testComputeNewSrc_AbsentToMan() {
+        assertEquals("MAN", ArticleProvenanceServiceImpl.computeNewSrc(null));
+    }
+
+    @Test
+    public void testComputeNewSrc_GsToMan() {
+        assertEquals("MAN", ArticleProvenanceServiceImpl.computeNewSrc("GS"));
+    }
+
+    @Test
+    public void testComputeNewSrc_PmToManFromPm() {
+        assertEquals("MAN_FROM_PM", ArticleProvenanceServiceImpl.computeNewSrc("PM"));
+    }
+
+    @Test
+    public void testComputeNewSrc_CtscToManFromCtsc() {
+        assertEquals("MAN_FROM_CTSC", ArticleProvenanceServiceImpl.computeNewSrc("CTSC"));
+    }
+
+    @Test
+    public void testComputeNewSrc_ManIsNoop() {
+        assertEquals("MAN", ArticleProvenanceServiceImpl.computeNewSrc("MAN"));
+    }
+
+    @Test
+    public void testComputeNewSrc_ManFromPmIsNoop() {
+        assertEquals("MAN_FROM_PM", ArticleProvenanceServiceImpl.computeNewSrc("MAN_FROM_PM"));
+    }
+
+    @Test
+    public void testComputeNewSrc_ManFromCtscIsNoop() {
+        assertEquals("MAN_FROM_CTSC", ArticleProvenanceServiceImpl.computeNewSrc("MAN_FROM_CTSC"));
+    }
+
+    private void stubGetItemSrc(String existingSrc) {
+        GetItemResult result = new GetItemResult();
+        if (existingSrc != null) {
+            HashMap<String, AttributeValue> item = new HashMap<>();
+            item.put("src", new AttributeValue().withS(existingSrc));
+            result.setItem(item);
+        }
+        when(amazonDynamoDB.getItem(any(GetItemRequest.class))).thenReturn(result);
+    }
+
+    @Test
+    public void testCuratorAction_NoExisting_CandidateList_WritesSrcMan() {
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        UpdateItemRequest req = captor.getValue();
+        assertEquals("MAN", req.getExpressionAttributeValues().get(":new").getS());
+        assertEquals("attribute_not_exists(src)", req.getConditionExpression());
+        assertTrue("UpdateExpression must SET src and frd: " + req.getUpdateExpression(),
+                req.getUpdateExpression().contains("SET src = :new")
+                        && req.getUpdateExpression().contains("frd = if_not_exists(frd, :ts)"));
+    }
+
+    @Test
+    public void testCuratorAction_ExistingPm_CandidateList_TransitionsToManFromPm() {
+        stubGetItemSrc("PM");
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        UpdateItemRequest req = captor.getValue();
+        assertEquals("MAN_FROM_PM", req.getExpressionAttributeValues().get(":new").getS());
+        assertEquals("PM", req.getExpressionAttributeValues().get(":existing").getS());
+        assertEquals("src = :existing", req.getConditionExpression());
+    }
+
+    @Test
+    public void testCuratorAction_ExistingCtsc_CandidateList_TransitionsToManFromCtsc() {
+        stubGetItemSrc("CTSC");
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        UpdateItemRequest req = captor.getValue();
+        assertEquals("MAN_FROM_CTSC", req.getExpressionAttributeValues().get(":new").getS());
+        assertEquals("CTSC", req.getExpressionAttributeValues().get(":existing").getS());
+    }
+
+    @Test
+    public void testCuratorAction_ExistingManFromPm_CandidateList_NoSrcChangeOnlyFrdMaintenance() {
+        stubGetItemSrc("MAN_FROM_PM");
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB).updateItem(captor.capture());
+        UpdateItemRequest req = captor.getValue();
+        // Should write only frd (idempotent on src)
+        assertTrue("Expression must be only frd if_not_exists: " + req.getUpdateExpression(),
+                req.getUpdateExpression().equals("SET frd = if_not_exists(frd, :ts)"));
+        // No condition (since src is already correct)
+        assertTrue("No conditional needed for noop: " + req.getConditionExpression(),
+                req.getConditionExpression() == null);
+    }
+
+    @Test
+    public void testCuratorAction_PubmedSearch_NewPmid_WritesPmUiSearchThenManFromPm() {
+        stubGetItemSrc(null);
+        // First updateItem call is the PM_UI_SEARCH retrieval-record write (D-13)
+        // Second updateItem call is the D-11 transition (which sees no existing src after the
+        // mock GetItem; in real life GetItem would read what D-13 just wrote, but we control
+        // the mock to verify the two-step sequence).
+        service.upsertCuratorAction("uid1", 100L, EntryPath.PUBMED_SEARCH, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB, times(2)).updateItem(captor.capture());
+        UpdateItemRequest first = captor.getAllValues().get(0);
+        // Step 1: PM_UI_SEARCH retrieval-record write
+        assertTrue("First call must SET rs to PM_UI_SEARCH if absent: " + first.getUpdateExpression(),
+                first.getUpdateExpression().contains("rs  = if_not_exists(rs,  :rs)"));
+        assertEquals("PM_UI_SEARCH", first.getExpressionAttributeValues().get(":rs").getS());
+        assertEquals("PM", first.getExpressionAttributeValues().get(":pm").getS());
+        assertNotNull(first.getExpressionAttributeValues().get(":rsSet"));
+        assertEquals("PM_UI_SEARCH", first.getExpressionAttributeValues().get(":rsSet").getSS().get(0));
+    }
+
+    @Test
+    public void testCuratorAction_PubmedSearch_TwoUpdateItemCallsSequence() {
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.PUBMED_SEARCH, 1700000000L);
+        // PUBMED_SEARCH path: 1 PM_UI_SEARCH write + 1 D-11 transition = 2 updateItem calls
+        verify(amazonDynamoDB, times(2)).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_CandidateList_OneUpdateItemCall() {
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+        // CANDIDATE_LIST path: only the D-11 transition = 1 updateItem call
+        verify(amazonDynamoDB, times(1)).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_NullUid_SkipsCallEntirely() {
+        service.upsertCuratorAction(null, 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+        verify(amazonDynamoDB, never()).updateItem(any(UpdateItemRequest.class));
+        verify(amazonDynamoDB, never()).getItem(any(GetItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_NullEntryPath_DefaultsCandidateList() {
+        stubGetItemSrc("PM");
+        service.upsertCuratorAction("uid1", 100L, null, 1700000000L);
+        // Should be 1 updateItem call (CANDIDATE_LIST path)
+        verify(amazonDynamoDB, times(1)).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_RaceOnUpdate_RetriesOnce() {
+        stubGetItemSrc("PM");
+        when(amazonDynamoDB.updateItem(any(UpdateItemRequest.class)))
+                .thenThrow(new ConditionalCheckFailedException("race"))
+                .thenReturn(null);  // second attempt succeeds
+
+        service.upsertCuratorAction("uid1", 100L, EntryPath.CANDIDATE_LIST, 1700000000L);
+        // 2 updateItem invocations: original + 1 retry
+        verify(amazonDynamoDB, times(2)).updateItem(any(UpdateItemRequest.class));
+        // GetItem is called twice (once initial, once on retry)
+        verify(amazonDynamoDB, times(2)).getItem(any(GetItemRequest.class));
     }
 }

--- a/src/test/java/reciter/service/dynamo/FeedbackLogServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/FeedbackLogServiceImplTest.java
@@ -1,0 +1,141 @@
+package reciter.service.dynamo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
+
+import reciter.service.FeedbackLogService;
+import reciter.service.FeedbackLogService.Feedback;
+
+/**
+ * Unit tests for {@link FeedbackLogServiceImpl}.
+ *
+ * <p>Covers Phase 32 D-01 (schema), D-02 (sk format), D-03 (src=MAN), D-04 (feedback enum),
+ * and Phase 33-02 idempotency / retry semantics.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FeedbackLogServiceImplTest {
+
+    @Mock
+    private AmazonDynamoDB amazonDynamoDB;
+
+    private FeedbackLogServiceImpl service;
+
+    @Before
+    public void setUp() {
+        service = new FeedbackLogServiceImpl(amazonDynamoDB);
+    }
+
+    private PutItemRequest captureRequest() {
+        ArgumentCaptor<PutItemRequest> captor = ArgumentCaptor.forClass(PutItemRequest.class);
+        verify(amazonDynamoDB).putItem(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void testRecordAction_TableNameIsFeedbackLog() {
+        service.recordAction("ajg9004", 12345L, Feedback.ACCEPTED, 3, 1700000000L);
+        assertEquals("FeedbackLog", captureRequest().getTableName());
+    }
+
+    @Test
+    public void testRecordAction_ItemHasFullSchema() {
+        service.recordAction("ajg9004", 12345L, Feedback.ACCEPTED, 3, 1700000000L);
+        Map<String, AttributeValue> item = captureRequest().getItem();
+        assertEquals("ajg9004", item.get("uid").getS());
+        assertEquals("12345", item.get("articleId").getS());
+        assertEquals("ACCEPTED", item.get("feedback").getS());
+        assertEquals("3", item.get("curatedBy").getN());
+        assertEquals("MAN", item.get("src").getS());
+        assertEquals("1700000000", item.get("createTimestamp").getN());
+        assertEquals("1700000000", item.get("modifyTimestamp").getN());
+        assertNotNull(item.get("sk"));
+    }
+
+    @Test
+    public void testRecordAction_SkFormat_EpochHashHex() {
+        service.recordAction("uid1", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        String sk = captureRequest().getItem().get("sk").getS();
+        // Format: "<epoch>#<8-hex>"
+        assertTrue("sk should match epoch#hex format: " + sk,
+                sk.matches("^\\d+#[0-9a-f]{8}$"));
+        assertTrue("sk should start with the epoch: " + sk,
+                sk.startsWith("1700000000#"));
+    }
+
+    @Test
+    public void testRecordAction_ConditionExpression_PreventsCollision() {
+        service.recordAction("uid1", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        assertEquals("attribute_not_exists(sk)", captureRequest().getConditionExpression());
+    }
+
+    @Test
+    public void testRecordAction_FeedbackRejected_WritesRejected() {
+        service.recordAction("uid1", 1L, Feedback.REJECTED, 0, 1700000000L);
+        assertEquals("REJECTED", captureRequest().getItem().get("feedback").getS());
+    }
+
+    @Test
+    public void testRecordAction_FeedbackPending_WritesPending() {
+        service.recordAction("uid1", 1L, Feedback.PENDING, 0, 1700000000L);
+        assertEquals("PENDING", captureRequest().getItem().get("feedback").getS());
+    }
+
+    @Test
+    public void testRecordAction_SkCollision_RetriesWithFreshSuffix() {
+        when(amazonDynamoDB.putItem(any(PutItemRequest.class)))
+                .thenThrow(new ConditionalCheckFailedException("collision"))
+                .thenReturn(null);  // second attempt succeeds
+
+        service.recordAction("uid1", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        verify(amazonDynamoDB, times(2)).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    public void testRecordAction_DynamoDbException_LoggedNotThrown() {
+        when(amazonDynamoDB.putItem(any(PutItemRequest.class)))
+                .thenThrow(new AmazonDynamoDBException("simulated"));
+
+        service.recordAction("uid1", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        // Single attempt (non-CCE exceptions are not retried)
+        verify(amazonDynamoDB, times(1)).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    public void testRecordAction_NullUid_SkipsCallEntirely() {
+        service.recordAction(null, 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        verify(amazonDynamoDB, never()).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    public void testRecordAction_EmptyUid_SkipsCallEntirely() {
+        service.recordAction("", 1L, Feedback.ACCEPTED, 0, 1700000000L);
+        verify(amazonDynamoDB, never()).putItem(any(PutItemRequest.class));
+    }
+
+    @Test
+    public void testRecordAction_NullFeedback_SkipsCallEntirely() {
+        service.recordAction("uid1", 1L, null, 0, 1700000000L);
+        verify(amazonDynamoDB, never()).putItem(any(PutItemRequest.class));
+    }
+}


### PR DESCRIPTION
## Summary

Bundles the three Phase 33 PRs that have been deployed and validated on dev EKS:

- **#610** — Phase 33-01: write ArticleProvenance on every retrieval strategy hit
- **#611** — Phase 33-02: write FeedbackLog + apply ArticleProvenance D-11/D-13 on curator actions
- **#612** — Phase 33-01b: write src=PM on retrieval-found items via if_not_exists (post-deploy bug fix)

`git cherry origin/master origin/development` confirms these three commits are the only delta between master and development as of 2026-04-30. Master was last updated 2026-04-27 via PR #609; nothing else has accumulated since.

Net diff: **11 files changed, 1,153 insertions, 12 deletions** (mostly tests).

## What this enables on prod

1. **`ArticleProvenance` populated on every retrieval cycle** — established users get fresh `rs/frd/ads` writes per strategy hit; previously the table was only populated by Phase 31's one-time Python backfill and would have aged out organically.

2. **`FeedbackLog` populated on every curator action** — curator history mirrored from MySQL `admin_feedback_log` to the new DynamoDB table during the 4-week dual-write transition window per Phase 33 D-07. PM's existing direct-MySQL writes are unchanged; we add a side-effect write inside `DynamoDbGoldStandardService.save()`.

3. **Algo-coverage signal queryable** — composite `src` values (`MAN_FROM_PM`, `MAN_FROM_CTSC`) now populate forward-going so analysts can run:
   - `WHERE src='MAN'` → curator-only PMIDs (algo missed entirely)
   - `WHERE src='MAN_FROM_PM' AND rs='PM_UI_SEARCH'` → PM UI's PubMed search rediscovered
   - `WHERE src='MAN_FROM_PM' AND contains(ads,'PM_UI_SEARCH') AND rs!='PM_UI_SEARCH'` → sub-threshold rediscovery
   - `WHERE src='MAN_FROM_PM' AND NOT contains(ads,'PM_UI_SEARCH')` → regular candidate-list curation

## Dev validation evidence

All recorded in `~/Dropbox/Projects/ReCiter Research/analysis/phase_33_local_smoke_test.md`:

- **Local smoke test (pre-deploy)**: 4 calls exercising all D-11/D-13 paths against real DynamoDB; all expected writes verified; cleanup left 0 residual items
- **Dev EKS deploy validation (post-deploy)**:
  - `kubectl rollout status` clean for both image deploys (`586.2026-04-30.16.02.55.2e11b461` and `587.2026-04-30.17.02.31.e78508fd`)
  - `scripts/spot_check_feedback_log.py --strict` — 4/4 continuity uids pass schema invariants
  - 4 continuity uids exercised with full `feature-generator/by/uid?refreshFlag=ALL_PUBLICATIONS` runs (meb7002, sfs2002, rsb2005, ajg9004); all HTTP 200; AP writes verified per uid
  - 615 src-absent items discovered and backfilled out-of-band before fix #612 landed; 0 residual src-absent rs-present items

## Backwards compatibility

- `POST/PUT /reciter/goldstandard` keeps the existing 3-arg shape; the new `?entryPath=CANDIDATE_LIST|PUBMED_SEARCH` query param is optional and defaults to `CANDIDATE_LIST`. PM Next.js callers don't need to change to keep working.
- `IDynamoDbGoldStandardService.save()` 3-arg overloads delegate to 4-arg overloads with `EntryPath.CANDIDATE_LIST`. Any external Java callers (none found in this repo) keep working.
- `PmidProvenance` writes are intentionally preserved — both legacy and new tables get writes during the 4-week soak. Removal is a separate post-soak follow-up.
- `EntryPath` enum is in this repo's `reciter.feedback` package (not in the `reciter-article-model` JAR), avoiding a cross-repo Maven release.

## Test plan

- [x] `mvn test` — 39 new tests pass (11 FeedbackLogServiceImplTest + 28 ArticleProvenanceServiceImplTest); 2 pre-existing `TargetAuthorSelectionTest` NPEs unchanged (unrelated)
- [x] Local smoke against real DynamoDB — all D-11/D-13 paths verified
- [x] Dev EKS deploy verified at scale — 4 continuity uids, 5,507 AP items examined post-deploy, all schema invariants hold
- [ ] **Prod cutover via `ReCiter-Production` CodePipeline ManualApproval** ← Mahender's action
- [ ] 24h prod soak per Phase 33 D-19: compare FeedbackLog write rate to historical `admin_feedback_log` baseline (~50/day); track AP write volume from first prod inst-client run (1:30 PM UTC the day after deploy)

## Follow-ups (not blocking this PR)

- `ReCiter-Publication-Manager` Next.js to emit `?entryPath=PUBMED_SEARCH` on PubMed-search-originated curator actions — small, separate PR
- `PmidProvenance` Java cleanup — open after the 4-week dual-write soak passes
- `ads` set strategy-name dedup — Phase 31's short codes (e.g., "FNI") and Phase 33-01's class-name codes (e.g., "FirstNameInitialRetrievalStrategy") coexist; functional no-op, optional cosmetic cleanup