### PR TITLE
security: constant-time api-key comparison (#639 part 1)

### DIFF
--- a/src/main/java/reciter/security/MultiApiKeyFilter.java
+++ b/src/main/java/reciter/security/MultiApiKeyFilter.java
@@ -1,6 +1,8 @@
 package reciter.security;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -63,7 +65,7 @@ public class MultiApiKeyFilter extends OncePerRequestFilter {
 				Optional.ofNullable(request.getHeader("api-key"))
 		        .filter(key -> !key.isEmpty())
 		        .ifPresent(apiKey -> {
-		        	 if (!apiKey.equals(consumerPrincipalRequestValue)) {
+		        	 if (!constantTimeEquals(apiKey, consumerPrincipalRequestValue)) {
 		        		 throw new BadCredentialsException("Invalid API key");
 		                }
 		                UsernamePasswordAuthenticationToken auth =
@@ -77,7 +79,7 @@ public class MultiApiKeyFilter extends OncePerRequestFilter {
 				Optional.ofNullable(request.getHeader("api-key"))
 		        .filter(key -> !key.isEmpty())
 		        .ifPresent(apiKey -> {
-		        	 if (!apiKey.equals(adminPrincipalRequestValue)) {
+		        	 if (!constantTimeEquals(apiKey, adminPrincipalRequestValue)) {
 		        		 throw new BadCredentialsException("Invalid API key");
 		                }
 		                UsernamePasswordAuthenticationToken auth =
@@ -112,5 +114,21 @@ public class MultiApiKeyFilter extends OncePerRequestFilter {
 	    }
 
 	    return false;
+	}
+
+	/**
+	 * Constant-time comparison of the supplied api-key against the expected value,
+	 * to avoid leaking the key through response-timing side channels (String.equals
+	 * short-circuits on the first differing byte). Returns false (rather than
+	 * throwing) when either value is null/absent, preserving the prior reject-on-
+	 * mismatch behavior.
+	 */
+	static boolean constantTimeEquals(String provided, String expected) {
+		if (provided == null || expected == null) {
+			return false;
+		}
+		return MessageDigest.isEqual(
+				provided.getBytes(StandardCharsets.UTF_8),
+				expected.getBytes(StandardCharsets.UTF_8));
 	}
 }

--- a/src/test/java/reciter/security/MultiApiKeyFilterTest.java
+++ b/src/test/java/reciter/security/MultiApiKeyFilterTest.java
@@ -1,0 +1,42 @@
+package reciter.security;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the constant-time api-key comparison used by {@link MultiApiKeyFilter}.
+ */
+public class MultiApiKeyFilterTest {
+
+	@Test
+	public void equalKeys_match() {
+		assertTrue(MultiApiKeyFilter.constantTimeEquals("s3cr3t-api-key", "s3cr3t-api-key"));
+	}
+
+	@Test
+	public void differentKeys_sameLength_doNotMatch() {
+		assertFalse(MultiApiKeyFilter.constantTimeEquals("s3cr3t-api-key", "X3cr3t-api-key"));
+	}
+
+	@Test
+	public void differentLengthKeys_doNotMatch() {
+		assertFalse(MultiApiKeyFilter.constantTimeEquals("short", "a-much-longer-api-key"));
+	}
+
+	@Test
+	public void nullExpected_doesNotMatch() {
+		assertFalse(MultiApiKeyFilter.constantTimeEquals("provided-key", null));
+	}
+
+	@Test
+	public void nullProvided_doesNotMatch() {
+		assertFalse(MultiApiKeyFilter.constantTimeEquals(null, "expected-key"));
+	}
+
+	@Test
+	public void emptyStrings_match() {
+		assertTrue(MultiApiKeyFilter.constantTimeEquals("", ""));
+	}
+}


### PR DESCRIPTION
## Summary
Addresses the constant-time-compare item of **#639**. `MultiApiKeyFilter` validated the request `api-key` against the admin/consumer keys with `String.equals` (`:66`, `:80`), which short-circuits on the first differing byte and leaks key bytes through response-timing side channels. Replaced with a null-safe `MessageDigest.isEqual` comparison.

## Changes
- `MultiApiKeyFilter` — new `constantTimeEquals(provided, expected)` helper using `MessageDigest.isEqual` over UTF-8 bytes; both comparison sites now use it. Returns `false` (not NPE) when the expected env value is null/absent, preserving the prior reject-on-mismatch behavior.
- `MultiApiKeyFilterTest` — 6 cases (equal, differing same-length, differing length, null expected, null provided, empty).

## Verification
`mvn test` in a clean worktree off `origin/development` → **111 tests, 0 failures, 0 errors, BUILD SUCCESS** (105 existing + 6 new).

## Deferred from #639 (with findings) — NOT in this PR
The other two items need decisions/infra and shouldn't ship un-verifiable:

**Swagger/springfox unauthenticated** — the security chain is scoped to `antMatcher("/reciter/**")`, so springfox paths bypass it; nginx also *intentionally* proxies `/reciter/swagger-ui/index.html` → backend `/swagger-ui/...`. The natural fix (profile-gate springfox off in prod) is **not currently wireable to `ENV_CONTEXT`**: I confirmed `ENV_CONTEXT` is set in `kubernetes/environments/reciter-dev.yaml` but **absent from `reciter-prod.yaml`**, so `spring.profiles.active=${ENV_CONTEXT:default}` would resolve to `default` in prod and the gate would silently not apply. Doing this correctly requires a coordinated change: (1) `application.properties` profile wiring + `application-prod.properties` with `springfox.documentation.enabled=false`, **and** (2) adding `SPRING_PROFILES_ACTIVE=prod` (or `ENV_CONTEXT`) to `reciter-prod.yaml` — plus a runtime check that `/reciter/swagger-ui/index.html` 404s in prod. Best done as its own PR with a deploy verification.

**JWT per-client allowlist is dead code** — `CognitoClientRegistry.isAllowed()` is never invoked; the JWT validator only checks `aud` contains `MASTER_CLIENT_ID`. Wiring `isAllowed()` into an `OAuth2TokenValidator` is an **auth-model decision** (multi-client vs single-client) with real blast radius: `isAllowed()` returns `false` on *any* Cognito error ("Security Bypass Prevention"), so if prod IAM lacks `ListUserPoolClients`, **all** JWT auth would break. Needs the team to confirm the intended model before enabling.

Suggest narrowing #639 to these two remaining items once this merges.