### PR TITLE
security: remediate 11 Dependabot CVEs via dependency bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
 		<dependency>
     			<groupId>commons-io</groupId>
     			<artifactId>commons-io</artifactId>
-    			<version>2.7</version>
+    			<version>2.14.0</version> <!-- 2.14.0 fixes GHSA-78wr-2p64-hpwj -->
 		</dependency>
 		<dependency>
 	        <groupId>org.apache.commons</groupId>
@@ -319,7 +319,7 @@
     	<dependency>
 		    <groupId>com.nimbusds</groupId>
 		    <artifactId>nimbus-jose-jwt</artifactId>
-		    <version>9.1.2</version> <!-- Library to handle JWKs -->
+		    <version>9.37.4</version> <!-- Library to handle JWKs; 9.37.4 fixes GHSA-gvpg-vgmx-xg6w / GHSA-xwmg-2g98-w7v9 -->
 		</dependency>
     	<dependency>
 	        <groupId>org.springframework.security</groupId>

--- a/src/main/resources/scripts/requirements.txt
+++ b/src/main/resources/scripts/requirements.txt
@@ -4,6 +4,6 @@ joblib==1.4.2
 boto3==1.35.40
 tensorflow-cpu==2.17.0
 six>=1.15.0
-urllib3==2.2.3
+urllib3==2.7.0
 chardet==5.2.0
-requests==2.32.3
+requests==2.34.2


### PR DESCRIPTION
## Summary
Clears **all 11 open Dependabot alerts** with drop-in version bumps — no framework changes, no API churn. This is the security-CVE subset of **#634**; the Spring Boot 2.5 EOL upgrade is intentionally left out (see below).

## Changes
**Java — `pom.xml`**
| Package | From | To | Fixes |
|---|---|---|---|
| `com.nimbusds:nimbus-jose-jwt` | 9.1.2 | **9.37.4** | GHSA-gvpg-vgmx-xg6w (high), GHSA-xwmg-2g98-w7v9 (med) |
| `commons-io:commons-io` | 2.7 | **2.14.0** | GHSA-78wr-2p64-hpwj (high) |

**Python — `src/main/resources/scripts/requirements.txt`**
| Package | From | To | Fixes |
|---|---|---|---|
| `urllib3` | 2.2.3 | **2.7.0** | 4 high + 2 med GHSAs |
| `requests` | 2.32.3 | **2.34.2** | 2 med GHSAs |

## Verification
- `mvn test` (clean worktree off `origin/development`) → **105 tests, 0 failures, 0 errors, BUILD SUCCESS**.
- `mvn dependency:tree` confirms `nimbus-jose-jwt:9.37.4` and `commons-io:2.14.0` actually resolve (direct pins win over the Spring Security transitive).
- `nimbus-jose-jwt` is not referenced directly in `src/main/java` (transitive JWKS handling for `spring-security-oauth2-jose`), so the 9.x→9.x bump carries no source-API risk; `commons-io` (used in `DynamoDbS3Operations`) is API-stable across 2.7→2.14.
- Python: a clean-venv `pip install --dry-run` confirms `urllib3 2.7.0` + `requests 2.34.2` coexist with the pinned `boto3 1.35.40` (botocore 1.35.99) — no resolver conflict.

> **Note (Python runtime):** clearing the high `urllib3` CVE requires `>= 2.7.0`, which with botocore needs **Python ≥ 3.10**. This is consistent with the file's existing `tensorflow-cpu==2.17.0` / `pandas==2.2.3` pins (3.9–3.12). Please confirm the scoring runtime is ≥ 3.10 before deploy.

## Scope / remaining #634 work (NOT in this PR)
This PR does **not** close #634 — it removes the immediate CVE exposure. The framework modernization remains and should be a separate, staged effort:
- Spring Boot **2.5 (EOL) → 2.7 → 3.x**
- Replace **springfox** (→ springdoc-openapi) and **spring-data-dynamodb** (abandoned) — the upgrade blockers
- Consolidate **AWS SDK** v1/v2

Suggest narrowing #634 to that framework scope once this merges.