### PR TITLE
fix(provenance): drop :new from EAV in D-11 no-op branch

### DIFF
--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -181,22 +181,24 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
 
         String newSrc = computeNewSrc(existingSrc);
 
-        // 2. Build conditional UpdateItem
+        // 2. Build conditional UpdateItem. Only add :new to values when the
+        // UpdateExpression actually references it; DynamoDB rejects unused
+        // ExpressionAttributeValues with ValidationException.
         Map<String, AttributeValue> values = new HashMap<>();
-        values.put(":new", new AttributeValue().withS(newSrc));
         values.put(":ts", new AttributeValue().withN(String.valueOf(epochSeconds)));
 
         UpdateItemRequest req = new UpdateItemRequest()
                 .withTableName(TABLE_NAME)
-                .withKey(key)
-                .withExpressionAttributeValues(values);
+                .withKey(key);
 
         if (existingSrc == null) {
             // New row: write src + frd, condition on src absence
+            values.put(":new", new AttributeValue().withS(newSrc));
             req.withUpdateExpression("SET src = :new, frd = if_not_exists(frd, :ts)")
                .withConditionExpression("attribute_not_exists(src)");
         } else if (!newSrc.equals(existingSrc)) {
             // Transition: condition on observed existing value to detect concurrent write
+            values.put(":new", new AttributeValue().withS(newSrc));
             values.put(":existing", new AttributeValue().withS(existingSrc));
             req.withUpdateExpression("SET src = :new, frd = if_not_exists(frd, :ts)")
                .withConditionExpression("src = :existing");
@@ -204,6 +206,7 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
             // No-op on src; ensure frd is present
             req.withUpdateExpression("SET frd = if_not_exists(frd, :ts)");
         }
+        req.withExpressionAttributeValues(values);
 
         try {
             amazonDynamoDB.updateItem(req);

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -280,6 +280,15 @@ public class ArticleProvenanceServiceImplTest {
         // No condition (since src is already correct)
         assertTrue("No conditional needed for noop: " + req.getConditionExpression(),
                 req.getConditionExpression() == null);
+        // Regression: DynamoDB rejects ExpressionAttributeValues that aren't referenced
+        // in the UpdateExpression with ValidationException. The no-op branch must NOT
+        // include :new (only :ts is referenced).
+        assertTrue(":new must not be in ExpressionAttributeValues for noop branch: "
+                        + req.getExpressionAttributeValues().keySet(),
+                !req.getExpressionAttributeValues().containsKey(":new"));
+        assertTrue(":ts must be present in ExpressionAttributeValues: "
+                        + req.getExpressionAttributeValues().keySet(),
+                req.getExpressionAttributeValues().containsKey(":ts"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Phase 33 D-11 transition path was unconditionally adding `:new` to `ExpressionAttributeValues` even on the no-op branch (where `src` is already in a terminal state — `MAN`, `MAN_FROM_PM`, `MAN_FROM_CTSC` — and only `frd` is being maintained). DynamoDB rejects this with:

```
ValidationException: Value provided in ExpressionAttributeValues unused in expressions: keys: {:new}
```

The catch in `applyD11Transition` swallows it as a warning, so no curator request fails — but every no-op transition produces a noisy log line and the `frd` write is rejected. Spam is observable in current prod logs (e.g., `nlt2002` at 11:08 UTC today, ~30 occurrences in a single feature-generator call).

## Fix

`:new` is now added to the values map only on branches whose `UpdateExpression` references it. The no-op branch carries only `:ts`.

## Test

Strengthened `testCuratorAction_ExistingManFromPm_CandidateList_NoSrcChangeOnlyFrdMaintenance` to assert `:new` is **absent** from `ExpressionAttributeValues` on the no-op branch — exactly the gap that let this ship. Without the fix this assertion would fail; with the fix all 28 tests in `ArticleProvenanceServiceImplTest` pass.

```
Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Test plan

- [ ] Approve dev pipeline, deploy to `reciter-dev`
- [ ] Tail dev pod logs while triggering a feature-generator call on a user with mixed AP states; confirm no `D-11 update failed ... unused in expressions` warnings
- [ ] Confirm `frd` is now persisted on no-op rows in `ArticleProvenance` (sample a row before/after)