### PR TITLE
AAR curation attribution: capture curatedBy + tag Authorship Review curations (EntryPath.PM_AUTHOR)

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -86,6 +86,8 @@ import reciter.service.OrcidService;
 import reciter.service.PubMedService;
 import reciter.service.ScopusService;
 import reciter.service.dynamo.IDynamoDbGoldStandardService;
+import reciter.service.dynamo.FeedbackLogQueryService;
+import reciter.service.dynamo.AuditHistoryEntry;
 import reciter.utils.AuthorNameSanitizationUtils;
 import reciter.utils.GenderProbability;
 import reciter.utils.InstitutionSanitizationUtil;
@@ -121,6 +123,9 @@ public class ReCiterController {
     @Autowired
     private IDynamoDbGoldStandardService dynamoDbGoldStandardService;
 
+    @Autowired
+    private FeedbackLogQueryService feedbackLogQueryService;
+
     @Value("${use.scopus.articles}")
     private boolean useScopusArticles;
     
@@ -153,7 +158,8 @@ public class ReCiterController {
     @ResponseBody
     public ResponseEntity updateGoldStandard(@RequestBody GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
     		@RequestParam(value = "source", required = false) String provenanceSource,
-    		@RequestParam(value = "entryPath", required = false) String entryPathParam) {
+    		@RequestParam(value = "entryPath", required = false) String entryPathParam,
+    		@RequestParam(value = "curatedBy", required = false, defaultValue = "0") int curatedBy) {
         StopWatch stopWatch = new StopWatch("Update GoldStandard");
         stopWatch.start("Update GoldStandard");
     	if(goldStandard == null) {
@@ -165,12 +171,12 @@ public class ReCiterController {
     	if(goldStandardUpdateFlag == null ||
     			goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE || goldStandardUpdateFlag == GoldStandardUpdateFlag.DELETE) {
     		if(goldStandardUpdateFlag == null) {
-    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource, entryPath);
+    			dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.UPDATE, provenanceSource, entryPath, curatedBy);
     		} else {
-    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
+    			dynamoDbGoldStandardService.save(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath, curatedBy);
     		}
     	} else {
-    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource, entryPath);
+    		dynamoDbGoldStandardService.save(goldStandard, GoldStandardUpdateFlag.REFRESH, provenanceSource, entryPath, curatedBy);
         }
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
@@ -229,6 +235,28 @@ public class ReCiterController {
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
         return ResponseEntity.ok(goldStandard);
+    }
+
+    @ApiOperation(value = "Get curation audit history (FeedbackLog + ArticleProvenance) for a uid",
+            notes = "Returns the curator action history (accept/reject/pending) for the person, newest first, each row enriched with how the PMID first arrived (ArticleProvenance).")
+    @ApiImplicitParams({
+    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Audit history retrieval successful"),
+            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
+            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    })
+    @RequestMapping(value = "/reciter/feedback-log/{uid}", method = RequestMethod.GET, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity<List<AuditHistoryEntry>> retrieveFeedbackLogByUid(@PathVariable String uid) {
+        StopWatch stopWatch = new StopWatch("Get curation audit history by uid");
+        stopWatch.start("Get curation audit history by uid");
+        List<AuditHistoryEntry> history = feedbackLogQueryService.getAuditHistory(uid);
+        stopWatch.stop();
+        log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+        return ResponseEntity.ok(history);
     }
 
     @ApiOperation(value = "Delete a gold standard record by uid", notes = "This api deletes a gold standard record from the GoldStandard table by uid.")

--- a/src/main/java/reciter/feedback/EntryPath.java
+++ b/src/main/java/reciter/feedback/EntryPath.java
@@ -14,11 +14,19 @@ package reciter.feedback;
  *   <li>{@link #PUBMED_SEARCH} — curator queried PubMed inside PM's UI and accepted
  *       (or rejected) a result. The Java write path treats this as its own
  *       retrieval strategy with {@code rs='PM_UI_SEARCH'} (D-13).</li>
+ *   <li>{@link #PM_AUTHOR} — curator acted on a row in the PM Authorship Review tab
+ *       (the adversarial-attribution-review queue of WCM authorships production buried
+ *       or never scored). The Java write path stamps {@code rs='PM_AUTHOR'} into the
+ *       ArticleProvenance strategy set so these curations are auditable, but — unlike
+ *       PUBMED_SEARCH — it does NOT seed {@code src='PM'}: a never-retrieved authorship
+ *       stays {@code src='MAN'} (algo-missed, curator-found) while an already-retrieved
+ *       one still lifts to {@code MAN_FROM_PM} via the D-11 transition.</li>
  * </ul>
  */
 public enum EntryPath {
     CANDIDATE_LIST,
-    PUBMED_SEARCH;
+    PUBMED_SEARCH,
+    PM_AUTHOR;
 
     /**
      * Resolve a string to {@link EntryPath} with case-insensitive matching.

--- a/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ArticleProvenanceServiceImpl.java
@@ -37,6 +37,7 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
     private static final Logger log = LoggerFactory.getLogger(ArticleProvenanceServiceImpl.class);
     private static final String TABLE_NAME = "ArticleProvenance";
     private static final String PM_UI_SEARCH_RS = "PM_UI_SEARCH";
+    private static final String PM_AUTHOR_RS = "PM_AUTHOR";
     private static final String SRC_PM = "PM";
     private static final String SRC_CTSC = "CTSC";
     private static final String SRC_GS_PLACEHOLDER = "GS";
@@ -113,6 +114,10 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
         // sees src='PM' and lifts to MAN_FROM_PM. CANDIDATE_LIST skips this step.
         if (path == EntryPath.PUBMED_SEARCH) {
             writePmUiSearchRecord(uid, pmid, epochSeconds);
+        } else if (path == EntryPath.PM_AUTHOR) {
+            // Authorship Review tab: stamp the PM_AUTHOR entry-path marker into rs/ads so
+            // these curations are auditable, but do NOT seed src='PM' (see writePmAuthorRecord).
+            writePmAuthorRecord(uid, pmid, epochSeconds);
         }
 
         // D-11 transition with one retry on race
@@ -149,6 +154,42 @@ public class ArticleProvenanceServiceImpl implements ArticleProvenanceService {
             amazonDynamoDB.updateItem(req);
         } catch (AmazonDynamoDBException e) {
             log.warn("PM_UI_SEARCH retrieval-record write failed for uid={} pmid={}: {}",
+                    uid, pmid, e.getMessage());
+        }
+    }
+
+    /**
+     * Authorship Review tab (PM_AUTHOR) marker write. Mirrors {@link #writePmUiSearchRecord}
+     * — sets {@code rs} if absent, ensures {@code frd}, and ADDs PM_AUTHOR to the {@code ads}
+     * strategy set — but deliberately does NOT seed {@code src='PM'}. The AAR queue contains
+     * authorships production either buried (already retrieved → an ArticleProvenance row with
+     * {@code src='PM'} already exists → D-11 lifts it to MAN_FROM_PM) or never scored at all
+     * (no row → D-11 sets {@code src='MAN'} = algo-missed, curator-found). Seeding {@code src='PM'}
+     * here would wrongly relabel a never-retrieved authorship as PM-sourced.
+     */
+    private void writePmAuthorRecord(String uid, long pmid, long epochSeconds) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("uid", new AttributeValue().withS(uid));
+        key.put("articleId", new AttributeValue().withS(String.valueOf(pmid)));
+
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":rs", new AttributeValue().withS(PM_AUTHOR_RS));
+        values.put(":ts", new AttributeValue().withN(String.valueOf(epochSeconds)));
+        values.put(":rsSet", new AttributeValue().withSS(Collections.singletonList(PM_AUTHOR_RS)));
+
+        UpdateItemRequest req = new UpdateItemRequest()
+                .withTableName(TABLE_NAME)
+                .withKey(key)
+                .withUpdateExpression(
+                        "SET rs  = if_not_exists(rs,  :rs), " +
+                        "    frd = if_not_exists(frd, :ts) " +
+                        "ADD ads :rsSet")
+                .withExpressionAttributeValues(values);
+
+        try {
+            amazonDynamoDB.updateItem(req);
+        } catch (AmazonDynamoDBException e) {
+            log.warn("PM_AUTHOR marker write failed for uid={} pmid={}: {}",
                     uid, pmid, e.getMessage());
         }
     }

--- a/src/main/java/reciter/service/dynamo/AuditHistoryEntry.java
+++ b/src/main/java/reciter/service/dynamo/AuditHistoryEntry.java
@@ -1,0 +1,29 @@
+package reciter.service.dynamo;
+
+/**
+ * One row of curation audit history for the Publication Manager UI: a FeedbackLog
+ * action (accept/reject/pending) on a PMID, enriched with that article's
+ * ArticleProvenance (how the PMID first arrived). Serialized directly to JSON.
+ */
+public class AuditHistoryEntry {
+
+    /** PubMed ID the action applied to. */
+    public String articleId;
+    /** ACCEPTED | REJECTED | PENDING. */
+    public String feedback;
+    /** Curator's admin_users.userID (0 = unknown; pre-Phase-34 rows are 0). */
+    public int curatedBy;
+    /** Action time, epoch seconds (UTC). */
+    public long createTimestamp;
+    /** FeedbackLog sort key ({@code <epoch>#<hex>}); useful for stable ordering. */
+    public String sk;
+    /** Feedback source (always "MAN" for PM-sourced actions). */
+    public String src;
+
+    /** ArticleProvenance: first retrieval strategy that found this PMID (how it arrived). */
+    public String provenanceRs;
+    /** ArticleProvenance: first retrieval date, epoch seconds (nullable). */
+    public Long provenanceFrd;
+    /** ArticleProvenance: provenance source (PM, MAN, CTSC, MAN_FROM_PM, ...). */
+    public String provenanceSrc;
+}

--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -69,10 +69,16 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     @Override
     public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
                      String provenanceSource, EntryPath entryPath) {
-        saveInternal(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
+        saveInternal(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath, 0);
     }
 
-    private void saveInternal(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource, EntryPath entryPath) {
+    @Override
+    public void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+                     String provenanceSource, EntryPath entryPath, int curatedBy) {
+        saveInternal(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath, curatedBy);
+    }
+
+    private void saveInternal(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource, EntryPath entryPath, int curatedBy) {
     	// Resolve provenance strategy: caller-supplied source, or default
     	String strategy = (provenanceSource != null && !provenanceSource.isBlank())
     			? provenanceSource : PM_MANUAL_STRATEGY;
@@ -230,7 +236,7 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     						goldStandard.getUid(),
     						incomingAcceptedPmids, incomingRejectedPmids,
     						existingAccepted, existingRejected,
-    						entryPath);
+    						entryPath, curatedBy);
     			}
     			dynamoDbGoldStandardRepository.save(goldStandard);
     		}
@@ -339,10 +345,11 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     						auditLog.addAll(newEntries);
     						goldStandardNew.setAuditLog(auditLog);
     					}
