### PR TITLE
fix(dynamodb): null-guard S3 ops when bucket is unavailable

### DIFF
--- a/src/main/java/reciter/database/dynamodb/DynamoDbS3Operations.java
+++ b/src/main/java/reciter/database/dynamodb/DynamoDbS3Operations.java
@@ -54,7 +54,16 @@ public class DynamoDbS3Operations {
 	 * @param keyName
 	 */
 	public void saveLargeItem(String bucketName, Object object, String keyName) {
-		
+		// Skip S3 entirely when client or bucket is unavailable (e.g., standalone
+		// local mode with aws.s3.use=false). The previous code's else branch
+		// dereferenced bucketName.toLowerCase() unconditionally, producing
+		// NullPointerException for any Analysis object large enough to spill
+		// (>400KB DynamoDB item limit). The S3 cache is best-effort; callers
+		// don't depend on it for the API response.
+		if (s3 == null || bucketName == null) {
+			return;
+		}
+
 		if(s3 != null && bucketName != null && !s3.doesObjectExist(bucketName.toLowerCase(), keyName)) {
 			
 			//AmazonS3Config.createFolder(bucketName, AnalysisOutput.class.getName(), s3);
@@ -114,6 +123,12 @@ public class DynamoDbS3Operations {
 	 * @return
 	 */
 	public <T> Object retrieveLargeItem(String bucketName, String keyName, Class<T> objectClass) {
+		// Match the null guard in saveLargeItem. Return null so callers fall back
+		// to the standard DynamoDB read path (which the caller already does for
+		// items <= 400KB).
+		if (s3 == null || bucketName == null) {
+			return null;
+		}
 		try {
 			S3Object s3Object = s3.getObject(new GetObjectRequest(bucketName.toLowerCase(), keyName));
 			String objectContent = IOUtils.toString(s3Object.getObjectContent(), StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary

`DynamoDbS3Operations.saveLargeItem` and `retrieveLargeItem` both dereference `bucketName.toLowerCase()` without null-checking the bucket name, throwing `NullPointerException` for any call when the S3 client is disabled (e.g., `aws.s3.use=false` in standalone/local mode, or any other path where the bucket is unset).

## Root cause

```java
// saveLargeItem
if (s3 != null && bucketName != null && !s3.doesObjectExist(bucketName.toLowerCase(), keyName)) {
    // upload — guarded
} else {
    log.info("Deleting Object from bucket " + bucketName + ...);
    s3.deleteObject(bucketName.toLowerCase(), keyName);  // ← NPE when bucketName == null
    ...
}

// retrieveLargeItem
public <T> Object retrieveLargeItem(String bucketName, String keyName, ...) {
    try {
        S3Object s3Object = s3.getObject(new GetObjectRequest(bucketName.toLowerCase(), keyName));  // ← NPE when bucketName == null
        ...
    }
}
```

The outer `if` in `saveLargeItem` checks `bucketName != null`, but the `else` branch (taken when an existing object needs to be replaced — or when `s3 == null` / `bucketName == null` short-circuit the AND) calls `bucketName.toLowerCase()` unconditionally. `retrieveLargeItem` has no guard at all.

## Trigger

Surfaced during cross-institutional external validation. With `aws.s3.use=false`, the bucket name passed to these methods is null. Researchers with very common short last names (Liu, Chen, Lee, Li, Wang, …) produce PubMed candidate pools and `Analysis` outputs that exceed DynamoDB's 400KB per-item limit, which spills to S3 via `saveLargeItem`/`retrieveLargeItem`. Every such request returned HTTP 500. Approximately 10% of researchers in a 7,581-person external-validation run were affected, concentrated in institutions with many East Asian researchers.

## Fix

Short-circuit both methods when `s3 == null || bucketName == null`. The S3 spill cache is best-effort: callers (`PubMedServiceImpl.findByPmids`, `ReCiterFeedbackArticleScorer`, etc.) receive feature-generator results directly via the API response, and `findByPmids` already iterates with null-safe element handling.

## Test plan

- [ ] Spin up standalone local stack (`scripts/start_local_reciter.sh` with `aws.s3.use=false` in `application.properties`) before this fix → HTTP 500 with `NullPointerException` on any UID whose Analysis exceeds 400KB.
- [ ] Same stack with this fix applied → HTTP 200, valid feature-generator response.
- [ ] Confirm no regression in deployed environment (where `aws.s3.use=true` and bucketName is always set, the new guard never fires).
- [ ] Empirically: in a 7,581-UID external-validation run, this fix recovered ~10% of previously-failing UIDs (concentrated on short-common-name authors with large candidate pools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)