### PR TITLE
Test coverage for scoring/provenance core; fix 2 failing TargetAuthorSelection tests

### DIFF
--- a/src/test/java/reciter/algorithm/evidence/targetauthor/TargetAuthorSelectionTest.java
+++ b/src/test/java/reciter/algorithm/evidence/targetauthor/TargetAuthorSelectionTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Spy;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,15 +14,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import reciter.model.article.ReCiterAuthor;
 import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
 import reciter.utils.AuthorNameSanitizationUtils;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TargetAuthorSelectionTest {
 
 	@BeforeClass
@@ -35,13 +31,13 @@ public class TargetAuthorSelectionTest {
 		//MockitoAnnotations.initMocks(this);
 	}
 	
-	@Spy
+	// Plain instances: these are data holders, not mocks. Spying concrete JDK
+	// collections (ArrayList/HashSet) under JDK 17 + Mockito/Objenesis instantiates
+	// them without running their constructors, leaving elementData/map null -> NPE.
 	TargetAuthorSelection targetAuthorSelection = new TargetAuthorSelection();
-	
-	@Spy
+
 	List<AuthorName> sanitizedIdentityAuthors = new ArrayList<AuthorName>();
-	
-	@Spy
+
 	Set<Entry<ReCiterAuthor, ReCiterAuthor>> multipleMarkedTargetAuthor = new HashSet<Map.Entry<ReCiterAuthor,ReCiterAuthor>>();
 
 	/*	@Test

--- a/src/test/java/reciter/engine/erroranalysis/AnalysisTest.java
+++ b/src/test/java/reciter/engine/erroranalysis/AnalysisTest.java
@@ -1,0 +1,146 @@
+package reciter.engine.erroranalysis;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import reciter.model.article.ReCiterArticle;
+
+/**
+ * Regression coverage for the precision/recall/accuracy formulas in
+ * {@link Analysis#performAnalysis(List, List)}, which were corrected in 2026-02
+ * (PENDING articles excluded from the confusion matrix; precision = TP/(TP+FP);
+ * accuracy = (TP+TN)/total). Pure function — no mocks, no AWS.
+ */
+public class AnalysisTest {
+
+    private static final int ACCEPTED = 1;
+    private static final int REJECTED = -1;
+    private static final int PENDING = 0;
+    private static final double DELTA = 1e-9;
+
+    private static ReCiterArticle article(long pmid, int goldStandard) {
+        ReCiterArticle a = new ReCiterArticle(pmid);
+        a.setGoldStandard(goldStandard);
+        return a;
+    }
+
+    @Test
+    public void allAcceptedPresent_precisionAndRecallAreOne() {
+        Analysis a = Analysis.performAnalysis(
+                Arrays.asList(article(1L, ACCEPTED), article(2L, ACCEPTED)),
+                Arrays.asList(1L, 2L));
+
+        assertEquals(2, a.getTruePos());
+        assertEquals(0, a.getFalsePos());
+        assertEquals(0, a.getFalseNeg());
+        assertEquals(1.0, a.getPrecision(), DELTA);
+        assertEquals(1.0, a.getRecall(), DELTA);
+        assertEquals(1.0, a.getAccuracy(), DELTA);
+    }
+
+    @Test
+    public void acceptedMissingFromCluster_lowersRecall() {
+        // pmid 2 is accepted in the gold standard but absent from the article set -> FN
+        Analysis a = Analysis.performAnalysis(
+                Arrays.asList(article(1L, ACCEPTED)),
+                Arrays.asList(1L, 2L));
+
+        assertEquals(1, a.getTruePos());
+        assertEquals(1, a.getFalseNeg());
+        assertEquals(1.0, a.getPrecision(), DELTA); // TP/(TP+FP) = 1/1
+        assertEquals(0.5, a.getRecall(), DELTA);    // TP/goldSize = 1/2
+    }
+
+    @Test
+    public void confirmedRejectedPresent_lowersPrecision() {
+        // pmid 3 is a confirmed rejection present in the cluster -> FP
+        Analysis a = Analysis.performAnalysis(
+                Arrays.asList(article(1L, ACCEPTED), article(3L, REJECTED)),
+                Arrays.asList(1L));
+
+        assertEquals(1, a.getTruePos());
+        assertEquals(1, a.getFalsePos());
+        assertEquals(0.5, a.getPrecision(), DELTA); // 1/(1+1)
+        assertEquals(1.0, a.getRecall(), DELTA);    // 1/1
+    }
+
+    @Test
+    public void pendingArticleIsNotCountedAsFalsePositive() {
+        // The core 2026-02 fix: a PENDING (goldStandard==0) article above threshold
+        // must be skipped, not counted as FP.
+        Analysis a = Analysis.performAnalysis(
+                Arrays.asList(article(1L, ACCEPTED), article(5L, PENDING)),
+                Arrays.asList(1L));
+
+        assertEquals(1, a.getTruePos());
+        assertEquals(0, a.getFalsePos());
+        assertEquals(1, a.getPendingSkippedCount());
+        assertEquals(1.0, a.getPrecision(), DELTA);
+    }
+
+    @Test
+    public void nullOrEmptyGoldStandard_returnsZeroedAnalysis() {
+        List<ReCiterArticle> articles = Arrays.asList(article(1L, ACCEPTED));
+
+        Analysis withNull = Analysis.performAnalysis(articles, null);
+        assertEquals(0, withNull.getTruePos());
+        assertEquals(0.0, withNull.getPrecision(), DELTA);
+        assertEquals(0.0, withNull.getRecall(), DELTA);
+        assertEquals(0.0, withNull.getAccuracy(), DELTA);
+
+        Analysis withEmpty = Analysis.performAnalysis(articles, Collections.emptyList());
+        assertEquals(0.0, withEmpty.getPrecision(), DELTA);
+        assertEquals(0.0, withEmpty.getRecall(), DELTA);
+    }
+
+    @Test
+    public void noTruePositivesOrFalsePositives_metricsAreZeroNotNaN() {
+        // Empty cluster, non-empty gold standard -> only FNs. Guards must avoid
+        // 0/0 = NaN in precision/accuracy.
+        Analysis a = Analysis.performAnalysis(
+                Collections.emptyList(),
+                Arrays.asList(1L));
+
+        assertEquals(0, a.getTruePos());
+        assertEquals(0, a.getFalsePos());
+        assertEquals(1, a.getFalseNeg());
+        assertEquals(0.0, a.getPrecision(), DELTA);
+        assertEquals(0.0, a.getRecall(), DELTA);
+        assertEquals(0.0, a.getAccuracy(), DELTA);
+        assertFalse("precision must not be NaN", Double.isNaN(a.getPrecision()));
+        assertFalse("accuracy must not be NaN", Double.isNaN(a.getAccuracy()));
+    }
+
+    @Test
+    public void acceptedLabelNotInGoldSet_treatedAsTrueNegative() {
+        // Data-inconsistency branch: article labelled accepted (goldStandard==1) but
+        // its pmid is not in the supplied gold-standard list -> conservatively TN.
+        Analysis a = Analysis.performAnalysis(
+                Arrays.asList(article(7L, ACCEPTED)),
+                Arrays.asList(8L));
+
+        assertEquals(0, a.getTruePos());
+        assertEquals(1, a.getTrueNeg());
+        assertEquals(0, a.getFalsePos());
+        assertEquals(1, a.getFalseNeg()); // pmid 8 missing from cluster
+    }
+
+    @Test
+    public void assignGoldStandard_labelsAcceptedAndRejectedLeavingOthersPending() {
+        List<ReCiterArticle> articles = new ArrayList<>(Arrays.asList(
+                article(1L, PENDING), article(2L, PENDING), article(3L, PENDING)));
+
+        Analysis.assignGoldStandard(articles, Arrays.asList(1L), Arrays.asList(2L));
+
+        assertEquals(ACCEPTED, articles.get(0).getGoldStandard());
+        assertEquals(REJECTED, articles.get(1).getGoldStandard());
+        assertEquals(PENDING, articles.get(2).getGoldStandard());
+    }
+}

--- a/src/test/java/reciter/feedback/EntryPathTest.java
+++ b/src/test/java/reciter/feedback/EntryPathTest.java
@@ -1,0 +1,42 @@
+package reciter.feedback;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Coverage for {@link EntryPath#fromString(String)}, the PM-UI -> Java decoder.
+ * The PM_AUTHOR value (Phase 34) must resolve case-insensitively, and unknown/null
+ * inputs must fall back to the safe default CANDIDATE_LIST.
+ */
+public class EntryPathTest {
+
+    @Test
+    public void resolvesPmAuthorExact() {
+        assertEquals(EntryPath.PM_AUTHOR, EntryPath.fromString("PM_AUTHOR"));
+    }
+
+    @Test
+    public void resolvesPmAuthorCaseInsensitive() {
+        assertEquals(EntryPath.PM_AUTHOR, EntryPath.fromString("pm_author"));
+        assertEquals(EntryPath.PM_AUTHOR, EntryPath.fromString("Pm_Author"));
+    }
+
+    @Test
+    public void resolvesPmAuthorWithSurroundingWhitespace() {
+        assertEquals(EntryPath.PM_AUTHOR, EntryPath.fromString("  PM_AUTHOR  "));
+    }
+
+    @Test
+    public void resolvesOtherKnownValues() {
+        assertEquals(EntryPath.PUBMED_SEARCH, EntryPath.fromString("pubmed_search"));
+        assertEquals(EntryPath.CANDIDATE_LIST, EntryPath.fromString("candidate_list"));
+    }
+
+    @Test
+    public void nullEmptyAndUnknownFallBackToCandidateList() {
+        assertEquals(EntryPath.CANDIDATE_LIST, EntryPath.fromString(null));
+        assertEquals(EntryPath.CANDIDATE_LIST, EntryPath.fromString(""));
+        assertEquals(EntryPath.CANDIDATE_LIST, EntryPath.fromString("not_a_real_path"));
+    }
+}

--- a/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
+++ b/src/test/java/reciter/service/dynamo/ArticleProvenanceServiceImplTest.java
@@ -1,6 +1,7 @@
 package reciter.service.dynamo;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -355,5 +356,65 @@ public class ArticleProvenanceServiceImplTest {
         verify(amazonDynamoDB, times(2)).updateItem(any(UpdateItemRequest.class));
         // GetItem is called twice (once initial, once on retry)
         verify(amazonDynamoDB, times(2)).getItem(any(GetItemRequest.class));
+    }
+
+    // ---- Phase 34: PM_AUTHOR (Authorship Review tab) entry path ----
+
+    @Test
+    public void testCuratorAction_PmAuthor_NewPmid_WritesPmAuthorMarkerWithoutSrcPm() {
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.PM_AUTHOR, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB, times(2)).updateItem(captor.capture());
+        UpdateItemRequest marker = captor.getAllValues().get(0);
+
+        // Marker mirrors PM_UI_SEARCH: sets rs/frd via if_not_exists and ADDs to ads...
+        assertTrue("Marker must SET rs via if_not_exists: " + marker.getUpdateExpression(),
+                marker.getUpdateExpression().contains("rs  = if_not_exists(rs,  :rs)"));
+        assertTrue("Marker must ADD to ads: " + marker.getUpdateExpression(),
+                marker.getUpdateExpression().contains("ADD ads :rsSet"));
+        assertEquals("PM_AUTHOR", marker.getExpressionAttributeValues().get(":rs").getS());
+        assertEquals("PM_AUTHOR", marker.getExpressionAttributeValues().get(":rsSet").getSS().get(0));
+
+        // ...but, unlike PUBMED_SEARCH, it must NOT seed src='PM'. This is the invariant
+        // that keeps a never-retrieved authorship at src='MAN' rather than MAN_FROM_PM.
+        assertFalse("Marker must NOT touch src: " + marker.getUpdateExpression(),
+                marker.getUpdateExpression().contains("src"));
+        assertFalse("Marker must NOT carry :pm: " + marker.getExpressionAttributeValues().keySet(),
+                marker.getExpressionAttributeValues().containsKey(":pm"));
+    }
+
+    @Test
+    public void testCuratorAction_PmAuthor_TwoUpdateItemCallsSequence() {
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.PM_AUTHOR, 1700000000L);
+        // PM_AUTHOR path: 1 marker write + 1 D-11 transition = 2 updateItem calls
+        verify(amazonDynamoDB, times(2)).updateItem(any(UpdateItemRequest.class));
+    }
+
+    @Test
+    public void testCuratorAction_PmAuthor_NeverRetrieved_D11WritesMan() {
+        // No prior ArticleProvenance row (never retrieved). Because the marker does not
+        // seed src='PM', the D-11 transition writes src='MAN' (algo-missed, curator-found).
+        stubGetItemSrc(null);
+        service.upsertCuratorAction("uid1", 100L, EntryPath.PM_AUTHOR, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB, times(2)).updateItem(captor.capture());
+        UpdateItemRequest d11 = captor.getAllValues().get(1);
+        assertEquals("MAN", d11.getExpressionAttributeValues().get(":new").getS());
+    }
+
+    @Test
+    public void testCuratorAction_PmAuthor_AlreadyRetrievedPm_D11LiftsToManFromPm() {
+        // Already-retrieved authorship (existing src='PM'): D-11 lifts it to MAN_FROM_PM.
+        stubGetItemSrc("PM");
+        service.upsertCuratorAction("uid1", 100L, EntryPath.PM_AUTHOR, 1700000000L);
+
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(amazonDynamoDB, times(2)).updateItem(captor.capture());
+        UpdateItemRequest d11 = captor.getAllValues().get(1);
+        assertEquals("MAN_FROM_PM", d11.getExpressionAttributeValues().get(":new").getS());
     }
 }

