### PR TITLE
fix: harden latent NPEs flagged in #625 review

### DIFF
--- a/src/main/java/reciter/controller/IdentityController.java
+++ b/src/main/java/reciter/controller/IdentityController.java
@@ -98,13 +98,14 @@ public class IdentityController {
     public void saveIdentities(@RequestBody List<Identity> identities) {
         StopWatch stopWatch = new StopWatch("Add list of identities to Identity table in DynamoDb");
         stopWatch.start("Add list of identities to Identity table in DynamoDb");
-        log.info("calling saveIdentities with number of identities=" + identities.size());
         
         if (identities == null || identities.isEmpty()) {
             stopWatch.stop();
             log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
             log.info("The request body must contain at least one Identity");
+            return;
         }
+        log.info("calling saveIdentities with number of identities=" + identities.size());
      
         for(Identity identity : identities)
         {	
@@ -246,11 +247,11 @@ public class IdentityController {
     private void validateMandatoryFields(Identity identity) {
         String[] mandatoryFields = getMandatoryFields();
 
-        List<AuthorName> listofAuthorNames = identity.getAlternateNames();
-        
-        if (identity ==null || identity.getUid() == null || identity.getUid().isEmpty()) {
+        if (identity == null || identity.getUid() == null || identity.getUid().isEmpty()) {
             throw new IllegalArgumentException("Field 'Uid' in Identity is required but not provided.");
         }
+
+        List<AuthorName> listofAuthorNames = identity.getAlternateNames();
        if(listofAuthorNames!=null) {
         for (AuthorName authorName : listofAuthorNames) {
             // Ensure each field is present and valid

--- a/src/main/java/reciter/database/dynamodb/DynamoDbS3Operations.java
+++ b/src/main/java/reciter/database/dynamodb/DynamoDbS3Operations.java
@@ -171,6 +171,12 @@ public class DynamoDbS3Operations {
 	 * @return date of the object that was stored
 	 */
 	public Date getObjectSaveTimestamp(String bucketName, String keyName) {
+		// Match the null guards in saveLargeItem / retrieveLargeItem. Return null
+		// when the S3 client or bucket is unavailable so the caller falls back to
+		// a fresh DynamoDB read instead of throwing NullPointerException.
+		if (s3 == null || bucketName == null) {
+			return null;
+		}
 		try {
 			S3Object s3Object = s3.getObject(new GetObjectRequest(bucketName.toLowerCase(), keyName));
 			Date lastModifedDate = s3Object.getObjectMetadata().getLastModified();


### PR DESCRIPTION
## Summary

Follow-up to the #625 review. Fixes three latent `NullPointerException`s in code already on `development` — two flagged during that review, plus one identical-pattern bug found alongside it in the same file.

## Fixes

### 1. `DynamoDbS3Operations.getObjectSaveTimestamp` — missing null guard  *(flagged in #625 review)*

#625 added `s3 == null || bucketName == null` guards to `saveLargeItem` and `retrieveLargeItem`, but left `getObjectSaveTimestamp` with the same unguarded `s3.getObject(new GetObjectRequest(bucketName.toLowerCase(), …))` — the last unguarded S3 read method in the class, throwing `NullPointerException` when `aws.s3.use=false`. Added the matching guard; it returns `null`, which the sole caller (`IdentityServiceImpl.findAll`) already treats as a cache miss. Not a live bug today (that caller is gated behind `isS3Use`), but it makes the class uniformly safe.

### 2. `IdentityController.saveIdentities` — empty/null check did not return  *(flagged in #625 review)*

The `if (identities == null || identities.isEmpty())` block logged a message but did not `return`, and ran *after* `identities.size()` had already been called. A null request body threw `NullPointerException` (and an empty body silently fell through to a no-op save). The guard now runs before any dereference of `identities` and returns early.

### 3. `IdentityController.validateMandatoryFields` — dereference before null check  *(found alongside #2 — not in the original review flags)*

`identity.getAlternateNames()` was dereferenced before the `identity == null` check, so a null `identity` threw `NullPointerException` instead of the intended `IllegalArgumentException`. Reordered the null check ahead of the dereference; both callers already catch `IllegalArgumentException`.

## Relationship to #626

All three live in code that is part of the open `development → master` PR #626. Merging this into `development` before #626 is merged folds the fixes into that promotion and resolves #626's "Follow-up (non-blocking)" note about `getObjectSaveTimestamp`.

## Verification

- `BUILD SUCCESS` on the fix branch (Java 17).
- Test suite: 82 tests, 0 failures, 2 errors — the same pre-existing `@Spy`-on-JDK-collection failures in `TargetAuthorSelectionTest` present on `development`; no new failures introduced.