-    					// Phase 33-02: per-uid FeedbackLog + ArticleProvenance writes for the diff
+    					// Phase 33-02: per-uid FeedbackLog + ArticleProvenance writes for the diff.
+    					// Bulk/list (PUT) path carries no interactive curator id -> curatedBy = 0.
     					recordFeedbackLogAndArticleProvenance(uid,
     							batchIncomingAccepted, batchIncomingRejected,
-    							existingAccepted, existingRejected, entryPath);
+    							existingAccepted, existingRejected, entryPath, 0);
     				}
     			}
     			dynamoDbGoldStandardRepository.saveAll(goldStandard);
@@ -430,14 +437,14 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 	 * before the D-11 transition (D-13). Both services log and continue on failure;
 	 * curator request never blocks.
 	 *
-	 * <p>{@code curatedBy} is set to 0 because the {@code POST /reciter/goldstandard}
-	 * endpoint does not currently carry a userID. Future work: extend the endpoint to
-	 * include curatedBy in the request payload.
+	 * <p>{@code curatedBy} is the curating user's id (admin_users.userID) supplied by
+	 * Publication Manager via the {@code curatedBy} request param; it is 0 when the
+	 * caller does not provide one (e.g., bulk/list updates or non-PM callers).
 	 */
 	private void recordFeedbackLogAndArticleProvenance(String uid,
 			List<Long> incomingAccepted, List<Long> incomingRejected,
 			List<Long> existingAccepted, List<Long> existingRejected,
-			EntryPath entryPath) {
+			EntryPath entryPath, int curatedBy) {
 		long actionEpoch = System.currentTimeMillis() / 1000L;
 		Set<Long> incomingAccSet = new HashSet<>(incomingAccepted);
 		Set<Long> incomingRejSet = new HashSet<>(incomingRejected);
@@ -467,15 +474,15 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 				uid, entryPath, newlyAccepted.size(), newlyRejected.size(), newlyPending.size());
 
 		for (Long pmid : newlyAccepted) {
-			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.ACCEPTED, 0, actionEpoch);
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.ACCEPTED, curatedBy, actionEpoch);
 			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
 		}
 		for (Long pmid : newlyRejected) {
-			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.REJECTED, 0, actionEpoch);
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.REJECTED, curatedBy, actionEpoch);
 			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
 		}
 		for (Long pmid : newlyPending) {
-			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.PENDING, 0, actionEpoch);
+			feedbackLogService.recordAction(uid, pmid, FeedbackLogService.Feedback.PENDING, curatedBy, actionEpoch);
 			articleProvenanceService.upsertCuratorAction(uid, pmid, entryPath, actionEpoch);
 		}
 	}

