### PR TITLE
fix(retrieval): suppress empty and degenerate PubMed ESearch queries

### DIFF
--- a/src/main/java/reciter/xml/retriever/pubmed/AbstractNameRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/AbstractNameRetrievalStrategy.java
@@ -53,11 +53,10 @@ public abstract class AbstractNameRetrievalStrategy extends AbstractRetrievalStr
 		List<PubMedQueryType> pubMedQueries = new ArrayList<PubMedQueryType>();
 
 		PubMedQueryType pubMedQueryType = new PubMedQueryType();
-		Set<AuthorName> originalIdentityNames = new HashSet<>();
+		Set<AuthorName> originalIdentityNames = identityNames.getOrDefault(IdentityNameType.ORIGINAL, new HashSet<>());
 		for(Entry<IdentityNameType, Set<AuthorName>> identityName: identityNames.entrySet()) {
-			
+
 			if(identityName.getKey() == IdentityNameType.ORIGINAL) {
-				originalIdentityNames = identityName.getValue();
 				pubMedQueryType.setLenientQuery(new PubMedQueryResult(buildNameQuery(identityName.getValue(), identity)));
 				pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(buildNameQuery(identityName.getValue(), identity)));
 			} else {
@@ -101,10 +100,9 @@ public abstract class AbstractNameRetrievalStrategy extends AbstractRetrievalStr
 		List<PubMedQueryType> pubMedQueries = new ArrayList<PubMedQueryType>();
 		
 		PubMedQueryType pubMedQueryType = new PubMedQueryType();
+		Set<AuthorName> originalIdentityNames = identityNames.getOrDefault(IdentityNameType.ORIGINAL, new HashSet<>());
 		for(Entry<IdentityNameType, Set<AuthorName>> identityName: identityNames.entrySet()) {
-			Set<AuthorName> originalIdentityNames = new HashSet<>();
 			if(identityName.getKey() == IdentityNameType.ORIGINAL) {
-				originalIdentityNames = identityName.getValue();
 				pubMedQueryType.setLenientQuery(new PubMedQueryResult(buildNameQuery(identityName.getValue(), identity, startDate, endDate)));
 				pubMedQueryType.setLenientCountQuery(new PubMedQueryResult(buildNameQuery(identityName.getValue(), identity)));
 			} else {

--- a/src/main/java/reciter/xml/retriever/pubmed/AbstractRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/AbstractRetrievalStrategy.java
@@ -135,7 +135,13 @@ public abstract class AbstractRetrievalStrategy implements RetrievalStrategy {
 		for (PubMedQueryType pubMedQueryType : pubMedQueries) {
 			
 			PubMedQuery encodedInitialCountQuery = pubMedQueryType.getLenientCountQuery().getQuery();
-			handler = getNumberOfResults(encodedInitialCountQuery);
+			String countQueryStr = encodedInitialCountQuery == null ? "" : encodedInitialCountQuery.toString().trim();
+			if (countQueryStr.isEmpty() || countQueryStr.equals("()")) {
+				slf4jLogger.info("Skipping degenerate count query [{}] for strategy [{}]", countQueryStr, getRetrievalStrategyName());
+				handler = 0;
+			} else {
+				handler = getNumberOfResults(encodedInitialCountQuery);
+			}
 			if(!useStrictQueryOnly) {
 				slf4jLogger.info("Constructed lenient count query {}", pubMedQueryType.getLenientCountQuery().getQuery());
 				slf4jLogger.info("Constructed lenient query {}", pubMedQueryType.getLenientQuery().getQuery());

--- a/src/main/java/reciter/xml/retriever/pubmed/SecondInitialRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/SecondInitialRetrievalStrategy.java
@@ -104,11 +104,15 @@ public class SecondInitialRetrievalStrategy extends AbstractNameRetrievalStrateg
 				}
 			}
 			buf.append(")");
-			if(buf.toString().endsWith(" OR )")) {
-				return buf.toString().substring(0, buf.toString().length() - 5) + ")";
+			String result = buf.toString();
+			if(result.equals("()")) {
+				return null;
+			}
+			if(result.endsWith(" OR )")) {
+				return result.substring(0, result.length() - 5) + ")";
 			}
 			else {
-				return buf.toString();
+				return result;
 			}
 		} else {
 			return null;

--- a/src/test/java/reciter/xml/retriever/pubmed/SecondInitialRetrievalStrategyTest.java
+++ b/src/test/java/reciter/xml/retriever/pubmed/SecondInitialRetrievalStrategyTest.java
@@ -1,0 +1,64 @@
+package reciter.xml.retriever.pubmed;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.springframework.test.util.ReflectionTestUtils.invokeMethod;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import reciter.model.identity.AuthorName;
+import reciter.model.identity.Identity;
+
+public class SecondInitialRetrievalStrategyTest {
+
+	private final SecondInitialRetrievalStrategy strategy = new SecondInitialRetrievalStrategy();
+
+	private Identity identity(AuthorName primary, Set<AuthorName> alternates) {
+		Identity id = new Identity();
+		id.setPrimaryName(primary);
+		id.setAlternateNames(alternates == null ? Collections.<AuthorName>emptyList() : new java.util.ArrayList<>(alternates));
+		return id;
+	}
+
+	private AuthorName name(String first, String middle, String last) {
+		return new AuthorName(first, middle, last);
+	}
+
+	// Bug repro: "Eulho Jung" -> only one uppercase letter, no qualifying alternates -> previously returned "()"
+	@Test
+	public void singleUppercase_noAlternates_returnsNull() {
+		Identity id = identity(name("Eulho", null, "Jung"), Collections.<AuthorName>emptySet());
+		String keyword = invokeMethod(strategy, "getStrategySpecificKeyword", id);
+		assertNull("Single-uppercase first name with no alternates must not produce '()'", keyword);
+	}
+
+	// Same bug with single-uppercase alternates that also fail the >=2 check
+	@Test
+	public void singleUppercase_unqualifiedAlternates_returnsNull() {
+		Set<AuthorName> alts = new LinkedHashSet<>();
+		alts.add(name("eulho", null, "jung"));
+		Identity id = identity(name("Eulho", null, "Jung"), alts);
+		String keyword = invokeMethod(strategy, "getStrategySpecificKeyword", id);
+		assertNull("All-lowercase variants should not produce '()'", keyword);
+	}
+
+	// Positive case: two-uppercase first name should still produce a normal author query
+	@Test
+	public void twoUppercase_returnsAuthorQuery() {
+		Identity id = identity(name("McAdams", null, "Smith"), Collections.<AuthorName>emptySet());
+		String keyword = invokeMethod(strategy, "getStrategySpecificKeyword", id);
+		assertEquals("(Smith MA[au])", keyword);
+	}
+
+	// Positive case: first + middle giving two uppercase letters
+	@Test
+	public void firstAndMiddleUppercase_returnsAuthorQuery() {
+		Identity id = identity(name("John", "Robert", "Doe"), Collections.<AuthorName>emptySet());
+		String keyword = invokeMethod(strategy, "getStrategySpecificKeyword", id);
+		assertEquals("(Doe JR[au])", keyword);
+	}
+}


### PR DESCRIPTION
## Summary

Three independent bugs were emitting wasteful PubMed ESearch queries during article retrieval. Surfaced while investigating the May 3-4 inst-client incident; not the cause of that incident, but real correctness/efficiency issues worth fixing.

### Bug 1 — \`SecondInitialRetrievalStrategy\` returns \`"()"\`
When no name (primary or alternates) has two uppercase letters in \`firstName + middleName\`, the strategy returned the literal string \`"()"\`. PubMed responds with \`"Empty term and query_key - nothing todo"\`. Reproduced in prod for \`euj4002\` (Eulho Jung) — log line \`SecondInitialRetrievalStrategy produced query=[()]\`.

### Bug 2 — \`AbstractNameRetrievalStrategy\` order-dependent fallback
\`originalIdentityNames\` is initialized to an empty \`HashSet\` and populated only when the loop encounters the \`ORIGINAL\` key. Since \`identityNames\` is a \`HashMap\` (no guaranteed iteration order), the strict-fallback branch could fire before \`ORIGINAL\` was seen and pass an empty set to \`buildNameQuery\`, producing \`term=\` queries. Reproduced in prod for the same UID — \`FirstNameInitialRetrievalStrategy produced query=[]\` and \`FullNameRetrievalStrategy produced query=[]\`.

### Bug 3 — \`AbstractRetrievalStrategy\` always hits PubMed
\`getNumberOfResults()\` was called unconditionally even when the count query was empty or \`"()"\`. We now short-circuit to \`handler=0\` and log the skipped strategy.

## Changes

- \`SecondInitialRetrievalStrategy.java\` — return \`null\` when buf collapses to \`"()"\`
- \`AbstractNameRetrievalStrategy.java\` — pre-populate \`originalIdentityNames\` from the map before the loop (both \`buildQuery\` overloads)
- \`AbstractRetrievalStrategy.java\` — guard \`getNumberOfResults()\` against empty / \`"()"\` queries

## Test plan
- [x] New \`SecondInitialRetrievalStrategyTest\` (4 tests) — bug repro + positive cases pass
- [x] Existing retrieval tests still pass (12/12)
- [ ] Smoke test on dev EKS post-deploy: re-run \`euj4002\` and verify no \`produced query=[]\` / \`produced query=[()]\` lines in logs
- [ ] Confirm full retrieval result set unchanged for a known user (e.g., \`myleswo\`, \`euj4002\`)