### PR TITLE
fix: skip non-numeric CommentsCorrections PMIDs in ArticleTranslator

### DIFF
--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -462,11 +462,17 @@ public class ArticleTranslator {
             Map<Long, String> commentsCorrectionsRefTypes = new HashMap<>();
             List<MedlineCitationCommentsCorrections> commentsCorrectionsList = pubmedArticle.getMedlinecitation().getCommentscorrectionslist();
             for (MedlineCitationCommentsCorrections medlineCitationCommentsCorrections : commentsCorrectionsList) {
-                if(medlineCitationCommentsCorrections.getPmid() != null) {
-                    Long ccPmid = Long.parseLong(medlineCitationCommentsCorrections.getPmid());
-                    commentsCorrectionsPmids.add(ccPmid);
-                    if (medlineCitationCommentsCorrections.getReftype() != null) {
-                        commentsCorrectionsRefTypes.put(ccPmid, medlineCitationCommentsCorrections.getReftype());
+                String ccPmidStr = medlineCitationCommentsCorrections.getPmid();
+                if (ccPmidStr != null) {
+                    if (ccPmidStr.matches("\\d+")) {
+                        Long ccPmid = Long.parseLong(ccPmidStr);
+                        commentsCorrectionsPmids.add(ccPmid);
+                        if (medlineCitationCommentsCorrections.getReftype() != null) {
+                            commentsCorrectionsRefTypes.put(ccPmid, medlineCitationCommentsCorrections.getReftype());
+                        }
+                    } else {
+                        slf4jLogger.debug("Skipping non-numeric CommentsCorrections PMID for article {}: {}",
+                                pubmedArticle.getMedlinecitation().getMedlinecitationpmid().getPmid(), ccPmidStr);
                     }
                 }
             }

--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -412,6 +412,7 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 		}
 		return entries;
 	}
+
 	/**
 	 * Phase 33-02: emit FeedbackLog rows + ArticleProvenance D-11/D-13 transitions for
 	 * every curator action implied by the diff between incoming GS state and existing

--- a/src/test/java/reciter/algorithm/util/ArticleTranslatorTest.java
+++ b/src/test/java/reciter/algorithm/util/ArticleTranslatorTest.java
@@ -1,0 +1,64 @@
+package reciter.algorithm.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import reciter.model.article.ReCiterArticle;
+import reciter.model.pubmed.MedlineCitationCommentsCorrections;
+import reciter.model.pubmed.PubMedArticle;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ArticleTranslatorTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private PubMedArticle pubmedArticle;
+
+    @Before
+    public void setUp() {
+        when(pubmedArticle.getPubmeddata()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getArticle().getJournal()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getArticle().getPublicationtypelist()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getArticle().getPublicationAbstract()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getArticle().getAuthorlist()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getKeywordlist()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getMeshheadinglist()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getArticle().getArticledate()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getArticle().getGrantlist()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getArticle().getPagination()).thenReturn(null);
+        when(pubmedArticle.getMedlinecitation().getArticle().getElocationid()).thenReturn(null);
+    }
+
+    @Test
+    public void translateSkipsNonNumericCommentsCorrectionsAndKeepsNumeric() {
+        MedlineCitationCommentsCorrections pmcEntry = new MedlineCitationCommentsCorrections();
+        pmcEntry.setPmid("PMC7149824");
+        pmcEntry.setReftype("ErratumIn");
+
+        MedlineCitationCommentsCorrections textEntry = new MedlineCitationCommentsCorrections();
+        textEntry.setPmid("Zhu X., Han J. (2020). A novel circular RNA. BMC Cancer 20, 1190.");
+
+        MedlineCitationCommentsCorrections numericEntry = new MedlineCitationCommentsCorrections();
+        numericEntry.setPmid("32648546");
+        numericEntry.setReftype("ErratumFor");
+
+        List<MedlineCitationCommentsCorrections> ccList = Arrays.asList(pmcEntry, textEntry, numericEntry);
+        when(pubmedArticle.getMedlinecitation().getCommentscorrectionslist()).thenReturn(ccList);
+
+        ReCiterArticle result = ArticleTranslator.translate(pubmedArticle, null, "", null);
+
+        assertEquals(1, result.getCommentsCorrectionsPmids().size());
+        assertTrue(result.getCommentsCorrectionsPmids().contains(32648546L));
+        assertEquals("ErratumFor", result.getCommentsCorrectionsRefTypes().get(32648546L));
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes `NumberFormatException` crash in `ArticleTranslator.translate()` when a `CommentsCorrections` PMID field contains a PMC ID (e.g. `"PMC7149824"`) or a free-text citation string
- Validates each value with a digit-only check before calling `Long.parseLong`; non-numeric values are logged at DEBUG and skipped; numeric siblings are still recorded
- Adds `ArticleTranslatorTest` covering: no throw on non-numeric input, non-numeric PMIDs excluded, numeric PMID retained with its RefType

Closes #617.

## Test results (dev)

Tested on dev after merge. Both previously-failing users now return HTTP 200:

| uid | Before | After |
|-----|--------|-------|
| naa2018 | 500 `NumberFormatException: "PMC7149824"` | 200, 1 article scored |
| rjl4004 | 500 `NumberFormatException: "Zhu X…"` | 200, scoring complete |

## Test plan

- [x] Unit test: `ArticleTranslatorTest.translateSkipsNonNumericCommentsCorrectionsAndKeepsNumeric`
- [x] Dev smoke test: `naa2018` and `rjl4004` — both HTTP 200 after deploy