--- a/src/main/java/reciter/service/dynamo/FeedbackLogQueryService.java
+++ b/src/main/java/reciter/service/dynamo/FeedbackLogQueryService.java
@@ -1,0 +1,164 @@
+package reciter.service.dynamo;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest;
+import com.amazonaws.services.dynamodbv2.model.QueryResult;
+
+/**
+ * Read-side service for curation audit history (Phase 34).
+ *
+ * <p>Queries the {@code FeedbackLog} table (curator accept/reject/pending actions)
+ * by {@code uid} and enriches each row with the matching {@code ArticleProvenance}
+ * record (how the PMID first arrived). Uses raw {@code AmazonDynamoDB.query},
+ * mirroring the write side ({@link FeedbackLogServiceImpl},
+ * {@link ArticleProvenanceServiceImpl}).
+ */
+@Service
+public class FeedbackLogQueryService {
+
+    private static final Logger log = LoggerFactory.getLogger(FeedbackLogQueryService.class);
+    private static final String FEEDBACK_LOG_TABLE = "FeedbackLog";
+    private static final String ARTICLE_PROVENANCE_TABLE = "ArticleProvenance";
+    private static final int MAX_ROWS = 2000;
+
+    private final AmazonDynamoDB amazonDynamoDB;
+
+    @Autowired
+    public FeedbackLogQueryService(AmazonDynamoDB amazonDynamoDB) {
+        this.amazonDynamoDB = amazonDynamoDB;
+    }
+
+    /**
+     * Return the curation audit history for a uid, newest action first, each row
+     * enriched with the article's retrieval provenance. Capped at {@value #MAX_ROWS}
+     * rows (logged if truncated).
+     */
+    public List<AuditHistoryEntry> getAuditHistory(String uid) {
+        List<AuditHistoryEntry> entries = new ArrayList<>();
+        if (uid == null || uid.isEmpty()) {
+            return entries;
+        }
+
+        Map<String, ProvenanceInfo> provenance = loadProvenance(uid);
+
+        Map<String, AttributeValue> lastKey = null;
+        do {
+            QueryRequest req = new QueryRequest()
+                    .withTableName(FEEDBACK_LOG_TABLE)
+                    .withKeyConditionExpression("uid = :uid")
+                    .addExpressionAttributeValuesEntry(":uid", new AttributeValue().withS(uid))
+                    .withScanIndexForward(false); // newest sk (highest epoch) first
+            if (lastKey != null) {
+                req.setExclusiveStartKey(lastKey);
+            }
+            QueryResult result = amazonDynamoDB.query(req);
+            for (Map<String, AttributeValue> item : result.getItems()) {
+                entries.add(toEntry(item, provenance));
+                if (entries.size() >= MAX_ROWS) {
+                    log.warn("FeedbackLog audit history for uid={} truncated at {} rows", uid, MAX_ROWS);
+                    return entries;
+                }
+            }
+            lastKey = result.getLastEvaluatedKey();
+        } while (lastKey != null && !lastKey.isEmpty());
+
+        return entries;
+    }
+
+    private AuditHistoryEntry toEntry(Map<String, AttributeValue> item, Map<String, ProvenanceInfo> provenance) {
+        AuditHistoryEntry e = new AuditHistoryEntry();
+        e.articleId = getS(item, "articleId");
+        e.feedback = getS(item, "feedback");
+        e.curatedBy = getNInt(item, "curatedBy");
+        e.createTimestamp = getNLong(item, "createTimestamp");
+        e.sk = getS(item, "sk");
+        e.src = getS(item, "src");
+        ProvenanceInfo p = (e.articleId != null) ? provenance.get(e.articleId) : null;
+        if (p != null) {
+            e.provenanceRs = p.rs;
+            e.provenanceFrd = p.frd;
+            e.provenanceSrc = p.src;
+        }
+        return e;
+    }
+
+    /** Load all ArticleProvenance rows for a uid into an articleId -> provenance map. */
+    private Map<String, ProvenanceInfo> loadProvenance(String uid) {
+        Map<String, ProvenanceInfo> map = new HashMap<>();
+        try {
+            Map<String, AttributeValue> lastKey = null;
+            do {
+                QueryRequest req = new QueryRequest()
+                        .withTableName(ARTICLE_PROVENANCE_TABLE)
+                        .withKeyConditionExpression("uid = :uid")
+                        .addExpressionAttributeValuesEntry(":uid", new AttributeValue().withS(uid));
+                if (lastKey != null) {
+                    req.setExclusiveStartKey(lastKey);
+                }
+                QueryResult result = amazonDynamoDB.query(req);
+                for (Map<String, AttributeValue> item : result.getItems()) {
+                    String articleId = getS(item, "articleId");
+                    if (articleId == null) {
+                        continue;
+                    }
+                    ProvenanceInfo p = new ProvenanceInfo();
+                    p.rs = getS(item, "rs");
+                    p.frd = item.containsKey("frd") ? Long.valueOf(getNLong(item, "frd")) : null;
+                    p.src = getS(item, "src");
+                    map.put(articleId, p);
+                }
+                lastKey = result.getLastEvaluatedKey();
+            } while (lastKey != null && !lastKey.isEmpty());
+        } catch (Exception e) {
+            // Provenance is enrichment only; never fail the audit-history read on it.
+            log.warn("Failed to load ArticleProvenance for uid={}: {}", uid, e.getMessage());
+        }
+        return map;
+    }
+
+    private static String getS(Map<String, AttributeValue> item, String key) {
+        AttributeValue v = item.get(key);
+        return (v == null) ? null : v.getS();
+    }
+
+    private static int getNInt(Map<String, AttributeValue> item, String key) {
+        AttributeValue v = item.get(key);
+        if (v == null || v.getN() == null) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(v.getN());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private static long getNLong(Map<String, AttributeValue> item, String key) {
+        AttributeValue v = item.get(key);
+        if (v == null || v.getN() == null) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(v.getN());
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private static class ProvenanceInfo {
+        String rs;
+        Long frd;
+        String src;
+    }
+}

--- a/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/IDynamoDbGoldStandardService.java
@@ -20,6 +20,14 @@ public interface IDynamoDbGoldStandardService {
     void save(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
               String provenanceSource, reciter.feedback.EntryPath entryPath);
 
+    /**
+     * Overload carrying the curating user's id (admin_users.userID from Publication
+     * Manager) so FeedbackLog rows record who performed the action. Other overloads
+     * default {@code curatedBy} to 0 (unknown — bulk/list updates or non-PM callers).
+     */
+    void save(GoldStandard goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag,
+              String provenanceSource, reciter.feedback.EntryPath entryPath, int curatedBy);
+
     GoldStandard findByUid(String uid);
     List<GoldStandard> findByUids(List<String> uid);
     void delete(String uid);


### PR DESCRIPTION
## AAR curation attribution — two fixes

Driven by a live verification of the Authorship Review tab's curator actions against the (shared dev/prod) DynamoDB. Two gaps were found and fixed here.

### 1. Capture `curatedBy` on the gold-standard write path (cherry-pick of `cca5a679`)
The Java goldstandard endpoint accepted no `curatedBy` request param, so every `FeedbackLog` row and audit entry was written with `curatedBy = 0` — the curator's identity was lost on the DynamoDB side (it survived only in reciterdb `authorship_review.reviewer` + MySQL `admin_feedback_log`). PM already sends `&curatedBy=<userID>`; this wires the endpoint (`@RequestParam curatedBy`) through `save → recordFeedbackLogAndArticleProvenance → FeedbackLogServiceImpl` so the real userID lands. Also adds an audit-history read endpoint (`FeedbackLogQueryService`).

### 2. Tag Authorship Review curations with `EntryPath.PM_AUTHOR`
The Authorship Review tab (the `adversarial-attribution-review` queue) sent no `entryPath`, so its curations defaulted to `CANDIDATE_LIST` and were indistinguishable from a normal candidate-list accept in `ArticleProvenance`. This adds `EntryPath.PM_AUTHOR` and stamps `rs='PM_AUTHOR'` into the provenance strategy set (`ads`) via `writePmAuthorRecord`, which **mirrors the `PUBMED_SEARCH`/`PM_UI_SEARCH` path but deliberately does NOT seed `src='PM'`**:
- AAR-queue authorships are either **already-retrieved** (an AP row with `src='PM'` exists → D-11 lifts to `MAN_FROM_PM`) or **never scored** (no row → D-11 sets `src='MAN'`, algo-missed/curator-found).
- Seeding `src='PM'` would wrongly relabel a never-retrieved authorship as PM-sourced. So `src` stays the correct lineage value; `PM_AUTHOR` is recorded only as the entry-path/strategy marker.

The companion PM change (send `entryPath=PM_AUTHOR` from `authorships.controller.ts`) is a separate PR. Unknown `entryPath` values fall back to `CANDIDATE_LIST`, so deploying this before/after PM is safe either way.

## Verification
- `mvn -DskipTests compile` → **BUILD SUCCESS** (Java 17).
- **Not** runtime-tested — needs deploy to `reciter-dev` (ReCiter CodePipeline: `development` → ManualApproval → EKS `reciter-dev`), then re-run an Authorship-tab Accept and confirm `FeedbackLog.curatedBy` = the curator's userID and `ArticleProvenance.ads` contains `PM_AUTHOR`.

## Deploy note
Both fixes write the shared production DynamoDB. This PR targets `development` (dev) only; promotion to `master`/prod is a separate, later step.