--- a/src/test/java/reciter/service/dynamo/FeedbackLogQueryServiceTest.java
+++ b/src/test/java/reciter/service/dynamo/FeedbackLogQueryServiceTest.java
@@ -1,0 +1,205 @@
+package reciter.service.dynamo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest;
+import com.amazonaws.services.dynamodbv2.model.QueryResult;
+
+/**
+ * Unit tests for {@link FeedbackLogQueryService#getAuditHistory(String)} (Phase 34
+ * audit-history read path). Verifies: null/empty short-circuit, field mapping +
+ * provenance join, multi-page concatenation, the {@code MAX_ROWS} truncation cap,
+ * graceful degradation when the provenance join fails, and the
+ * {@code NumberFormatException -> 0} fallback for malformed numeric attributes.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FeedbackLogQueryServiceTest {
+
+    private static final String FEEDBACK_LOG = "FeedbackLog";
+    private static final String ARTICLE_PROVENANCE = "ArticleProvenance";
+
+    @Mock
+    private AmazonDynamoDB amazonDynamoDB;
+
+    private FeedbackLogQueryService service;
+
+    @Before
+    public void setUp() {
+        service = new FeedbackLogQueryService(amazonDynamoDB);
+    }
+
+    // ---- helpers ----
+
+    private static Map<String, AttributeValue> s(String key, String val, Map<String, AttributeValue> m) {
+        m.put(key, new AttributeValue().withS(val));
+        return m;
+    }
+
+    private static Map<String, AttributeValue> feedbackItem(String articleId, String feedback,
+                                                            String curatedByN, String tsN, String sk, String src) {
+        Map<String, AttributeValue> m = new HashMap<>();
+        if (articleId != null) m.put("articleId", new AttributeValue().withS(articleId));
+        if (feedback != null) m.put("feedback", new AttributeValue().withS(feedback));
+        if (curatedByN != null) m.put("curatedBy", new AttributeValue().withN(curatedByN));
+        if (tsN != null) m.put("createTimestamp", new AttributeValue().withN(tsN));
+        if (sk != null) m.put("sk", new AttributeValue().withS(sk));
+        if (src != null) m.put("src", new AttributeValue().withS(src));
+        return m;
+    }
+
+    private static Map<String, AttributeValue> provItem(String articleId, String rs, String frdN, String src) {
+        Map<String, AttributeValue> m = new HashMap<>();
+        if (articleId != null) m.put("articleId", new AttributeValue().withS(articleId));
+        if (rs != null) m.put("rs", new AttributeValue().withS(rs));
+        if (frdN != null) m.put("frd", new AttributeValue().withN(frdN));
+        if (src != null) m.put("src", new AttributeValue().withS(src));
+        return m;
+    }
+
+    @SafeVarargs
+    private static QueryResult page(Map<String, AttributeValue> lastKey, Map<String, AttributeValue>... items) {
+        List<Map<String, AttributeValue>> list = new ArrayList<>();
+        for (Map<String, AttributeValue> i : items) list.add(i);
+        QueryResult r = new QueryResult().withItems(list);
+        if (lastKey != null) r.setLastEvaluatedKey(lastKey);
+        return r;
+    }
+
+    /** Route query() by table name: ArticleProvenance -> prov; FeedbackLog -> successive pages. */
+    private void stubQueries(QueryResult prov, QueryResult... feedbackPages) {
+        AtomicInteger fb = new AtomicInteger(0);
+        when(amazonDynamoDB.query(any(QueryRequest.class))).thenAnswer(inv -> {
+            QueryRequest r = inv.getArgument(0);
+            if (ARTICLE_PROVENANCE.equals(r.getTableName())) {
+                return prov;
+            }
+            int idx = Math.min(fb.getAndIncrement(), feedbackPages.length - 1);
+            return feedbackPages[idx];
+        });
+    }
+
+    // ---- tests ----
+
+    @Test
+    public void nullOrEmptyUid_returnsEmptyAndNeverQueries() {
+        assertTrue(service.getAuditHistory(null).isEmpty());
+        assertTrue(service.getAuditHistory("").isEmpty());
+        verify(amazonDynamoDB, never()).query(any(QueryRequest.class));
+    }
+
+    @Test
+    public void singlePage_mapsFieldsAndJoinsProvenanceByArticleId() {
+        stubQueries(
+                page(null, provItem("100", "PUBMED_NAME_AFFIL", "1699000000", "MAN")),
+                page(null, feedbackItem("100", "ACCEPTED", "42", "1700000000", "1700000000#ab", "MAN")));
+
+        List<AuditHistoryEntry> history = service.getAuditHistory("uid1");
+
+        assertEquals(1, history.size());
+        AuditHistoryEntry e = history.get(0);
+        assertEquals("100", e.articleId);
+        assertEquals("ACCEPTED", e.feedback);
+        assertEquals(42, e.curatedBy);
+        assertEquals(1700000000L, e.createTimestamp);
+        assertEquals("1700000000#ab", e.sk);
+        assertEquals("MAN", e.src);
+        // provenance join
+        assertEquals("PUBMED_NAME_AFFIL", e.provenanceRs);
+        assertEquals(Long.valueOf(1699000000L), e.provenanceFrd);
+        assertEquals("MAN", e.provenanceSrc);
+    }
+
+    @Test
+    public void multiplePages_areConcatenated() {
+        Map<String, AttributeValue> lastKey = s("uid", "uid1", s("sk", "1700000001#a", new HashMap<>()));
+        stubQueries(
+                page(null), // no provenance
+                page(lastKey, feedbackItem("100", "ACCEPTED", "1", "1700000002", "1700000002#a", "MAN")),
+                page(null, feedbackItem("200", "REJECTED", "1", "1700000001", "1700000001#b", "MAN")));
+
+        List<AuditHistoryEntry> history = service.getAuditHistory("uid1");
+
+        assertEquals(2, history.size());
+        assertEquals("100", history.get(0).articleId);
+        assertEquals("200", history.get(1).articleId);
+    }
+
+    @Test
+    public void resultsTruncateAtMaxRows() {
+        Map<String, AttributeValue>[] many = buildItems(2500);
+        // single page well over the cap; truncation happens inside the item loop
+        stubQueries(page(null), page(null, many));
+
+        List<AuditHistoryEntry> history = service.getAuditHistory("uid1");
+
+        assertEquals(2000, history.size());
+    }
+
+    @Test
+    public void provenanceLoadFailure_stillReturnsEntriesWithNullProvenance() {
+        when(amazonDynamoDB.query(any(QueryRequest.class))).thenAnswer(inv -> {
+            QueryRequest r = inv.getArgument(0);
+            if (ARTICLE_PROVENANCE.equals(r.getTableName())) {
+                throw new RuntimeException("provenance table unavailable");
+            }
+            return page(null, feedbackItem("100", "ACCEPTED", "7", "1700000000", "1700000000#z", "MAN"));
+        });
+
+        List<AuditHistoryEntry> history = service.getAuditHistory("uid1");
+
+        assertEquals(1, history.size());
+        AuditHistoryEntry e = history.get(0);
+        assertEquals("100", e.articleId);   // audit row still returned
+        assertEquals(7, e.curatedBy);
+        assertNull("provenance fields stay null when the join fails", e.provenanceRs);
+        assertNull(e.provenanceFrd);
+        assertNull(e.provenanceSrc);
+    }
+
+    @Test
+    public void malformedNumericAttributes_fallBackToZero() {
+        Map<String, AttributeValue> corrupt = new HashMap<>();
+        corrupt.put("articleId", new AttributeValue().withS("100"));
+        corrupt.put("feedback", new AttributeValue().withS("ACCEPTED"));
+        corrupt.put("curatedBy", new AttributeValue().withN("not-a-number"));
+        corrupt.put("createTimestamp", new AttributeValue().withN("garbage"));
+        stubQueries(page(null), page(null, corrupt));
+
+        List<AuditHistoryEntry> history = service.getAuditHistory("uid1");
+
+        assertEquals(1, history.size());
+        AuditHistoryEntry e = history.get(0);
+        assertEquals("100", e.articleId);
+        assertEquals(0, e.curatedBy);          // NumberFormatException -> 0
+        assertEquals(0L, e.createTimestamp);   // NumberFormatException -> 0
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, AttributeValue>[] buildItems(int n) {
+        List<Map<String, AttributeValue>> list = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            list.add(feedbackItem(String.valueOf(i), "ACCEPTED", "1", "1700000000", i + "#x", "MAN"));
+        }
+        return list.toArray(new Map[0]);
+    }
+}


