### PR TITLE
Promote PR #615: fix D-11 no-op branch unused EAV (low-risk hotfix)

### DIFF
--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -181,22 +181,24 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
 
         String newSrc = computeNewSrc(existingSrc);
 
-        // 2. Build conditional UpdateItem
+        // 2. Build conditional UpdateItem. Only add :new to values when the
+        // UpdateExpression actually references it; DynamoDB rejects unused
+        // ExpressionAttributeValues with ValidationException.
         Map<String, AttributeValue> values = new HashMap<>();
-        values.put(":new", new AttributeValue().withS(newSrc));
         values.put(":ts", new AttributeValue().withN(String.valueOf(epochSeconds)));
 
         UpdateItemRequest req = new UpdateItemRequest()
                 .withTableName(TABLE_NAME)
-                .withKey(key)
-                .withExpressionAttributeValues(values);
+                .withKey(key);
 
         if (existingSrc == null) {
             // New row: write src + frd, condition on src absence
+            values.put(":new", new AttributeValue().withS(newSrc));
             req.withUpdateExpression("SET src = :new, frd = if_not_exists(frd, :ts)")
                .withConditionExpression("attribute_not_exists(src)");
         } else if (!newSrc.equals(existingSrc)) {
             // Transition: condition on observed existing value to detect concurrent write
+            values.put(":new", new AttributeValue().withS(newSrc));
             values.put(":existing", new AttributeValue().withS(existingSrc));
             req.withUpdateExpression("SET src = :new, frd = if_not_exists(frd, :ts)")
                .withConditionExpression("src = :existing");
@@ -204,6 +206,7 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
             // No-op on src; ensure frd is present
             req.withUpdateExpression("SET frd = if_not_exists(frd, :ts)");
         }
+        req.withExpressionAttributeValues(values);
 
         try {
             amazonDynamoDB.updateItem(req);

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -280,6 +280,15 @@ public class ArticleProvenanceServiceImplTest {
         // No condition (since src is already correct)
         assertTrue("No conditional needed for noop: " + req.getConditionExpression(),
                 req.getConditionExpression() == null);
+        // Regression: DynamoDB rejects ExpressionAttributeValues that aren't referenced
+        // in the UpdateExpression with ValidationException. The no-op branch must NOT
+        // include :new (only :ts is referenced).
+        assertTrue(":new must not be in ExpressionAttributeValues for noop branch: "
+                        + req.getExpressionAttributeValues().keySet(),
+                !req.getExpressionAttributeValues().containsKey(":new"));
+        assertTrue(":ts must be present in ExpressionAttributeValues: "
+                        + req.getExpressionAttributeValues().keySet(),
+                req.getExpressionAttributeValues().containsKey(":ts"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Promotes commit `09cd0ec1` (PR #615) from `development` to `master`. **One-commit delta**, no other changes.

Phase 33's D-11 transition path was unconditionally adding `:new` to `ExpressionAttributeValues` even on the no-op branch (where `src` is already in a terminal state — `MAN`, `MAN_FROM_PM`, `MAN_FROM_CTSC` — and only `frd` is being maintained). DynamoDB rejects this with:

```
ValidationException: Value provided in ExpressionAttributeValues unused in expressions: keys: {:new}
```

The catch in `applyD11Transition` swallows it as a warning, so no curator request fails — but every no-op transition produces a noisy log line (currently observable in prod pod logs) and the conditional `frd` write is rejected silently.

## Risk

**Low.** Two-file change:
- `ArticleProvenanceServiceImpl.java`: `:new` is now added to the values map only on branches whose `UpdateExpression` references it. No other behavior change.
- `ArticleProvenanceServiceImplTest.java`: existing no-op test strengthened to assert `:new` is absent. All 28 tests pass.

## Dev validation

- Merged to development, deployed to dev EKS as image 590.2026-05-06.14.52.11.2632bc04
- Feature-generator regression: thc2015 returns 106 articles, recall=1.0, precision=0.81 (matches prod)
- Dev pod logs clean: 3,129 lines captured during smoke test, zero D-11 / unused in expressions warnings, zero WARN/ERROR

## Test plan

- [ ] Approve prod pipeline (ReCiter-Production)
- [ ] After EKS rollout, tail prod pod logs and confirm warnings stop on subsequent curator activity