### PR TITLE
fix(scoring): stop swallowing exceptions on the scoring path

### DIFF
--- a/src/main/java/reciter/algorithm/article/score/predictor/NeuralNetworkModelArticlesScorer.java
+++ b/src/main/java/reciter/algorithm/article/score/predictor/NeuralNetworkModelArticlesScorer.java
@@ -103,8 +103,7 @@ public class NeuralNetworkModelArticlesScorer {
 				    conn.setDoOutput(true);
 				}
 			} catch (Exception e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				log.error("Failed to open Lambda HTTP connection to {} for model={}, dataFile={}", reciterScoringServiceUrl, goldStandardModelName, articleDataFilename, e);
 			}
 	      
 	        
@@ -120,8 +119,7 @@ public class NeuralNetworkModelArticlesScorer {
 			try {
 				payload = mapper.writeValueAsString(payloadMap);
 			} catch (JsonProcessingException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				log.error("Failed to serialize local-Lambda scoring payload for model={}, dataFile={}", goldStandardModelName, articleDataFilename, e);
 			}
 	        
 			try {
@@ -174,7 +172,7 @@ public class NeuralNetworkModelArticlesScorer {
 			     
 
 			} catch (IOException | RuntimeException e) {
-			    e.printStackTrace(); // You may want to log this properly
+			    log.error("Local Lambda scoring invocation/parse failed for model={}, dataFile={}; returning null", goldStandardModelName, articleDataFilename, e);
 			}
 			return null;
 	    }
@@ -202,7 +200,7 @@ public class NeuralNetworkModelArticlesScorer {
 			try {
 				payloadJson = mapper.writeValueAsString(payloadMap);
 			} catch (JsonProcessingException e) {
-				e.printStackTrace();
+				log.error("Failed to serialize AWS Lambda scoring payload for model={}, dataFile={}", goldStandardModelName, articleDataFilename, e);
 			}
 	        
 	        InvokeRequest request = new InvokeRequest()
@@ -238,8 +236,7 @@ public class NeuralNetworkModelArticlesScorer {
 		        }
 	          
 	        } catch (Exception e) {
-	            log.error("Lambda invocation failed: {}" , e.getMessage());
-	            e.printStackTrace();
+	            log.error("AWS Lambda scoring invocation/parse failed for function={}, model={}, dataFile={}", lambdaFunctionName, goldStandardModelName, articleDataFilename, e);
 	        }
 	        return null;
 	    }

--- a/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
+++ b/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
@@ -410,8 +410,8 @@ public class ReCiterArticleScorer extends AbstractArticleScorer {
        
 
 		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			slf4jLogger.error("Failed to write/upload identity scoring input or invoke scorer for uid={}, file={}", identity.getUid(), fileName, e);
+			throw new RuntimeException("Identity scoring failed for uid=" + identity.getUid(), e);
 		}
        return null;
    }
@@ -440,8 +440,7 @@ public class ReCiterArticleScorer extends AbstractArticleScorer {
 															    getPubmedTargetAuthorAffiliationScore(article.getAffiliationEvidence()),
 															    ((article.getGoldStandard()==1)? "ACCEPTED" : (article.getGoldStandard()==-1)? "REJECTED" :"PENDING"));
 		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			slf4jLogger.error("Failed to map identity score for articleId={}; article will be dropped from scoring", article.getArticleId(), e);
 		}
 		return null;
 
@@ -627,7 +626,7 @@ public class ReCiterArticleScorer extends AbstractArticleScorer {
         	}
         
         } catch (Exception e) {
-            e.printStackTrace();
+            slf4jLogger.error("Failed to upload scoring input file to S3 bucket={}, key={}", FeedbackScoreBucketName, keyName, e);
 			return false;			 
         }
  	}


### PR DESCRIPTION
## Summary
Fixes **#637**. `printStackTrace()` calls on the scoring path converted exceptions into `null`/`false` sentinels the caller cannot distinguish from "no result" — the worst failure mode for a disambiguation engine: silently empty/zero authorship scores with no log signal.

## Changes
**`NeuralNetworkModelArticlesScorer`** (Lambda invocation/parsing) — all 5 `printStackTrace()` replaced with `log.error(...)` carrying model / dataFile / Lambda-function context (the broad `catch(Exception)` around the AWS invoke keeps returning `null`, but now logs the full throwable + context).

**`ReCiterArticleScorer`**:
- `executePythonScriptForArticleIdentityTotalScore` — `IOException` is now logged with `uid`/`file` and **rethrown** as `RuntimeException` instead of returning `null`, so a genuine single-uid scoring failure surfaces instead of a misleading empty result.
- `mapToIdentityScore` — **keeps** returning `null` (a throw would abort the entire identity's parallel scoring stream), but now `log.error` with the `articleId`, turning a silent `.filter(Objects::nonNull)` drop into a visible, attributable signal.
- `uploadJsonFileIntoS3` — `log.error` with bucket/key instead of `printStackTrace`.

## Behavior change (intended)
The single-uid `/reciter/feature-generator/by/uid` path now returns a 5xx when scoring genuinely fails (IOException), rather than `200` with empty features. The **batch** `/feature-generator/by/group` path reads the cached `Analysis` and never calls `engine.run`, so it is unaffected. Verified caller chain: `ReCiterEngine.run` (lines 88 and 122) → `ReCiterController.runFeatureGenerator` (not wrapped in try/catch).

## Verification
`mvn test` in a clean worktree → **105 tests, 0 failures, 0 errors, BUILD SUCCESS**. No `printStackTrace()` remains in either file. All log-message variables confirmed in scope.

## Follow-ups (not in this PR)
- A dedicated `ScoringException` type would read better than raw `RuntimeException` for the rethrow (none exists today).
- Unit tests asserting the log-and-drop / rethrow behavior (needs a Logback `ListAppender` + scorer scaffolding).
- 43 `printStackTrace()` calls exist across the codebase; this PR covers the damaging scoring-path ones. The rest are lower priority.