### PR TITLE
ci: gate deploy build on unit tests; deprecate stale buildspec.yml

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,4 +1,9 @@
 version: 0.2
+# DEPRECATED - DO NOT USE. Stale Elastic Beanstalk artifact, not wired to any active pipeline.
+# The live CI/CD build path is k8-buildspec.yml (EKS deploy via Dockerfile).
+# This file references a non-existent reciter-2.1.0.jar (pom is 2.1.3) and ships
+# .ebextensions/Procfile for an EB deployment model ReCiter no longer uses.
+# Retained only until confirmed safe to delete; do not edit or re-enable.
 # https://docs.aws.amazon.com/codebuild/latest/userguide/getting-started.html
 phases:
   install:

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -43,7 +43,10 @@ phases:
         - cat ./kubernetes/k8-deployment.yaml
   build:
     commands:
-      - mvn clean install -Dmaven.test.skip=true
+      # Run the unit test suite as part of the build. `mvn clean install` binds the
+      # test phase, so any test failure fails this build phase and gates the deploy
+      # (docker build/push and `kubectl set image` only run if tests pass).
+      - mvn clean install
       - |
         if expr "${BRANCH}" : ".*master" >/dev/null || expr "${BRANCH}" : ".*dev" >/dev/null; then
           docker build --tag $REPOSITORY_URI:$TAG .


### PR DESCRIPTION
## Summary
Fixes **#633**. The live EKS build path (`k8-buildspec.yml`) ran `mvn clean install -Dmaven.test.skip=true`, which skips both test **compilation and execution**. The 105-test suite never ran on the deploy path, so regressions — and tests that no longer compile after a refactor — shipped silently. This is the likely root cause of the recent run of NPE-hardening hotfixes.

## Changes
- **`k8-buildspec.yml`** — drop `-Dmaven.test.skip=true` so `mvn clean install` compiles and runs the test suite. A test failure now fails the `build` phase **before** `docker build`/`push` and `kubectl set image`, gating the dev/master deploy.
- **`buildspec.yml`** — marked **DEPRECATED** (comment header). It is the dead Elastic Beanstalk path: copies a non-existent `reciter-2.1.0.jar` (pom is `2.1.3`) and ships `.ebextensions`/`Procfile`, while deployment is EKS via the `Dockerfile`.

## Verification
Local run of the exact CI command in a clean worktree off `origin/development`:
```
mvn clean install  →  Tests run: 105, Failures: 0, Errors: 0, Skipped: 0
                      Building jar: target/reciter-2.1.3.jar
                      BUILD SUCCESS
```
All DynamoDB-touching tests use `@Mock AmazonDynamoDB` (MockitoJUnitRunner) — no live AWS/network — so enabling the gate will not block deploys on environment access.

## Follow-ups (not in this PR)
- **Recommend deleting** `buildspec.yml` outright once it's confirmed no CodeBuild project still references it as its buildspec (an AWS-console check). Deprecation header used here as the safe, reversible step.
- The `.ebextensions` fileset in `pom.xml` is part of the same dead EB packaging and can be cleaned up with the eventual deletion.