### PR TITLE
fix(scoring): correct filter-dependent metrics, dup ESearchResult, zero penalty, silent TN

### DIFF
--- a/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
+++ b/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
@@ -554,9 +554,13 @@ public class ReCiterArticleScorer extends AbstractArticleScorer {
                  article.setTargetAuthorCount(targetAuthorCount);
                  if(targetAuthorCount == 0)
                  {
-                	 double authorshipLikelyhoodScore = (strategyParameters.getTargetAuthorMissingPenaltyPercent() * (article.getAuthorshipLikelihoodScore()/100));
+                	 // FIX (#640-C): capture the ORIGINAL score before overwriting it. Previously
+                	 // the penalty was computed AFTER setAuthorshipLikelihoodScore, so it read back
+                	 // the new value and the delta was always x-x=0.
+                	 double originalAuthorshipLikelihoodScore = article.getAuthorshipLikelihoodScore();
+                	 double authorshipLikelyhoodScore = (strategyParameters.getTargetAuthorMissingPenaltyPercent() * (originalAuthorshipLikelihoodScore/100));
                 	 article.setAuthorshipLikelihoodScore(authorshipLikelyhoodScore);
-                	 article.setTargetAuthorCountPenalty(authorshipLikelyhoodScore - article.getAuthorshipLikelihoodScore());
+                	 article.setTargetAuthorCountPenalty(authorshipLikelyhoodScore - originalAuthorshipLikelihoodScore);
                  }
             return article;
         })

