### PR TITLE
test(#634): Stage 0 — context-load smoke test + dependency baseline

### DIFF
--- a/docs/634-modernization/dependency-tree-stage0-baseline.txt
+++ b/docs/634-modernization/dependency-tree-stage0-baseline.txt
@@ -1,0 +1,267 @@
+edu.cornell.weill.reciter:reciter:jar:2.1.3
++- org.springframework.boot:spring-boot-starter-test:jar:2.5.0:test
+|  +- org.springframework.boot:spring-boot-starter:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-autoconfigure:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-starter-logging:jar:2.5.0:compile
+|  |  |  +- ch.qos.logback:logback-classic:jar:1.2.3:compile
+|  |  |  |  \- ch.qos.logback:logback-core:jar:1.2.3:compile
+|  |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.16.0:compile
+|  |  |  \- org.slf4j:jul-to-slf4j:jar:1.7.30:compile
+|  |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
+|  |  \- org.yaml:snakeyaml:jar:1.28:compile
+|  +- org.springframework.boot:spring-boot-test:jar:2.5.0:test
+|  +- org.springframework.boot:spring-boot-test-autoconfigure:jar:2.5.0:test
+|  +- com.jayway.jsonpath:json-path:jar:2.5.0:test
+|  |  \- net.minidev:json-smart:jar:2.4.7:test
+|  |     \- net.minidev:accessors-smart:jar:2.4.7:test
+|  |        \- org.ow2.asm:asm:jar:9.1:test
+|  +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:test
+|  |  \- jakarta.activation:jakarta.activation-api:jar:1.2.2:test
+|  +- org.assertj:assertj-core:jar:3.19.0:test
+|  +- org.hamcrest:hamcrest:jar:2.2:compile
+|  +- org.junit.jupiter:junit-jupiter:jar:5.7.2:test
+|  |  +- org.junit.jupiter:junit-jupiter-api:jar:5.7.2:test
+|  |  +- org.junit.jupiter:junit-jupiter-params:jar:5.7.2:test
+|  |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.7.2:test
+|  +- org.mockito:mockito-junit-jupiter:jar:3.9.0:test
+|  +- org.skyscreamer:jsonassert:jar:1.5.0:test
+|  |  \- com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1:test
+|  +- org.springframework:spring-core:jar:5.3.7:compile
+|  |  \- org.springframework:spring-jcl:jar:5.3.7:compile
+|  +- org.springframework:spring-test:jar:5.3.7:test
+|  \- org.xmlunit:xmlunit-core:jar:2.8.2:test
++- org.junit.vintage:junit-vintage-engine:jar:5.7.2:test
+|  +- org.apiguardian:apiguardian-api:jar:1.1.0:test
+|  \- org.junit.platform:junit-platform-engine:jar:1.7.2:test
+|     +- org.opentest4j:opentest4j:jar:1.2.0:test
+|     \- org.junit.platform:junit-platform-commons:jar:1.7.2:test
++- com.google.code.gson:gson:jar:2.8.6:compile
++- org.springframework.security:spring-security-config:jar:5.5.0:compile
+|  +- org.springframework:spring-aop:jar:5.3.7:compile
+|  +- org.springframework:spring-beans:jar:5.3.7:compile
+|  +- org.springframework:spring-context:jar:5.3.7:compile
+|  \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.0:compile
+|     +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.5.0:compile
+|     |  +- org.jetbrains:annotations:jar:13.0:compile
+|     |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.0:compile
+|     \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.0:compile
++- org.springframework.security:spring-security-web:jar:5.5.0:compile
+|  +- org.springframework:spring-expression:jar:5.3.7:compile
+|  \- org.springframework:spring-web:jar:5.3.7:compile
++- org.springframework.security:spring-security-core:jar:5.5.0:compile
+|  \- org.springframework.security:spring-security-crypto:jar:5.5.0:compile
++- org.springframework.boot:spring-boot-starter-websocket:jar:2.5.0:compile
+|  +- org.springframework.boot:spring-boot-starter-web:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-starter-json:jar:2.5.0:compile
+|  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.12.3:compile
+|  |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.12.3:compile
+|  |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:2.5.0:compile
+|  |  |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:9.0.46:compile
+|  |  |  +- org.apache.tomcat.embed:tomcat-embed-el:jar:9.0.46:compile
+|  |  |  \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:9.0.46:compile
+|  |  \- org.springframework:spring-webmvc:jar:5.3.7:compile
+|  +- org.springframework:spring-messaging:jar:5.3.7:compile
+|  \- org.springframework:spring-websocket:jar:5.3.7:compile
++- org.springframework.boot:spring-boot-starter-aop:jar:2.5.0:compile
+|  \- org.aspectj:aspectjweaver:jar:1.9.6:compile
++- org.apache.commons:commons-lang3:jar:3.12.0:compile
++- commons-io:commons-io:jar:2.14.0:compile
++- org.apache.commons:commons-csv:jar:1.9.0:compile
++- org.json:json:jar:20240303:compile
++- junit:junit:jar:4.13.2:compile
+|  \- org.hamcrest:hamcrest-core:jar:2.2:compile
++- com.unboundid:unboundid-ldapsdk:jar:4.0.14:compile
++- org.projectlombok:lombok:jar:1.18.44:compile
++- com.github.derjust:spring-data-dynamodb:jar:5.1.0:compile
+|  +- org.springframework:spring-tx:jar:5.3.7:compile
+|  +- org.springframework.data:spring-data-commons:jar:2.1.20.RELEASE:compile
+|  +- org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
+|  |  +- jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
+|  |  \- org.jboss.logging:jboss-logging:jar:3.4.1.Final:compile
+|  +- com.amazonaws:aws-java-sdk-dynamodb:jar:1.11.925:compile
+|  \- javax.enterprise:cdi-api:jar:1.2:compile
+|     +- javax.el:javax.el-api:jar:3.0.0:compile
+|     +- javax.interceptor:javax.interceptor-api:jar:1.2:compile
+|     \- javax.inject:javax.inject:jar:1:compile
++- io.springfox:springfox-boot-starter:jar:3.0.0:compile
+|  +- io.springfox:springfox-oas:jar:3.0.0:compile
+|  |  +- io.swagger.core.v3:swagger-annotations:jar:2.1.2:compile
+|  |  +- io.swagger.core.v3:swagger-models:jar:2.1.2:compile
+|  |  +- io.springfox:springfox-spi:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-schema:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-core:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-spring-web:jar:3.0.0:compile
+|  |  |  \- io.github.classgraph:classgraph:jar:4.8.83:compile
+|  |  +- io.springfox:springfox-spring-webmvc:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-spring-webflux:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-swagger-common:jar:3.0.0:compile
+|  |  \- org.mapstruct:mapstruct:jar:1.3.1.Final:runtime
+|  +- io.springfox:springfox-data-rest:jar:3.0.0:compile
+|  +- io.springfox:springfox-bean-validators:jar:3.0.0:compile
+|  +- io.springfox:springfox-swagger2:jar:3.0.0:compile
+|  |  +- io.swagger:swagger-annotations:jar:1.5.20:compile
+|  |  \- io.swagger:swagger-models:jar:1.5.20:compile
+|  +- io.springfox:springfox-swagger-ui:jar:3.0.0:compile
+|  +- com.fasterxml:classmate:jar:1.5.1:compile
+|  +- org.slf4j:slf4j-api:jar:1.7.30:compile
+|  +- org.springframework.plugin:spring-plugin-core:jar:2.0.0.RELEASE:compile
+|  \- org.springframework.plugin:spring-plugin-metadata:jar:2.0.0.RELEASE:compile
++- com.amazonaws:DynamoDBLocal:jar:1.25.1:compile
+|  +- commons-cli:commons-cli:jar:1.6.0:compile
+|  +- com.almworks.sqlite4java:libsqlite4java-linux-amd64:so:1.0.392:runtime
+|  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.12.3:compile
+|  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.12.3:compile
+|  +- software.amazon.awssdk:cognitoidentity:jar:2.16.46:compile
+|  +- software.amazon.awssdk:cognitoidentityprovider:jar:2.16.46:compile
+|  +- software.amazon.awssdk:pinpoint:jar:2.16.46:compile
+|  +- software.amazon.awssdk:dynamodb:jar:2.16.46:compile
+|  |  \- software.amazon.awssdk:profiles:jar:2.16.46:compile
+|  +- software.amazon.awssdk:dynamodb-enhanced:jar:2.16.46:compile
+|  +- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
+|  +- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile
+|  +- org.eclipse.jetty:jetty-client:jar:9.4.41.v20210516:compile
+|  |  +- org.eclipse.jetty:jetty-http:jar:9.4.41.v20210516:compile
+|  |  |  \- org.eclipse.jetty:jetty-util:jar:9.4.41.v20210516:compile
+|  |  \- org.eclipse.jetty:jetty-io:jar:9.4.41.v20210516:compile
+|  +- org.eclipse.jetty:jetty-server:jar:9.4.41.v20210516:compile
+|  |  \- javax.servlet:javax.servlet-api:jar:4.0.1:compile
+|  \- com.google.guava:guava:jar:33.3.0-jre:compile
+|     +- com.google.guava:failureaccess:jar:1.0.2:compile
+|     +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
+|     +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
+|     \- com.google.j2objc:j2objc-annotations:jar:3.0.0:compile
++- com.almworks.sqlite4java:sqlite4java:jar:1.0.392:compile
++- com.almworks.sqlite4java:libsqlite4java-linux-i386:so:1.0.392:compile
++- com.almworks.sqlite4java:libsqlite4java-osx:dylib:1.0.392:compile
++- com.almworks.sqlite4java:sqlite4java-win32-x64:dll:1.0.392:compile
++- com.almworks.sqlite4java:sqlite4java-win32-x86:dll:1.0.392:compile
++- com.opencsv:opencsv:jar:4.2:compile
+|  +- org.apache.commons:commons-text:jar:1.3:compile
+|  +- commons-beanutils:commons-beanutils:jar:1.9.3:compile
+|  |  \- commons-collections:commons-collections:jar:3.2.2:compile
+|  \- org.apache.commons:commons-collections4:jar:4.1:compile
++- com.amazonaws:aws-java-sdk-sqs:jar:1.11.925:compile
+|  \- com.amazonaws:jmespath-java:jar:1.11.925:compile
++- com.amazonaws:aws-java-sdk-sts:jar:1.11.925:compile
++- com.amazonaws:amazon-sqs-java-extended-client-lib:jar:1.0.3:compile
+|  \- com.amazonaws:aws-java-sdk-s3:jar:1.11.925:compile
+|     \- com.amazonaws:aws-java-sdk-kms:jar:1.11.925:compile
++- javax.xml.bind:jaxb-api:jar:2.3.0:compile
++- org.springframework.boot:spring-boot-starter-security:jar:2.5.0:compile
++- software.amazon.awssdk:secretsmanager:jar:2.20.34:compile
+|  +- software.amazon.awssdk:aws-json-protocol:jar:2.20.34:compile
+|  |  \- software.amazon.awssdk:third-party-jackson-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:protocol-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:sdk-core:jar:2.20.34:compile
+|  |  \- org.reactivestreams:reactive-streams:jar:1.0.3:compile
+|  +- software.amazon.awssdk:auth:jar:2.20.34:compile
+|  |  \- software.amazon.eventstream:eventstream:jar:1.0.1:compile
+|  +- software.amazon.awssdk:http-client-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:regions:jar:2.20.34:compile
+|  +- software.amazon.awssdk:annotations:jar:2.20.34:compile
+|  +- software.amazon.awssdk:utils:jar:2.20.34:compile
+|  +- software.amazon.awssdk:aws-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:metrics-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:json-utils:jar:2.20.34:compile
+|  +- software.amazon.awssdk:endpoints-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:apache-client:jar:2.20.34:runtime
+|  |  \- org.apache.httpcomponents:httpcore:jar:4.4.14:compile
+|  \- software.amazon.awssdk:netty-nio-client:jar:2.20.34:runtime
+|     +- io.netty:netty-codec-http:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-codec-http2:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-codec:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-transport:jar:4.1.65.Final:runtime
+|     |  \- io.netty:netty-resolver:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-common:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-buffer:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-handler:jar:4.1.65.Final:runtime
+|     \- io.netty:netty-transport-classes-epoll:jar:4.1.86.Final:runtime
+|        \- io.netty:netty-transport-native-unix-common:jar:4.1.65.Final:runtime
++- com.auth0:java-jwt:jar:3.19.4:compile
+|  \- com.fasterxml.jackson.core:jackson-databind:jar:2.12.3:compile
++- com.nimbusds:nimbus-jose-jwt:jar:9.37.4:compile
+|  \- com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile
++- org.springframework.security:spring-security-oauth2-jose:jar:5.6.0:compile
+|  \- org.springframework.security:spring-security-oauth2-core:jar:5.5.0:compile
++- org.springframework.security:spring-security-oauth2-resource-server:jar:5.6.0:compile
++- edu.cornell.weill.reciter:reciter-scopus-model:jar:2.0.3:compile
+|  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.12.3:compile
+|  \- io.swagger:swagger-codegen-maven-plugin:jar:3.0.0-rc1:compile
+|     +- org.apache.maven:maven-core:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-model:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-settings:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-settings-builder:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-repository-metadata:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-artifact:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-model-builder:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-aether-provider:jar:3.2.5:compile
+|     |  |  \- org.eclipse.aether:aether-spi:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-impl:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-api:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-util:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.3.0.M1:compile
+|     |  |  \- org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.3.0.M1:compile
+|     |  +- org.sonatype.sisu:sisu-guice:jar:no_aop:3.2.3:compile
+|     |  |  \- aopalliance:aopalliance:jar:1.0:compile
+|     |  +- org.codehaus.plexus:plexus-interpolation:jar:1.21:compile
+|     |  +- org.codehaus.plexus:plexus-utils:jar:3.0.20:compile
+|     |  +- org.codehaus.plexus:plexus-classworlds:jar:2.5.2:compile
+|     |  +- org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
+|     |  \- org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:compile
+|     |     \- org.sonatype.plexus:plexus-cipher:jar:1.4:compile
+|     +- org.apache.maven:maven-compat:jar:3.2.5:compile
+|     |  \- org.apache.maven.wagon:wagon-provider-api:jar:2.8:compile
+|     +- org.apache.maven:maven-plugin-api:jar:3.2.5:compile
+|     +- org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.4:compile
+|     +- io.swagger:swagger-codegen:jar:3.0.0-rc1:compile
+|     |  +- io.swagger.core.v3:swagger-core:jar:2.0.0:compile
+|     |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.12.3:compile
+|     |  |  \- javax.validation:validation-api:jar:2.0.1.Final:compile
+|     |  +- io.swagger.parser.v3:swagger-parser-core:jar:2.0.0:compile
+|     |  +- io.swagger.parser.v3:swagger-parser-v3:jar:2.0.0:compile
+|     |  +- io.swagger.parser.v3:swagger-parser:jar:2.0.0:compile
+|     |  |  \- io.swagger.parser.v3:swagger-parser-v2-converter:jar:2.0.0:compile
+|     |  |     +- io.swagger:swagger-parser:jar:1.0.35:compile
+|     |  |     |  \- io.swagger:swagger-core:jar:1.5.19:compile
+|     |  |     \- io.swagger:swagger-compat-spec-parser:jar:1.0.35:compile
+|     |  |        +- com.github.java-json-tools:json-schema-validator:jar:2.2.8:compile
+|     |  |        |  +- com.github.java-json-tools:json-schema-core:jar:1.2.8:compile
+|     |  |        |  |  \- com.github.fge:uri-template:jar:0.9:compile
+|     |  |        |  +- javax.mail:mailapi:jar:1.4.3:compile
+|     |  |        |  |  \- javax.activation:activation:jar:1.1:compile
+|     |  |        |  +- com.googlecode.libphonenumber:libphonenumber:jar:8.0.0:compile
+|     |  |        |  \- net.sf.jopt-simple:jopt-simple:jar:5.0.3:compile
+|     |  |        \- com.github.fge:json-patch:jar:1.6:compile
+|     |  |           \- com.github.fge:jackson-coreutils:jar:1.6:compile
+|     |  |              \- com.github.fge:msg-simple:jar:1.1:compile
+|     |  |                 \- com.github.fge:btf:jar:1.2:compile
+|     |  +- com.samskivert:jmustache:jar:1.15:compile
+|     |  +- org.slf4j:slf4j-ext:jar:1.7.30:compile
+|     |  +- com.atlassian.commonmark:commonmark:jar:0.9.0:compile
+|     |  \- com.github.jknack:handlebars:jar:4.0.6:compile
+|     |     \- org.mozilla:rhino:jar:1.7R4:compile
+|     \- io.swagger:swagger-codegen-generators:jar:1.0.0-rc1:compile
++- com.amazonaws:aws-java-sdk-lambda:jar:1.12.742:compile
++- com.amazonaws:aws-java-sdk-core:jar:1.12.742:compile
+|  +- commons-logging:commons-logging:jar:1.1.3:compile
+|  +- commons-codec:commons-codec:jar:1.15:compile
+|  +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
+|  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.12.3:compile
+|  \- joda-time:joda-time:jar:2.12.7:compile
++- com.amazonaws:aws-java-sdk-cognitoidp:jar:1.12.742:compile
++- edu.cornell.weill.reciter:reciter-pubmed-model:jar:2.0.3:compile
++- edu.cornell.weill.reciter:reciter-identity-model:jar:2.0.10:compile
++- edu.cornell.weill.reciter:reciter-article-model:jar:2.0.36:compile
+|  \- org.springframework.data:spring-data-commons-core:jar:1.4.1.RELEASE:compile
++- edu.cornell.weill.reciter:reciter-dynamodb-model:jar:2.0.15:compile
++- com.github.bohnman:squiggly-filter-jackson:jar:1.3.18:compile
+|  \- net.jcip:jcip-annotations:jar:1.0:compile
++- org.antlr:antlr4-runtime:jar:4.6:compile
++- org.mockito:mockito-core:jar:3.9.0:compile
+|  +- net.bytebuddy:byte-buddy:jar:1.10.22:compile
+|  +- net.bytebuddy:byte-buddy-agent:jar:1.10.22:compile
+|  \- org.objenesis:objenesis:jar:3.2:compile
+\- com.github.ben-manes.caffeine:caffeine:jar:2.9.3:compile
+   +- org.checkerframework:checker-qual:jar:3.19.0:compile
+   \- com.google.errorprone:error_prone_annotations:jar:2.10.0:compile

--- a/src/test/java/reciter/ApplicationContextSmokeTest.java
+++ b/src/test/java/reciter/ApplicationContextSmokeTest.java
@@ -1,0 +1,93 @@
+package reciter;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.s3.AmazonS3;
+
+import reciter.consumer.service.CognitoAuthService;
+import reciter.database.dynamodb.DynamoDbConfig;
+import reciter.security.CognitoClientRegistry;
+import reciter.service.GenderService;
+import reciter.service.NameFrequencyService;
+import reciter.service.ScienceMetrixDepartmentCategoryService;
+import reciter.service.ScienceMetrixService;
+import reciter.service.dynamo.DynamoDbInstitutionAfidService;
+import reciter.service.dynamo.DynamoDbMeshTermService;
+
+/**
+ * Stage 0 context-load smoke test (#634 dependency modernization).
+ *
+ * <p>Boots the full Spring application context under the dedicated {@code test}
+ * profile (see {@code application-test.properties}), which neutralizes the
+ * property-controlled live-AWS startup blockers. The {@code @MockBean} overrides
+ * below stand in for the beans that build live AWS SDK clients or run data loads
+ * at startup:
+ * <ul>
+ *   <li>{@code AmazonDynamoDB} / {@code AmazonS3} — would otherwise hit DynamoDB/S3/STS.</li>
+ *   <li>{@code CognitoAuthService} / {@code CognitoClientRegistry} — build live Cognito clients.</li>
+ *   <li>The six services invoked by {@code Application}'s {@code ApplicationReadyEvent}
+ *       listeners — mocked so the startup data-load is a no-op (Mockito returns empty
+ *       lists for list-returning methods by default).</li>
+ * </ul>
+ *
+ * <p>This is the per-stage gate for #634: every framework/wiring change (Stages 1-3)
+ * must keep this green, proving the context still wires end to end.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@ActiveProfiles("test")
+public class ApplicationContextSmokeTest {
+
+    @MockBean
+    private AmazonDynamoDB amazonDynamoDB;
+
+    @MockBean
+    private AmazonS3 amazonS3;
+
+    @MockBean
+    private CognitoAuthService cognitoAuthService;
+
+    @MockBean
+    private CognitoClientRegistry cognitoClientRegistry;
+
+    // Services invoked by Application's ApplicationReadyEvent listeners. Mocking them
+    // makes populateStaticEngineParameters() a no-op at startup without needing AWS.
+    @MockBean
+    private ScienceMetrixService scienceMetrixService;
+
+    @MockBean
+    private ScienceMetrixDepartmentCategoryService scienceMetrixDepartmentCategoryService;
+
+    @MockBean
+    private DynamoDbMeshTermService dynamoDbMeshTermService;
+
+    @MockBean
+    private GenderService genderService;
+
+    @MockBean
+    private NameFrequencyService nameFrequencyService;
+
+    @MockBean
+    private DynamoDbInstitutionAfidService dynamoDbInstitutionAfidService;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void contextLoads() {
+        assertNotNull("Spring application context should load", context);
+        // A concrete bean from the DynamoDB wiring path proves the persistence config
+        // wired (the surface Stage 1 will rework when spring-data-dynamodb is removed).
+        assertNotNull("DynamoDbConfig should be wired", context.getBean(DynamoDbConfig.class));
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,28 @@
+# Stage 0 smoke-test profile (#634 dependency modernization).
+#
+# Activated via @ActiveProfiles("test") on ApplicationContextSmokeTest. Overrides
+# the property-controlled live-AWS startup blockers in application.properties so a
+# full @SpringBootTest context load runs deterministically in CI with no AWS creds.
+# Beans that build live AWS SDK clients or run data loads at startup are replaced
+# with @MockBean overrides in the test class itself.
+
+# Disable API security so apiKeySetter() does not require ADMIN_API_KEY/CONSUMER_API_KEY
+# env vars and WebSecurity ignores /reciter/**.
+spring.security.enabled=false
+
+# Do not build a live S3 client / create buckets (STS getCallerIdentity) at startup.
+aws.s3.use=false
+
+# Do not call listTables()/createTable() against live DynamoDB at startup
+# (AmazonDynamoDB is also @MockBean-replaced, but keep this off for clarity).
+aws.dynamodb.settings.table.create=false
+
+# Skip the file-import ApplicationReadyEvent path.
+aws.dynamodb.settings.file.import=false
+
+# Force jwtDecoder() down its fail-fast, no-network branch (userPoolId == "NONE").
+aws.cognito.user-pool-id=NONE
+
+# S3UserLogHandler.@PostConstruct requires a non-empty region to build its client.
+aws.cognito.userpool.region=us-east-1
+aws.region=us-east-1


### PR DESCRIPTION
Stage 0 of the #634 dependency-modernization plan. Establishes the per-stage gate for the upcoming `spring-data-dynamodb` / `springfox` / Spring Boot 2.7 work.

## What's here
- **`ApplicationContextSmokeTest`** — a `@SpringBootTest` that boots the full Spring context under a dedicated `test` profile. The profile neutralizes the property-controlled live-AWS startup blockers (security, S3, DynamoDB table creation, file import, Cognito JWT) and `@MockBean` overrides stand in for the beans that build live AWS clients or run startup data loads (the six `ApplicationReadyEvent` services return empty lists by default, so the ready-event is a no-op). This is the first automated "does it still boot" assertion in the suite.
- **`application-test.properties`** — the test profile above.
- **`docs/634-modernization/dependency-tree-stage0-baseline.txt`** — a `mvn dependency:tree` snapshot for diffing dependency changes across stages.

## Verification
- `mvn clean install` (Java 17): **127 tests, 0 failures** (126 existing + 1 smoke), BUILD SUCCESS.

## Why
Every later stage (1 = remove `spring-data-dynamodb`, 2 = `springfox`→`springdoc`, 3 = Boot 2.7 + `SecurityFilterChain`) is a wiring/framework change whose primary risk is "does the context still boot." This test is that gate. It already paid off — it caught a latent prod-startup bug in the stacked Stage 1 PR (missing Hibernate Validator after the `spring-data-dynamodb` removal).

Part of #634. Targets `development`.