### PR DESCRIPTION
Addresses #635 and unblocks the CI test gate in #633. **Test-only — no production code changed.**

## What & why
- **fix(test): TargetAuthorSelectionTest** — `testCheckEmailMatch` and `testCheckExactLastMiddleFirstNameMatch` were failing with NPE (red on `development`, unnoticed because CI skips tests). Root cause: `@Spy` on concrete JDK collections (`ArrayList`/`HashSet`) — under JDK 17 + modern Mockito the spy is built via Objenesis without running the constructor, leaving `elementData`/`map` null. The collections are plain data holders, so use real instances. Production code untouched.
- **test(metrics): AnalysisTest** (8) — the precision/recall/accuracy pure function (rewritten 2026-02) had zero coverage. Covers TP/FP/TN/FN classification, the PENDING-excluded-from-FP fix, divide-by-zero guards (no NaN), and the accepted-not-in-goldSet→TN branch.
- **test(provenance): ArticleProvenanceServiceImplTest + EntryPathTest** (4 + 5) — covers the new PM_AUTHOR marker invariant (sets rs/frd/ads but must **not** seed `src='PM'`; D-11 → MAN when never-retrieved, MAN_FROM_PM when `src='PM'` exists) and case-insensitive `EntryPath.fromString` with CANDIDATE_LIST fallback.
- **test(audit): FeedbackLogQueryServiceTest** (6) — null/empty short-circuit, field mapping + provenance join, multi-page concatenation, MAX_ROWS=2000 truncation, provenance-join failure degradation, and the `NumberFormatException→0` fallback.

## Testing
`mvn test` (Java 17): **105/105 pass, 0 failures** (was 82 with 2 failing). +23 tests; the 2 reds fixed.

## Issue status
- **#633** — the suite is now green end-to-end, so a `mvn test` CI gate can be enabled (still needs the real CI build path confirmed, since `buildspec.yml` looks stale).
- **#635** — fixes the 2 failing tests and adds the cheap high-value tests it called for. Remaining: filling the other ~8 `TargetAuthorSelection` cascade steps.