--- a/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
+++ b/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
@@ -798,9 +798,13 @@ public class ReciterFeedbackArticleScorer extends AbstractFeedbackArticleScorer 
 				 		                 article.setTargetAuthorCount(targetAuthorCount);
 				 		                 if(targetAuthorCount == 0)
 				 		                 {
-				 		                	 double authorshipLikelyhoodScore = (strategyParameters.getTargetAuthorMissingPenaltyPercent() * (article.getAuthorshipLikelihoodScore()/100));
+				 		                	 // FIX (#640-C): capture the ORIGINAL score before overwriting it. Previously
+				 		                	 // the penalty was computed AFTER setAuthorshipLikelihoodScore, so it read back
+				 		                	 // the new value and the delta was always x-x=0.
+				 		                	 double originalAuthorshipLikelihoodScore = article.getAuthorshipLikelihoodScore();
+				 		                	 double authorshipLikelyhoodScore = (strategyParameters.getTargetAuthorMissingPenaltyPercent() * (originalAuthorshipLikelihoodScore/100));
 				 		                	 article.setAuthorshipLikelihoodScore(authorshipLikelyhoodScore);
-				 		                	 article.setTargetAuthorCountPenalty(authorshipLikelyhoodScore - article.getAuthorshipLikelihoodScore());
+				 		                	 article.setTargetAuthorCountPenalty(authorshipLikelyhoodScore - originalAuthorshipLikelihoodScore);
 				 		                 }
 				 		            return article;
 				 				 })

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -681,7 +681,24 @@ public class ReCiterController {
         	//All the results are filtered based on filterByFeedback
         	if(analysis.getReCiterFeature()!=null && analysis.getReCiterFeature().getReCiterArticleFeatures()!=null)
 			{
-			
+				// FIX (#640-A): Compute precision/recall/accuracy ONCE over the FULL candidate
+				// set BEFORE any display filtering. Previously each filterByFeedback branch ran
+				// performAnalysis over the already-filtered subset, so e.g. ACCEPTED_ONLY removed
+				// every REJECTED (false-positive) row and precision collapsed to TP/(TP+0)=1.0.
+				List<ReCiterArticle> fullCandidateSet = analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
+					    .map(featureArticle -> {
+					        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
+					        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
+					        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
+					        return article;
+					    })
+					    .collect(Collectors.toList());
+				Analysis featureAnalysis = Analysis.performAnalysis(fullCandidateSet,knownPmids);
+				analysis.getReCiterFeature().setPrecision(featureAnalysis.getPrecision());
+				analysis.getReCiterFeature().setRecall(featureAnalysis.getRecall());
+				analysis.getReCiterFeature().setOverallAccuracy(featureAnalysis.getAccuracy());
+
+				// Apply the display filter ONLY to the returned article list (metrics already set above).
 				if(filterByFeedback == FilterFeedbackType.ALL || filterByFeedback == null) {
 					analysis.getReCiterFeature().setReCiterArticleFeatures(analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
 								.filter(reCiterArticleFeature -> (reCiterArticleFeature.getAuthorshipLikelihoodScore() >= totalScore
@@ -693,58 +710,17 @@ public class ReCiterController {
 								reCiterArticleFeature.getUserAssertion() == PublicationFeedback.REJECTED
 								)
 								.collect(Collectors.toList()));
-					
-					
-					//List<Long> selectedArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream().map(article -> article.getPmid()).collect(Collectors.toList());
-					List<ReCiterArticle> reCiterFeatureArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
-						    .map(featureArticle -> {
-						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
-						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
-						        return article;
-						    })
-						    .collect(Collectors.toList());
-					Analysis featureAnalysis = Analysis.performAnalysis(reCiterFeatureArticles,knownPmids);
 					analysis.getReCiterFeature().setCountSuggestedArticles(analysis.getReCiterFeature().getReCiterArticleFeatures().size());
-					analysis.getReCiterFeature().setPrecision(featureAnalysis.getPrecision());
-					analysis.getReCiterFeature().setRecall(featureAnalysis.getRecall());
-					analysis.getReCiterFeature().setOverallAccuracy(featureAnalysis.getAccuracy());
 				} else if(filterByFeedback == FilterFeedbackType.ACCEPTED_ONLY) {
 					analysis.getReCiterFeature().setReCiterArticleFeatures(analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
 							.filter(reCiterArticleFeature -> reCiterArticleFeature.getUserAssertion() == PublicationFeedback.ACCEPTED)
 							.collect(Collectors.toList()));
-					//List<Long> selectedArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream().map(article -> article.getPmid()).collect(Collectors.toList());
-					List<ReCiterArticle> reCiterFeatureArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
-						    .map(featureArticle -> {
-						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
-						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
-						        return article;
-						    })
-						    .collect(Collectors.toList());
-					Analysis featureAnalysis = Analysis.performAnalysis(reCiterFeatureArticles,knownPmids);
 					analysis.getReCiterFeature().setCountSuggestedArticles(analysis.getReCiterFeature().getReCiterArticleFeatures().size());
-					analysis.getReCiterFeature().setPrecision(featureAnalysis.getPrecision());
-					analysis.getReCiterFeature().setRecall(featureAnalysis.getRecall());
-					analysis.getReCiterFeature().setOverallAccuracy(featureAnalysis.getAccuracy());
 				} else if(filterByFeedback == FilterFeedbackType.REJECTED_ONLY) {
 					analysis.getReCiterFeature().setReCiterArticleFeatures(analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
 							.filter(reCiterArticleFeature -> reCiterArticleFeature.getUserAssertion() == PublicationFeedback.REJECTED)
 							.collect(Collectors.toList()));
-					//List<Long> selectedArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream().map(article -> article.getPmid()).collect(Collectors.toList());
-					List<ReCiterArticle> reCiterFeatureArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
-						    .map(featureArticle -> {
-						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
-						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
-						        return article;
-						    })
-						    .collect(Collectors.toList());
-					Analysis featureAnalysis = Analysis.performAnalysis(reCiterFeatureArticles,knownPmids);
 					analysis.getReCiterFeature().setCountSuggestedArticles(analysis.getReCiterFeature().getReCiterArticleFeatures().size());
-					analysis.getReCiterFeature().setPrecision(featureAnalysis.getPrecision());
-					analysis.getReCiterFeature().setRecall(featureAnalysis.getRecall());
-					analysis.getReCiterFeature().setOverallAccuracy(featureAnalysis.getAccuracy());
 				} else if(filterByFeedback == FilterFeedbackType.ACCEPTED_AND_NULL) {
 					analysis.getReCiterFeature().setReCiterArticleFeatures(analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
 							//.filter(reCiterArticleFeature -> (reCiterArticleFeature.getTotalArticleScoreStandardized() >= totalScore
@@ -755,20 +731,7 @@ public class ReCiterController {
 							reCiterArticleFeature.getUserAssertion() == PublicationFeedback.ACCEPTED
 							)
 							.collect(Collectors.toList()));
-					//List<Long> selectedArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream().map(article -> article.getPmid()).collect(Collectors.toList());
-					List<ReCiterArticle> reCiterFeatureArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
-						    .map(featureArticle -> {
-						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
-						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
-						        return article;
-						    })
-						    .collect(Collectors.toList());
-					Analysis featureAnalysis = Analysis.performAnalysis(reCiterFeatureArticles,knownPmids);
 					analysis.getReCiterFeature().setCountSuggestedArticles(analysis.getReCiterFeature().getReCiterArticleFeatures().size());
-					analysis.getReCiterFeature().setPrecision(featureAnalysis.getPrecision());
-					analysis.getReCiterFeature().setRecall(featureAnalysis.getRecall());
-					analysis.getReCiterFeature().setOverallAccuracy(featureAnalysis.getAccuracy());
 				} else if(filterByFeedback == FilterFeedbackType.REJECTED_AND_NULL) {
 					analysis.getReCiterFeature().setReCiterArticleFeatures(analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
 							//.filter(reCiterArticleFeature -> (reCiterArticleFeature.getTotalArticleScoreStandardized() >= totalScore
@@ -779,40 +742,14 @@ public class ReCiterController {
 							reCiterArticleFeature.getUserAssertion() == PublicationFeedback.REJECTED
 							)
 							.collect(Collectors.toList()));
-					//List<Long> selectedArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream().map(article -> article.getPmid()).collect(Collectors.toList());
-					List<ReCiterArticle> reCiterFeatureArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
-						    .map(featureArticle -> {
-						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
-						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
-						        return article;
-						    })
-						    .collect(Collectors.toList());
-					Analysis featureAnalysis = Analysis.performAnalysis(reCiterFeatureArticles,knownPmids);
 					analysis.getReCiterFeature().setCountSuggestedArticles(analysis.getReCiterFeature().getReCiterArticleFeatures().size());
-					analysis.getReCiterFeature().setPrecision(featureAnalysis.getPrecision());
-					analysis.getReCiterFeature().setRecall(featureAnalysis.getRecall());
-					analysis.getReCiterFeature().setOverallAccuracy(featureAnalysis.getAccuracy());
 				} else if(filterByFeedback == FilterFeedbackType.ACCEPTED_AND_REJECTED) {
 					analysis.getReCiterFeature().setReCiterArticleFeatures(analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
 							.filter(reCiterArticleFeature -> reCiterArticleFeature.getUserAssertion() == PublicationFeedback.ACCEPTED
 							||
 							reCiterArticleFeature.getUserAssertion() == PublicationFeedback.REJECTED)
 							.collect(Collectors.toList()));
-					//List<Long> selectedArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream().map(article -> article.getPmid()).collect(Collectors.toList());
-					List<ReCiterArticle> reCiterFeatureArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
-						    .map(featureArticle -> {
-						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
-						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
-						        return article;
-						    })
-						    .collect(Collectors.toList());
-					Analysis featureAnalysis = Analysis.performAnalysis(reCiterFeatureArticles,knownPmids);
 					analysis.getReCiterFeature().setCountSuggestedArticles(analysis.getReCiterFeature().getReCiterArticleFeatures().size());
-					analysis.getReCiterFeature().setPrecision(featureAnalysis.getPrecision());
-					analysis.getReCiterFeature().setRecall(featureAnalysis.getRecall());
-					analysis.getReCiterFeature().setOverallAccuracy(featureAnalysis.getAccuracy());
 				} else if(filterByFeedback == FilterFeedbackType.NULL) {
 					analysis.getReCiterFeature().setReCiterArticleFeatures(analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
 							//.filter(reCiterArticleFeature -> reCiterArticleFeature.getTotalArticleScoreStandardized() >= totalScore
@@ -820,20 +757,7 @@ public class ReCiterController {
 							&&
 							reCiterArticleFeature.getUserAssertion() == PublicationFeedback.NULL)
 							.collect(Collectors.toList()));
-					//List<Long> selectedArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream().map(article -> article.getPmid()).collect(Collectors.toList());
-					List<ReCiterArticle> reCiterFeatureArticles = analysis.getReCiterFeature().getReCiterArticleFeatures().stream()
-						    .map(featureArticle -> {
-						        ReCiterArticle article = new ReCiterArticle(featureArticle.getPmid());
-						        article.setAuthorshipLikelihoodScore(featureArticle.getAuthorshipLikelihoodScore());
-						        article.setGoldStandard(featureArticle.getUserAssertion() == PublicationFeedback.ACCEPTED ? 1 : featureArticle.getUserAssertion() == PublicationFeedback.REJECTED ? -1 : 0);
-						        return article;
-						    })
-						    .collect(Collectors.toList());
-					Analysis featureAnalysis = Analysis.performAnalysis(reCiterFeatureArticles,knownPmids);
 					analysis.getReCiterFeature().setCountSuggestedArticles(analysis.getReCiterFeature().getReCiterArticleFeatures().size());
-					analysis.getReCiterFeature().setPrecision(featureAnalysis.getPrecision());
-					analysis.getReCiterFeature().setRecall(featureAnalysis.getRecall());
-					analysis.getReCiterFeature().setOverallAccuracy(featureAnalysis.getAccuracy());
 				}
 			}
 			else if(analysis.getReCiterFeature()!=null)

--- a/src/main/java/reciter/engine/erroranalysis/Analysis.java
+++ b/src/main/java/reciter/engine/erroranalysis/Analysis.java
@@ -47,6 +47,8 @@ import java.util.Set;
  */
 public class Analysis {
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Analysis.class);
+
     private double precision;
     private double recall;
     private double accuracy;
@@ -144,7 +146,9 @@ public class Analysis {
                 analysis.getFalsePositiveList().add(pmid);
             } else {
                 // goldStandard == 1 but not in goldSet — data inconsistency;
-                // treat conservatively as TN
+                // treat conservatively as TN, but surface it (FIX #640-D) so gold/cache
+                // divergence is no longer silently absorbed.
+                log.warn("Accepted article pmid={} is labelled goldStandard==1 but is absent from the supplied gold-standard set (size={}); classifying as TN. Gold standard and cached analysis may be out of sync.", pmid, goldSet.size());
                 analysis.getTrueNegativeList().add(pmid);
             }
         }

--- a/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
@@ -151,6 +151,13 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 		} else {
 			List<ESearchPmid> eSearchPmids = eSearchResultDb.getESearchPmids();
 			if(eSearchPmid != null) {
+				// FIX (#640-B): upsert by retrievalStrategyName. Previously every re-run
+				// appended a new ESearchPmid for the same strategy without removing the prior
+				// entry, growing the ESearchResult item unbounded toward the 400KB DynamoDB cap.
+				String newStrategyName = eSearchPmid.getRetrievalStrategyName();
+				eSearchPmids.removeIf(existing -> existing != null
+						&& existing.getRetrievalStrategyName() != null
+						&& existing.getRetrievalStrategyName().equalsIgnoreCase(newStrategyName));
 				eSearchPmids.add(eSearchPmid);
 			}
 			if(!eSearchPmids.isEmpty()) {


### PR DESCRIPTION
## Summary
Fixes **#640** — four scoring/metric correctness issues found in the app review.

### A. Reported precision/recall depended on the display filter
Each `filterByFeedback` branch in the cached path recomputed `Analysis.performAnalysis` over the **already-filtered** subset. `ACCEPTED_ONLY` removed every `REJECTED` (false-positive) row, so precision collapsed to `TP/(TP+0) = 1.0` for that view. Metrics are now computed **once over the full cached candidate set**, and the `filterByFeedback` branch only shapes the returned article list (and `countSuggestedArticles`). This also collapses ~112 lines of duplicated per-branch metric code.

> **Behavior note:** because metrics are now over the full set, *every* filter view reports the same (correct) precision/recall/accuracy instead of filter-dependent numbers. This makes the cached path consistent with the non-cached `ReCiterFeatureGenerator` path, which already computed metrics over the full set and only display-filtered.

### B. `ESearchResult` unbounded duplicate growth
`AbstractReCiterRetrievalEngine.savePubMedArticles` appended a fresh `ESearchPmid` for the same `retrievalStrategyName` on every re-run without removing the prior one, growing the item toward the 400 KB DynamoDB cap for prolific authors. Now `removeIf` by `retrievalStrategyName` (case-insensitive, matching existing comparison semantics) before append → upsert.

### C. `targetAuthorCountPenalty` always stored as 0
Both scorers computed `setTargetAuthorCountPenalty(score - article.getAuthorshipLikelihoodScore())` **after** `setAuthorshipLikelihoodScore(...)`, so it read back the new value → `x - x = 0`. The *applied* penalty was always correct; only the explainability field was wrong. Now captures the original score first; penalty = `penalizedScore - originalScore`.

### D. Accepted-not-in-goldset silently absorbed as TN
`Analysis.performAnalysis` classified a `goldStandard==1` article absent from the gold set as TN with no signal, masking gold-standard/cache divergence. Now emits a `log.warn` (classification unchanged, so existing tests stay green).

## Verification
`mvn test` in a clean worktree off `origin/development` → **105 tests, 0 failures, 0 errors, BUILD SUCCESS**. `AnalysisTest` (which covers the (D) TN path) still passes. Each edit was applied as a verbatim, adversarially-verified replacement matching exactly one location.

## Follow-ups (not in this PR)
- (C) **Sign convention**: penalty is stored as `penalizedScore - originalScore` (a negative delta), faithful to the original expression order. If downstream consumers expect a positive magnitude, flip to `originalScore - penalizedScore`.
- Regression tests for (A) (seed a cached `AnalysisOutput`, assert precision is identical across `ALL` vs `ACCEPTED_ONLY` and ≠ 1.0) and (B) (run a strategy twice, assert one entry) — both need scaffolding.
- #636 covers the broader retrieval-perf rework of the same `ESearchResult` read-modify-write path.