### PR TITLE
refactor(#634): Stage 1 — remove spring-data-dynamodb via v1 DynamoDBMapper facade

### DIFF
--- a/docs/634-modernization/dependency-tree-stage1.txt
+++ b/docs/634-modernization/dependency-tree-stage1.txt
@@ -1,0 +1,265 @@
+edu.cornell.weill.reciter:reciter:jar:2.1.3
++- org.springframework.boot:spring-boot-starter-test:jar:2.5.0:test
+|  +- org.springframework.boot:spring-boot-starter:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-autoconfigure:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-starter-logging:jar:2.5.0:compile
+|  |  |  +- ch.qos.logback:logback-classic:jar:1.2.3:compile
+|  |  |  |  \- ch.qos.logback:logback-core:jar:1.2.3:compile
+|  |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.16.0:compile
+|  |  |  \- org.slf4j:jul-to-slf4j:jar:1.7.30:compile
+|  |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
+|  |  \- org.yaml:snakeyaml:jar:1.28:compile
+|  +- org.springframework.boot:spring-boot-test:jar:2.5.0:test
+|  +- org.springframework.boot:spring-boot-test-autoconfigure:jar:2.5.0:test
+|  +- com.jayway.jsonpath:json-path:jar:2.5.0:test
+|  |  \- net.minidev:json-smart:jar:2.4.7:test
+|  |     \- net.minidev:accessors-smart:jar:2.4.7:test
+|  |        \- org.ow2.asm:asm:jar:9.1:test
+|  +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:test
+|  |  \- jakarta.activation:jakarta.activation-api:jar:1.2.2:test
+|  +- org.assertj:assertj-core:jar:3.19.0:test
+|  +- org.hamcrest:hamcrest:jar:2.2:compile
+|  +- org.junit.jupiter:junit-jupiter:jar:5.7.2:test
+|  |  +- org.junit.jupiter:junit-jupiter-api:jar:5.7.2:test
+|  |  +- org.junit.jupiter:junit-jupiter-params:jar:5.7.2:test
+|  |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.7.2:test
+|  +- org.mockito:mockito-junit-jupiter:jar:3.9.0:test
+|  +- org.skyscreamer:jsonassert:jar:1.5.0:test
+|  |  \- com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1:test
+|  +- org.springframework:spring-core:jar:5.3.7:compile
+|  |  \- org.springframework:spring-jcl:jar:5.3.7:compile
+|  +- org.springframework:spring-test:jar:5.3.7:test
+|  \- org.xmlunit:xmlunit-core:jar:2.8.2:test
++- org.junit.vintage:junit-vintage-engine:jar:5.7.2:test
+|  +- org.apiguardian:apiguardian-api:jar:1.1.0:test
+|  \- org.junit.platform:junit-platform-engine:jar:1.7.2:test
+|     +- org.opentest4j:opentest4j:jar:1.2.0:test
+|     \- org.junit.platform:junit-platform-commons:jar:1.7.2:test
++- com.google.code.gson:gson:jar:2.8.6:compile
++- org.springframework.security:spring-security-config:jar:5.5.0:compile
+|  +- org.springframework:spring-aop:jar:5.3.7:compile
+|  +- org.springframework:spring-beans:jar:5.3.7:compile
+|  +- org.springframework:spring-context:jar:5.3.7:compile
+|  \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.0:compile
+|     +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.5.0:compile
+|     |  +- org.jetbrains:annotations:jar:13.0:compile
+|     |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.0:compile
+|     \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.0:compile
++- org.springframework.security:spring-security-web:jar:5.5.0:compile
+|  +- org.springframework:spring-expression:jar:5.3.7:compile
+|  \- org.springframework:spring-web:jar:5.3.7:compile
++- org.springframework.security:spring-security-core:jar:5.5.0:compile
+|  \- org.springframework.security:spring-security-crypto:jar:5.5.0:compile
++- org.springframework.boot:spring-boot-starter-websocket:jar:2.5.0:compile
+|  +- org.springframework.boot:spring-boot-starter-web:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-starter-json:jar:2.5.0:compile
+|  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.12.3:compile
+|  |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.12.3:compile
+|  |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:2.5.0:compile
+|  |  |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:9.0.46:compile
+|  |  |  \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:9.0.46:compile
+|  |  \- org.springframework:spring-webmvc:jar:5.3.7:compile
+|  +- org.springframework:spring-messaging:jar:5.3.7:compile
+|  \- org.springframework:spring-websocket:jar:5.3.7:compile
++- org.springframework.boot:spring-boot-starter-aop:jar:2.5.0:compile
+|  \- org.aspectj:aspectjweaver:jar:1.9.6:compile
++- org.apache.commons:commons-lang3:jar:3.12.0:compile
++- commons-io:commons-io:jar:2.14.0:compile
++- org.apache.commons:commons-csv:jar:1.9.0:compile
++- org.json:json:jar:20240303:compile
++- junit:junit:jar:4.13.2:compile
+|  \- org.hamcrest:hamcrest-core:jar:2.2:compile
++- com.unboundid:unboundid-ldapsdk:jar:4.0.14:compile
++- org.projectlombok:lombok:jar:1.18.44:compile
++- org.springframework:spring-tx:jar:5.3.7:compile
++- org.springframework.boot:spring-boot-starter-validation:jar:2.5.0:compile
+|  +- org.apache.tomcat.embed:tomcat-embed-el:jar:9.0.46:compile
+|  \- org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
+|     +- jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
+|     \- org.jboss.logging:jboss-logging:jar:3.4.1.Final:compile
++- io.springfox:springfox-boot-starter:jar:3.0.0:compile
+|  +- io.springfox:springfox-oas:jar:3.0.0:compile
+|  |  +- io.swagger.core.v3:swagger-annotations:jar:2.1.2:compile
+|  |  +- io.swagger.core.v3:swagger-models:jar:2.1.2:compile
+|  |  +- io.springfox:springfox-spi:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-schema:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-core:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-spring-web:jar:3.0.0:compile
+|  |  |  \- io.github.classgraph:classgraph:jar:4.8.83:compile
+|  |  +- io.springfox:springfox-spring-webmvc:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-spring-webflux:jar:3.0.0:compile
+|  |  +- io.springfox:springfox-swagger-common:jar:3.0.0:compile
+|  |  \- org.mapstruct:mapstruct:jar:1.3.1.Final:runtime
+|  +- io.springfox:springfox-data-rest:jar:3.0.0:compile
+|  +- io.springfox:springfox-bean-validators:jar:3.0.0:compile
+|  +- io.springfox:springfox-swagger2:jar:3.0.0:compile
+|  |  +- io.swagger:swagger-annotations:jar:1.5.20:compile
+|  |  \- io.swagger:swagger-models:jar:1.5.20:compile
+|  +- io.springfox:springfox-swagger-ui:jar:3.0.0:compile
+|  +- com.fasterxml:classmate:jar:1.5.1:compile
+|  +- org.slf4j:slf4j-api:jar:1.7.30:compile
+|  +- org.springframework.plugin:spring-plugin-core:jar:2.0.0.RELEASE:compile
+|  \- org.springframework.plugin:spring-plugin-metadata:jar:2.0.0.RELEASE:compile
++- com.amazonaws:DynamoDBLocal:jar:1.25.1:compile
+|  +- commons-cli:commons-cli:jar:1.6.0:compile
+|  +- com.almworks.sqlite4java:libsqlite4java-linux-amd64:so:1.0.392:runtime
+|  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.12.3:compile
+|  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.12.3:compile
+|  +- com.amazonaws:aws-java-sdk-dynamodb:jar:1.11.925:compile
+|  +- software.amazon.awssdk:cognitoidentity:jar:2.16.46:compile
+|  +- software.amazon.awssdk:cognitoidentityprovider:jar:2.16.46:compile
+|  +- software.amazon.awssdk:pinpoint:jar:2.16.46:compile
+|  +- software.amazon.awssdk:dynamodb:jar:2.16.46:compile
+|  |  \- software.amazon.awssdk:profiles:jar:2.16.46:compile
+|  +- software.amazon.awssdk:dynamodb-enhanced:jar:2.16.46:compile
+|  +- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
+|  +- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile
+|  +- org.eclipse.jetty:jetty-client:jar:9.4.41.v20210516:compile
+|  |  +- org.eclipse.jetty:jetty-http:jar:9.4.41.v20210516:compile
+|  |  |  \- org.eclipse.jetty:jetty-util:jar:9.4.41.v20210516:compile
+|  |  \- org.eclipse.jetty:jetty-io:jar:9.4.41.v20210516:compile
+|  +- org.eclipse.jetty:jetty-server:jar:9.4.41.v20210516:compile
+|  |  \- javax.servlet:javax.servlet-api:jar:4.0.1:compile
+|  \- com.google.guava:guava:jar:33.3.0-jre:compile
+|     +- com.google.guava:failureaccess:jar:1.0.2:compile
+|     +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
+|     +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
+|     \- com.google.j2objc:j2objc-annotations:jar:3.0.0:compile
++- com.almworks.sqlite4java:sqlite4java:jar:1.0.392:compile
++- com.almworks.sqlite4java:libsqlite4java-linux-i386:so:1.0.392:compile
++- com.almworks.sqlite4java:libsqlite4java-osx:dylib:1.0.392:compile
++- com.almworks.sqlite4java:sqlite4java-win32-x64:dll:1.0.392:compile
++- com.almworks.sqlite4java:sqlite4java-win32-x86:dll:1.0.392:compile
++- com.opencsv:opencsv:jar:4.2:compile
+|  +- org.apache.commons:commons-text:jar:1.3:compile
+|  +- commons-beanutils:commons-beanutils:jar:1.9.3:compile
+|  |  \- commons-collections:commons-collections:jar:3.2.2:compile
+|  \- org.apache.commons:commons-collections4:jar:4.1:compile
++- com.amazonaws:aws-java-sdk-sqs:jar:1.11.925:compile
+|  \- com.amazonaws:jmespath-java:jar:1.11.925:compile
++- com.amazonaws:aws-java-sdk-sts:jar:1.11.925:compile
++- com.amazonaws:amazon-sqs-java-extended-client-lib:jar:1.0.3:compile
+|  \- com.amazonaws:aws-java-sdk-s3:jar:1.11.925:compile
+|     \- com.amazonaws:aws-java-sdk-kms:jar:1.11.925:compile
++- javax.xml.bind:jaxb-api:jar:2.3.0:compile
++- org.springframework.boot:spring-boot-starter-security:jar:2.5.0:compile
++- software.amazon.awssdk:secretsmanager:jar:2.20.34:compile
+|  +- software.amazon.awssdk:aws-json-protocol:jar:2.20.34:compile
+|  |  \- software.amazon.awssdk:third-party-jackson-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:protocol-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:sdk-core:jar:2.20.34:compile
+|  |  \- org.reactivestreams:reactive-streams:jar:1.0.3:compile
+|  +- software.amazon.awssdk:auth:jar:2.20.34:compile
+|  |  \- software.amazon.eventstream:eventstream:jar:1.0.1:compile
+|  +- software.amazon.awssdk:http-client-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:regions:jar:2.20.34:compile
+|  +- software.amazon.awssdk:annotations:jar:2.20.34:compile
+|  +- software.amazon.awssdk:utils:jar:2.20.34:compile
+|  +- software.amazon.awssdk:aws-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:metrics-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:json-utils:jar:2.20.34:compile
+|  +- software.amazon.awssdk:endpoints-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:apache-client:jar:2.20.34:runtime
+|  |  \- org.apache.httpcomponents:httpcore:jar:4.4.14:compile
+|  \- software.amazon.awssdk:netty-nio-client:jar:2.20.34:runtime
+|     +- io.netty:netty-codec-http:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-codec-http2:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-codec:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-transport:jar:4.1.65.Final:runtime
+|     |  \- io.netty:netty-resolver:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-common:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-buffer:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-handler:jar:4.1.65.Final:runtime
+|     \- io.netty:netty-transport-classes-epoll:jar:4.1.86.Final:runtime
+|        \- io.netty:netty-transport-native-unix-common:jar:4.1.65.Final:runtime
++- com.auth0:java-jwt:jar:3.19.4:compile
+|  \- com.fasterxml.jackson.core:jackson-databind:jar:2.12.3:compile
++- com.nimbusds:nimbus-jose-jwt:jar:9.37.4:compile
+|  \- com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile
++- org.springframework.security:spring-security-oauth2-jose:jar:5.6.0:compile
+|  \- org.springframework.security:spring-security-oauth2-core:jar:5.5.0:compile
++- org.springframework.security:spring-security-oauth2-resource-server:jar:5.6.0:compile
++- edu.cornell.weill.reciter:reciter-scopus-model:jar:2.0.3:compile
+|  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.12.3:compile
+|  \- io.swagger:swagger-codegen-maven-plugin:jar:3.0.0-rc1:compile
+|     +- org.apache.maven:maven-core:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-model:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-settings:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-settings-builder:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-repository-metadata:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-artifact:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-model-builder:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-aether-provider:jar:3.2.5:compile
+|     |  |  \- org.eclipse.aether:aether-spi:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-impl:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-api:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-util:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.3.0.M1:compile
+|     |  |  +- javax.enterprise:cdi-api:jar:1.0:compile
+|     |  |  |  \- javax.annotation:jsr250-api:jar:1.0:compile
+|     |  |  \- org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.3.0.M1:compile
+|     |  +- org.sonatype.sisu:sisu-guice:jar:no_aop:3.2.3:compile
+|     |  |  +- javax.inject:javax.inject:jar:1:compile
+|     |  |  \- aopalliance:aopalliance:jar:1.0:compile
+|     |  +- org.codehaus.plexus:plexus-interpolation:jar:1.21:compile
+|     |  +- org.codehaus.plexus:plexus-utils:jar:3.0.20:compile
+|     |  +- org.codehaus.plexus:plexus-classworlds:jar:2.5.2:compile
+|     |  +- org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
+|     |  \- org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:compile
+|     |     \- org.sonatype.plexus:plexus-cipher:jar:1.4:compile
+|     +- org.apache.maven:maven-compat:jar:3.2.5:compile
+|     |  \- org.apache.maven.wagon:wagon-provider-api:jar:2.8:compile
+|     +- org.apache.maven:maven-plugin-api:jar:3.2.5:compile
+|     +- org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.4:compile
+|     +- io.swagger:swagger-codegen:jar:3.0.0-rc1:compile
+|     |  +- io.swagger.core.v3:swagger-core:jar:2.0.0:compile
+|     |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.12.3:compile
+|     |  |  \- javax.validation:validation-api:jar:2.0.1.Final:compile
+|     |  +- io.swagger.parser.v3:swagger-parser-core:jar:2.0.0:compile
+|     |  +- io.swagger.parser.v3:swagger-parser-v3:jar:2.0.0:compile
+|     |  +- io.swagger.parser.v3:swagger-parser:jar:2.0.0:compile
+|     |  |  \- io.swagger.parser.v3:swagger-parser-v2-converter:jar:2.0.0:compile
+|     |  |     +- io.swagger:swagger-parser:jar:1.0.35:compile
+|     |  |     |  \- io.swagger:swagger-core:jar:1.5.19:compile
+|     |  |     \- io.swagger:swagger-compat-spec-parser:jar:1.0.35:compile
+|     |  |        +- com.github.java-json-tools:json-schema-validator:jar:2.2.8:compile
+|     |  |        |  +- com.github.java-json-tools:json-schema-core:jar:1.2.8:compile
+|     |  |        |  |  \- com.github.fge:uri-template:jar:0.9:compile
+|     |  |        |  +- javax.mail:mailapi:jar:1.4.3:compile
+|     |  |        |  |  \- javax.activation:activation:jar:1.1:compile
+|     |  |        |  +- com.googlecode.libphonenumber:libphonenumber:jar:8.0.0:compile
+|     |  |        |  \- net.sf.jopt-simple:jopt-simple:jar:5.0.3:compile
+|     |  |        \- com.github.fge:json-patch:jar:1.6:compile
+|     |  |           \- com.github.fge:jackson-coreutils:jar:1.6:compile
+|     |  |              \- com.github.fge:msg-simple:jar:1.1:compile
+|     |  |                 \- com.github.fge:btf:jar:1.2:compile
+|     |  +- com.samskivert:jmustache:jar:1.15:compile
+|     |  +- org.slf4j:slf4j-ext:jar:1.7.30:compile
+|     |  +- com.atlassian.commonmark:commonmark:jar:0.9.0:compile
+|     |  \- com.github.jknack:handlebars:jar:4.0.6:compile
+|     |     \- org.mozilla:rhino:jar:1.7R4:compile
+|     \- io.swagger:swagger-codegen-generators:jar:1.0.0-rc1:compile
++- com.amazonaws:aws-java-sdk-lambda:jar:1.12.742:compile
++- com.amazonaws:aws-java-sdk-core:jar:1.12.742:compile
+|  +- commons-logging:commons-logging:jar:1.1.3:compile
+|  +- commons-codec:commons-codec:jar:1.15:compile
+|  +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
+|  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.12.3:compile
+|  \- joda-time:joda-time:jar:2.12.7:compile
++- com.amazonaws:aws-java-sdk-cognitoidp:jar:1.12.742:compile
++- edu.cornell.weill.reciter:reciter-pubmed-model:jar:2.0.3:compile
++- edu.cornell.weill.reciter:reciter-identity-model:jar:2.0.10:compile
++- edu.cornell.weill.reciter:reciter-article-model:jar:2.0.36:compile
+|  \- org.springframework.data:spring-data-commons-core:jar:1.4.1.RELEASE:compile
++- edu.cornell.weill.reciter:reciter-dynamodb-model:jar:2.0.15:compile
++- com.github.bohnman:squiggly-filter-jackson:jar:1.3.18:compile
+|  \- net.jcip:jcip-annotations:jar:1.0:compile
++- org.antlr:antlr4-runtime:jar:4.6:compile
++- org.mockito:mockito-core:jar:3.9.0:compile
+|  +- net.bytebuddy:byte-buddy:jar:1.10.22:compile
+|  +- net.bytebuddy:byte-buddy-agent:jar:1.10.22:compile
+|  \- org.objenesis:objenesis:jar:3.2:compile
+\- com.github.ben-manes.caffeine:caffeine:jar:2.9.3:compile
+   +- org.checkerframework:checker-qual:jar:3.19.0:compile
+   \- com.google.errorprone:error_prone_annotations:jar:2.10.0:compile

--- a/pom.xml
+++ b/pom.xml
@@ -145,13 +145,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework.data</groupId>
-                <artifactId>spring-data-releasetrain</artifactId>
-                <version>Lovelace-SR20</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
         			<groupId>com.amazonaws</groupId>
         			<artifactId>aws-java-sdk-bom</artifactId>
         			<version>1.11.925</version>
@@ -231,13 +224,20 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.github.derjust/spring-data-dynamodb -->
+        <!-- Provides org.springframework.dao.* (e.g. EmptyResultDataAccessException),
+             previously pulled in transitively via spring-data-dynamodb. Retained
+             explicitly after its removal (#634 Stage 1). Version managed by the Boot parent. -->
         <dependency>
-            <groupId>com.github.derjust</groupId>
-            <artifactId>spring-data-dynamodb</artifactId>
-            <version>5.1.0</version>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
         </dependency>
-        
+        <!-- Bean Validation provider (Hibernate Validator) for @Validated
+             @ConfigurationProperties such as StrategyParameters. Previously pulled in
+             transitively via spring-data-dynamodb; now declared explicitly (#634 Stage 1). -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
         <dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-boot-starter</artifactId>

--- a/src/main/java/reciter/Application.java
+++ b/src/main/java/reciter/Application.java
@@ -29,7 +29,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -82,7 +81,6 @@ import reciter.utils.DegreeYearStrategyUtils;
 @Configuration
 @EnableAutoConfiguration
 @EnableAsync
-@EnableDynamoDBRepositories("reciter.database.dynamodb")
 @ComponentScan("reciter")
 public class Application {
 	

--- a/src/main/java/reciter/database/dynamodb/DynamoDbConfig.java
+++ b/src/main/java/reciter/database/dynamodb/DynamoDbConfig.java
@@ -7,7 +7,6 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -23,7 +22,7 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMappingException;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
@@ -41,8 +40,6 @@ import com.amazonaws.services.dynamodbv2.util.TableUtils;
 import com.amazonaws.services.dynamodbv2.util.TableUtils.TableNeverTransitionedToStateException;
 
 @Configuration
-@EnableDynamoDBRepositories
-        (basePackages = "reciter.database.dynamodb.repository", dynamoDBMapperConfigRef = "dynamoDBMapperConfig")
 public class DynamoDbConfig {
 	
 	private static final Logger log = LoggerFactory.getLogger(DynamoDbConfig.class);
@@ -159,10 +156,16 @@ public class DynamoDbConfig {
         return amazonDynamoDB;
     }
     
+    /**
+     * Replaces the {@code DynamoDBMapper} that spring-data-dynamodb used to
+     * auto-register (#634 Stage 1). Backs both {@code DynamoDbCrudRepository} and
+     * the {@code @Autowired DynamoDBMapper} in {@code SchemaMigrationAspect}. Uses
+     * {@code DynamoDBMapperConfig.DEFAULT} (the bare config the old
+     * {@code dynamoDBMapperConfig} bean produced carried no overrides).
+     */
     @Bean
-    public DynamoDBMapperConfig dynamoDBMapperConfig() {
-    	DynamoDBMapperConfig.Builder builder = new DynamoDBMapperConfig.Builder();
-    	return builder.build();
+    public DynamoDBMapper dynamoDBMapper(AmazonDynamoDB amazonDynamoDB) {
+    	return new DynamoDBMapper(amazonDynamoDB);
     }
     
     /**

--- a/src/main/java/reciter/database/dynamodb/aspect/SchemaMigrationAspect.java
+++ b/src/main/java/reciter/database/dynamodb/aspect/SchemaMigrationAspect.java
@@ -54,7 +54,7 @@ public class SchemaMigrationAspect {
         
         return result;
     }
-    @Around("execution(* org.springframework.data.repository.CrudRepository.save(..))")
+    @Around("execution(* reciter.database.dynamodb.repository.DynamoDbCrudRepository+.save(..))")
     public Object ensureDefaultsOnSave(ProceedingJoinPoint joinPoint) throws Throwable {
         Object item = joinPoint.getArgs()[0];
         

--- a/src/main/java/reciter/database/dynamodb/repository/AnalysisOutputRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/AnalysisOutputRepository.java
@@ -1,11 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 
 import reciter.database.dynamodb.model.AnalysisOutput;
 
-@EnableScan
-public interface AnalysisOutputRepository extends CrudRepository<AnalysisOutput, String> {
+@Repository
+public class AnalysisOutputRepository extends DynamoDbCrudRepository<AnalysisOutput, String> {
 
+    public AnalysisOutputRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, AnalysisOutput.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/ApplicationUserRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/ApplicationUserRepository.java
@@ -1,9 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+
 import reciter.database.dynamodb.model.ApplicationUser;
 
-@EnableScan
-public interface ApplicationUserRepository extends CrudRepository<ApplicationUser, String> {
+@Repository
+public class ApplicationUserRepository extends DynamoDbCrudRepository<ApplicationUser, String> {
+
+    public ApplicationUserRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, ApplicationUser.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/DynamoDbCrudRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/DynamoDbCrudRepository.java
@@ -1,0 +1,124 @@
+package reciter.database.dynamodb.repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.KeyPair;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedScanList;
+
+/**
+ * Generic CRUD base over the AWS SDK v1 {@link DynamoDBMapper}, replacing
+ * {@code com.github.derjust:spring-data-dynamodb} (removed in #634 Stage 1).
+ *
+ * <p>Exposes exactly the subset of the former Spring Data {@code CrudRepository}
+ * contract that ReCiter's repositories actually use, with the same method
+ * signatures (returning {@link java.util.Optional} / {@link Iterable}) so callers
+ * compile unchanged. Each concrete repository extends this base, passing its
+ * domain type, e.g.:
+ *
+ * <pre>{@code
+ * @Repository
+ * public class IdentityRepository extends DynamoDbCrudRepository<Identity, String> {
+ *     public IdentityRepository(DynamoDBMapper dynamoDBMapper) {
+ *         super(dynamoDBMapper, Identity.class);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>{@link #findAll()}, {@link #count()} and {@link #deleteAll()} perform a table
+ * scan, mirroring the {@code @EnableScan} behavior the repositories previously
+ * relied on. All 15 repositories use a single-attribute hash key (their Spring Data
+ * ID type was {@code String}/{@code Long}, never a composite key class), so
+ * {@link DynamoDBMapper#load(Class, Object)} and {@link KeyPair#withHashKey(Object)}
+ * are correct for id-based access.
+ *
+ * @param <T>  the domain (entity) type
+ * @param <ID> the type of the entity's hash key
+ */
+public abstract class DynamoDbCrudRepository<T, ID> {
+
+    protected final DynamoDBMapper dynamoDBMapper;
+    protected final Class<T> domainType;
+
+    protected DynamoDbCrudRepository(DynamoDBMapper dynamoDBMapper, Class<T> domainType) {
+        this.dynamoDBMapper = dynamoDBMapper;
+        this.domainType = domainType;
+    }
+
+    public <S extends T> S save(S entity) {
+        dynamoDBMapper.save(entity);
+        return entity;
+    }
+
+    public <S extends T> Iterable<S> saveAll(Iterable<S> entities) {
+        List<S> batch = new ArrayList<>();
+        entities.forEach(batch::add);
+        if (!batch.isEmpty()) {
+            List<FailedBatch> failures = dynamoDBMapper.batchSave(batch);
+            if (failures != null && !failures.isEmpty()) {
+                throw failures.get(0).getException() instanceof RuntimeException
+                        ? (RuntimeException) failures.get(0).getException()
+                        : new RuntimeException("DynamoDB batchSave reported "
+                                + failures.size() + " failed batch(es)", failures.get(0).getException());
+            }
+        }
+        return batch;
+    }
+
+    public Optional<T> findById(ID id) {
+        return Optional.ofNullable(dynamoDBMapper.load(domainType, id));
+    }
+
+    public boolean existsById(ID id) {
+        return dynamoDBMapper.load(domainType, id) != null;
+    }
+
+    public Iterable<T> findAll() {
+        return dynamoDBMapper.scan(domainType, new DynamoDBScanExpression());
+    }
+
+    public Iterable<T> findAllById(Iterable<ID> ids) {
+        List<KeyPair> keyPairs = new ArrayList<>();
+        for (ID id : ids) {
+            keyPairs.add(new KeyPair().withHashKey(id));
+        }
+        if (keyPairs.isEmpty()) {
+            return new ArrayList<>();
+        }
+        Map<Class<?>, List<KeyPair>> itemsToGet = new HashMap<>();
+        itemsToGet.put(domainType, keyPairs);
+        Map<String, List<Object>> loaded = dynamoDBMapper.batchLoad(itemsToGet);
+        List<T> result = new ArrayList<>();
+        for (List<Object> tableItems : loaded.values()) {
+            for (Object item : tableItems) {
+                result.add(domainType.cast(item));
+            }
+        }
+        return result;
+    }
+
+    public long count() {
+        return dynamoDBMapper.count(domainType, new DynamoDBScanExpression());
+    }
+
+    public void deleteById(ID id) {
+        T entity = dynamoDBMapper.load(domainType, id);
+        if (entity != null) {
+            dynamoDBMapper.delete(entity);
+        }
+    }
+
+    public void deleteAll() {
+        PaginatedScanList<T> scanned = dynamoDBMapper.scan(domainType, new DynamoDBScanExpression());
+        List<T> items = new ArrayList<>(scanned);
+        if (!items.isEmpty()) {
+            dynamoDBMapper.batchDelete(items);
+        }
+    }
+}

--- a/src/main/java/reciter/database/dynamodb/repository/DynamoDbGoldStandardRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/DynamoDbGoldStandardRepository.java
@@ -1,9 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+
 import reciter.database.dynamodb.model.GoldStandard;
 
-@EnableScan
-public interface DynamoDbGoldStandardRepository extends CrudRepository<GoldStandard, String> {
+@Repository
+public class DynamoDbGoldStandardRepository extends DynamoDbCrudRepository<GoldStandard, String> {
+
+    public DynamoDbGoldStandardRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, GoldStandard.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/DynamoDbInstitutionAfidRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/DynamoDbInstitutionAfidRepository.java
@@ -1,9 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+
 import reciter.database.dynamodb.model.InstitutionAfid;
 
-@EnableScan
-public interface DynamoDbInstitutionAfidRepository extends CrudRepository<InstitutionAfid, String> {
+@Repository
+public class DynamoDbInstitutionAfidRepository extends DynamoDbCrudRepository<InstitutionAfid, String> {
+
+    public DynamoDbInstitutionAfidRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, InstitutionAfid.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/DynamoMeshTermRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/DynamoMeshTermRepository.java
@@ -1,9 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+
 import reciter.database.dynamodb.model.MeshTerm;
 
-@EnableScan
-public interface DynamoMeshTermRepository extends CrudRepository<MeshTerm, String> {
+@Repository
+public class DynamoMeshTermRepository extends DynamoDbCrudRepository<MeshTerm, String> {
+
+    public DynamoMeshTermRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, MeshTerm.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/ESearchCountRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/ESearchCountRepository.java
@@ -1,10 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 
 import reciter.database.dynamodb.model.ESearchCount;
 
-@EnableScan
-public interface ESearchCountRepository extends CrudRepository<ESearchCount, String> {
+@Repository
+public class ESearchCountRepository extends DynamoDbCrudRepository<ESearchCount, String> {
+
+    public ESearchCountRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, ESearchCount.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/ESearchResultRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/ESearchResultRepository.java
@@ -1,9 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+
 import reciter.database.dynamodb.model.ESearchResult;
 
-@EnableScan
-public interface ESearchResultRepository extends CrudRepository<ESearchResult, String> {
+@Repository
+public class ESearchResultRepository extends DynamoDbCrudRepository<ESearchResult, String> {
+
+    public ESearchResultRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, ESearchResult.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/GenderRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/GenderRepository.java
@@ -1,11 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 
 import reciter.database.dynamodb.model.Gender;
 
-@EnableScan
-public interface GenderRepository extends CrudRepository<Gender, String>{
+@Repository
+public class GenderRepository extends DynamoDbCrudRepository<Gender, String> {
 
+    public GenderRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, Gender.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/IdentityRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/IdentityRepository.java
@@ -1,10 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+
 import reciter.database.dynamodb.model.Identity;
 
-@EnableScan
-public interface IdentityRepository extends CrudRepository<Identity, String> {
+@Repository
+public class IdentityRepository extends DynamoDbCrudRepository<Identity, String> {
 
+    public IdentityRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, Identity.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/NameFrequencyRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/NameFrequencyRepository.java
@@ -1,11 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 
 import reciter.database.dynamodb.model.NameFrequency;
 
-@EnableScan
-public interface NameFrequencyRepository extends CrudRepository<NameFrequency, String>{
+@Repository
+public class NameFrequencyRepository extends DynamoDbCrudRepository<NameFrequency, String> {
 
+    public NameFrequencyRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, NameFrequency.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/OrcidRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/OrcidRepository.java
@@ -1,12 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 
 import reciter.database.dynamodb.model.AdminOrcid;
 
+@Repository
+public class OrcidRepository extends DynamoDbCrudRepository<AdminOrcid, String> {
 
-@EnableScan
-public interface OrcidRepository extends CrudRepository<AdminOrcid, String> {
-
+    public OrcidRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, AdminOrcid.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/PubMedArticleRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/PubMedArticleRepository.java
@@ -1,9 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+
 import reciter.database.dynamodb.model.PubMedArticle;
 
-@EnableScan
-public interface PubMedArticleRepository extends CrudRepository<PubMedArticle, Long> {
+@Repository
+public class PubMedArticleRepository extends DynamoDbCrudRepository<PubMedArticle, Long> {
+
+    public PubMedArticleRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, PubMedArticle.class);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/ScienceMetrixDepartmentCategoryRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/ScienceMetrixDepartmentCategoryRepository.java
@@ -1,15 +1,35 @@
 package reciter.database.dynamodb.repository;
 
+import java.util.Collections;
 import java.util.List;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 import reciter.database.dynamodb.model.ScienceMetrixDepartmentCategory;
 
-@EnableScan
-public interface ScienceMetrixDepartmentCategoryRepository extends CrudRepository<ScienceMetrixDepartmentCategory, Long> {
-	
-	List<ScienceMetrixDepartmentCategory> findByScienceMetrixJournalSubfieldId(Long subfieldId);
+@Repository
+public class ScienceMetrixDepartmentCategoryRepository
+        extends DynamoDbCrudRepository<ScienceMetrixDepartmentCategory, Long> {
 
+    public ScienceMetrixDepartmentCategoryRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, ScienceMetrixDepartmentCategory.class);
+    }
+
+    /**
+     * Replaces the former Spring Data derived query. {@code scienceMetrixJournalSubfieldId}
+     * is a numeric (N) attribute, so the filter binds it as a number.
+     */
+    public List<ScienceMetrixDepartmentCategory> findByScienceMetrixJournalSubfieldId(Long subfieldId) {
+        DynamoDBScanExpression scan = new DynamoDBScanExpression()
+                .withFilterExpression("#attr = :val")
+                .withExpressionAttributeNames(
+                        Collections.singletonMap("#attr", "scienceMetrixJournalSubfieldId"))
+                .withExpressionAttributeValues(
+                        Collections.singletonMap(":val", new AttributeValue().withN(String.valueOf(subfieldId))));
+        return dynamoDBMapper.scan(ScienceMetrixDepartmentCategory.class, scan);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/ScienceMetrixRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/ScienceMetrixRepository.java
@@ -1,12 +1,43 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
 import reciter.database.dynamodb.model.ScienceMetrix;
 
-@EnableScan
-public interface ScienceMetrixRepository extends CrudRepository<ScienceMetrix, Long> {
-    ScienceMetrix findByEissn(String eissn);
+@Repository
+public class ScienceMetrixRepository extends DynamoDbCrudRepository<ScienceMetrix, Long> {
 
-    ScienceMetrix findByIssn(String issn);
+    public ScienceMetrixRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, ScienceMetrix.class);
+    }
+
+    public ScienceMetrix findByEissn(String eissn) {
+        return scanFirstByStringAttribute("eissn", eissn);
+    }
+
+    public ScienceMetrix findByIssn(String issn) {
+        return scanFirstByStringAttribute("issn", issn);
+    }
+
+    /**
+     * Replaces the former Spring Data derived query. The {@code @EnableScan}
+     * repositories scanned with an equality filter on the (non-key) attribute, so
+     * this performs the same scan and returns the first match (or {@code null}).
+     */
+    private ScienceMetrix scanFirstByStringAttribute(String attributeName, String value) {
+        DynamoDBScanExpression scan = new DynamoDBScanExpression()
+                .withFilterExpression("#attr = :val")
+                .withExpressionAttributeNames(Collections.singletonMap("#attr", attributeName))
+                .withExpressionAttributeValues(
+                        Collections.singletonMap(":val", new AttributeValue().withS(value)));
+        List<ScienceMetrix> results = dynamoDBMapper.scan(ScienceMetrix.class, scan);
+        return results.isEmpty() ? null : results.get(0);
+    }
 }

--- a/src/main/java/reciter/database/dynamodb/repository/ScopusArticleRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/ScopusArticleRepository.java
@@ -1,9 +1,15 @@
 package reciter.database.dynamodb.repository;
 
-import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+
 import reciter.database.dynamodb.model.ScopusArticle;
 
-@EnableScan
-public interface ScopusArticleRepository extends CrudRepository<ScopusArticle, String> {
+@Repository
+public class ScopusArticleRepository extends DynamoDbCrudRepository<ScopusArticle, String> {
+
+    public ScopusArticleRepository(DynamoDBMapper dynamoDBMapper) {
+        super(dynamoDBMapper, ScopusArticle.class);
+    }
 }

--- a/src/test/java/reciter/database/dynamodb/repository/DynamoDbCrudRepositoryTest.java
+++ b/src/test/java/reciter/database/dynamodb/repository/DynamoDbCrudRepositoryTest.java
@@ -1,0 +1,200 @@
+package reciter.database.dynamodb.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedScanList;
+
+import reciter.database.dynamodb.model.Identity;
+
+/**
+ * Unit tests for the {@link DynamoDbCrudRepository} facade (#634 Stage 1), exercised
+ * through the concrete {@link IdentityRepository} with a mocked {@link DynamoDBMapper}.
+ * Mirrors the existing mocked-AWS-SDK test style (e.g. ArticleProvenanceServiceImplTest);
+ * per the JDK-17 guidance, only plain {@code @Mock}s are used (no {@code @Spy} on JDK
+ * collections).
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DynamoDbCrudRepositoryTest {
+
+    @Mock
+    private DynamoDBMapper dynamoDBMapper;
+
+    private IdentityRepository repository;
+
+    @Before
+    public void setUp() {
+        repository = new IdentityRepository(dynamoDBMapper);
+    }
+
+    @Test
+    public void save_delegatesToMapperAndReturnsEntity() {
+        Identity entity = new Identity();
+        Identity result = repository.save(entity);
+        verify(dynamoDBMapper).save(entity);
+        assertSame(entity, result);
+    }
+
+    @Test
+    public void saveAll_batchSavesAndReturnsEntities() {
+        Identity a = new Identity();
+        Identity b = new Identity();
+        when(dynamoDBMapper.batchSave(anyList())).thenReturn(Collections.emptyList());
+
+        Iterable<Identity> result = repository.saveAll(Arrays.asList(a, b));
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(dynamoDBMapper).batchSave(captor.capture());
+        assertEquals(Arrays.asList(a, b), captor.getValue());
+        assertEquals(Arrays.asList(a, b), toList(result));
+    }
+
+    @Test
+    public void saveAll_emptyDoesNotCallMapper() {
+        Iterable<Identity> result = repository.saveAll(Collections.<Identity>emptyList());
+        verify(dynamoDBMapper, never()).batchSave(anyList());
+        assertFalse(result.iterator().hasNext());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void saveAll_throwsWhenBatchReportsFailure() {
+        FailedBatch failed = org.mockito.Mockito.mock(FailedBatch.class);
+        when(failed.getException()).thenReturn(new RuntimeException("boom"));
+        when(dynamoDBMapper.batchSave(anyList())).thenReturn(Collections.singletonList(failed));
+        repository.saveAll(Collections.singletonList(new Identity()));
+    }
+
+    @Test
+    public void findById_present() {
+        Identity entity = new Identity();
+        when(dynamoDBMapper.load(Identity.class, "uid1")).thenReturn(entity);
+        Optional<Identity> result = repository.findById("uid1");
+        assertTrue(result.isPresent());
+        assertSame(entity, result.get());
+    }
+
+    @Test
+    public void findById_absentReturnsEmptyOptional() {
+        when(dynamoDBMapper.load(Identity.class, "missing")).thenReturn(null);
+        assertFalse(repository.findById("missing").isPresent());
+    }
+
+    @Test
+    public void existsById_reflectsLoad() {
+        when(dynamoDBMapper.load(Identity.class, "yes")).thenReturn(new Identity());
+        when(dynamoDBMapper.load(Identity.class, "no")).thenReturn(null);
+        assertTrue(repository.existsById("yes"));
+        assertFalse(repository.existsById("no"));
+    }
+
+    @Test
+    public void findAll_scansTable() {
+        @SuppressWarnings("unchecked")
+        PaginatedScanList<Identity> scanList = org.mockito.Mockito.mock(PaginatedScanList.class);
+        when(dynamoDBMapper.scan(eq(Identity.class), any(DynamoDBScanExpression.class))).thenReturn(scanList);
+        Iterable<Identity> result = repository.findAll();
+        assertSame(scanList, result);
+        verify(dynamoDBMapper).scan(eq(Identity.class), any(DynamoDBScanExpression.class));
+    }
+
+    @Test
+    public void findAllById_batchLoadsAndFlattens() {
+        Identity a = new Identity();
+        Identity b = new Identity();
+        Map<String, List<Object>> loaded =
+                Collections.singletonMap("Identity", Arrays.<Object>asList(a, b));
+        when(dynamoDBMapper.batchLoad(anyMap())).thenReturn(loaded);
+
+        List<Identity> result = toList(repository.findAllById(Arrays.asList("a", "b")));
+
+        assertEquals(Arrays.asList(a, b), result);
+        verify(dynamoDBMapper).batchLoad(anyMap());
+    }
+
+    @Test
+    public void findAllById_emptyDoesNotCallMapper() {
+        List<Identity> result = toList(repository.findAllById(Collections.<String>emptyList()));
+        assertTrue(result.isEmpty());
+        verify(dynamoDBMapper, never()).batchLoad(anyMap());
+    }
+
+    @Test
+    public void count_delegatesToMapperCount() {
+        when(dynamoDBMapper.count(eq(Identity.class), any(DynamoDBScanExpression.class))).thenReturn(42);
+        assertEquals(42L, repository.count());
+    }
+
+    @Test
+    public void deleteById_deletesWhenPresent() {
+        Identity entity = new Identity();
+        when(dynamoDBMapper.load(Identity.class, "uid1")).thenReturn(entity);
+        repository.deleteById("uid1");
+        verify(dynamoDBMapper).delete(entity);
+    }
+
+    @Test
+    public void deleteById_noDeleteWhenAbsent() {
+        when(dynamoDBMapper.load(Identity.class, "missing")).thenReturn(null);
+        repository.deleteById("missing");
+        verify(dynamoDBMapper, never()).delete(any());
+    }
+
+    @Test
+    public void deleteAll_scansThenBatchDeletes() {
+        Identity a = new Identity();
+        @SuppressWarnings("unchecked")
+        PaginatedScanList<Identity> scanList = org.mockito.Mockito.mock(PaginatedScanList.class);
+        when(scanList.toArray()).thenReturn(new Object[] { a });
+        when(dynamoDBMapper.scan(eq(Identity.class), any(DynamoDBScanExpression.class))).thenReturn(scanList);
+
+        repository.deleteAll();
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(dynamoDBMapper).batchDelete(captor.capture());
+        assertEquals(Collections.singletonList(a), captor.getValue());
+    }
+
+    @Test
+    public void deleteAll_emptyDoesNotBatchDelete() {
+        @SuppressWarnings("unchecked")
+        PaginatedScanList<Identity> scanList = org.mockito.Mockito.mock(PaginatedScanList.class);
+        when(scanList.toArray()).thenReturn(new Object[0]);
+        when(dynamoDBMapper.scan(eq(Identity.class), any(DynamoDBScanExpression.class))).thenReturn(scanList);
+
+        repository.deleteAll();
+
+        verify(dynamoDBMapper, never()).batchDelete(anyList());
+    }
+
+    private static <T> List<T> toList(Iterable<T> iterable) {
+        List<T> list = new ArrayList<>();
+        iterable.forEach(list::add);
+        return list;
+    }
+}

--- a/src/test/java/reciter/database/dynamodb/repository/ScienceMetrixDepartmentCategoryRepositoryTest.java
+++ b/src/test/java/reciter/database/dynamodb/repository/ScienceMetrixDepartmentCategoryRepositoryTest.java
@@ -1,0 +1,62 @@
+package reciter.database.dynamodb.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedScanList;
+
+import reciter.database.dynamodb.model.ScienceMetrixDepartmentCategory;
+
+/**
+ * Verifies the explicit scan replacing the former Spring Data derived query
+ * {@code findByScienceMetrixJournalSubfieldId} (#634 Stage 1): the numeric (N)
+ * attribute is filtered for equality and the scan result returned verbatim.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ScienceMetrixDepartmentCategoryRepositoryTest {
+
+    @Mock
+    private DynamoDBMapper dynamoDBMapper;
+
+    @Mock
+    private PaginatedScanList<ScienceMetrixDepartmentCategory> scanResult;
+
+    private ScienceMetrixDepartmentCategoryRepository repository;
+
+    @Before
+    public void setUp() {
+        repository = new ScienceMetrixDepartmentCategoryRepository(dynamoDBMapper);
+    }
+
+    @Test
+    public void findBySubfieldId_filtersNumericEqualityAndReturnsResults() {
+        when(dynamoDBMapper.scan(eq(ScienceMetrixDepartmentCategory.class), any(DynamoDBScanExpression.class)))
+                .thenReturn(scanResult);
+
+        List<ScienceMetrixDepartmentCategory> result =
+                repository.findByScienceMetrixJournalSubfieldId(101L);
+
+        assertSame(scanResult, result);
+        ArgumentCaptor<DynamoDBScanExpression> captor = ArgumentCaptor.forClass(DynamoDBScanExpression.class);
+        verify(dynamoDBMapper).scan(eq(ScienceMetrixDepartmentCategory.class), captor.capture());
+        DynamoDBScanExpression scan = captor.getValue();
+        assertEquals("#attr = :val", scan.getFilterExpression());
+        assertEquals("scienceMetrixJournalSubfieldId", scan.getExpressionAttributeNames().get("#attr"));
+        assertEquals("101", scan.getExpressionAttributeValues().get(":val").getN());
+    }
+}

--- a/src/test/java/reciter/database/dynamodb/repository/ScienceMetrixRepositoryTest.java
+++ b/src/test/java/reciter/database/dynamodb/repository/ScienceMetrixRepositoryTest.java
@@ -1,0 +1,92 @@
+package reciter.database.dynamodb.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedScanList;
+
+import reciter.database.dynamodb.model.ScienceMetrix;
+
+/**
+ * Verifies the explicit scan replacing the former Spring Data derived queries
+ * {@code findByEissn}/{@code findByIssn} (#634 Stage 1): the right (string)
+ * attribute is filtered for equality and the first match (or {@code null}) returned.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ScienceMetrixRepositoryTest {
+
+    @Mock
+    private DynamoDBMapper dynamoDBMapper;
+
+    @Mock
+    private PaginatedScanList<ScienceMetrix> scanResult;
+
+    private ScienceMetrixRepository repository;
+
+    @Before
+    public void setUp() {
+        repository = new ScienceMetrixRepository(dynamoDBMapper);
+    }
+
+    @Test
+    public void findByEissn_filtersEissnEqualityAndReturnsFirst() {
+        ScienceMetrix expected = new ScienceMetrix();
+        when(scanResult.isEmpty()).thenReturn(false);
+        when(scanResult.get(0)).thenReturn(expected);
+        when(dynamoDBMapper.scan(eq(ScienceMetrix.class), any(DynamoDBScanExpression.class)))
+                .thenReturn(scanResult);
+
+        ScienceMetrix result = repository.findByEissn("1234-5678");
+
+        assertSame(expected, result);
+        DynamoDBScanExpression scan = captureScan();
+        assertEquals("#attr = :val", scan.getFilterExpression());
+        assertEquals("eissn", scan.getExpressionAttributeNames().get("#attr"));
+        assertEquals("1234-5678", scan.getExpressionAttributeValues().get(":val").getS());
+    }
+
+    @Test
+    public void findByIssn_filtersIssnEqualityAndReturnsFirst() {
+        ScienceMetrix expected = new ScienceMetrix();
+        when(scanResult.isEmpty()).thenReturn(false);
+        when(scanResult.get(0)).thenReturn(expected);
+        when(dynamoDBMapper.scan(eq(ScienceMetrix.class), any(DynamoDBScanExpression.class)))
+                .thenReturn(scanResult);
+
+        ScienceMetrix result = repository.findByIssn("9999-0000");
+
+        assertSame(expected, result);
+        DynamoDBScanExpression scan = captureScan();
+        assertEquals("issn", scan.getExpressionAttributeNames().get("#attr"));
+        assertEquals("9999-0000", scan.getExpressionAttributeValues().get(":val").getS());
+    }
+
+    @Test
+    public void findByEissn_returnsNullWhenNoMatch() {
+        when(scanResult.isEmpty()).thenReturn(true);
+        when(dynamoDBMapper.scan(eq(ScienceMetrix.class), any(DynamoDBScanExpression.class)))
+                .thenReturn(scanResult);
+
+        assertNull(repository.findByEissn("absent"));
+    }
+
+    private DynamoDBScanExpression captureScan() {
+        ArgumentCaptor<DynamoDBScanExpression> captor = ArgumentCaptor.forClass(DynamoDBScanExpression.class);
+        verify(dynamoDBMapper).scan(eq(ScienceMetrix.class), captor.capture());
+        return captor.getValue();
+    }
+}


### PR DESCRIPTION
Stage 1 of #634. Removes the abandoned `com.github.derjust:spring-data-dynamodb` (pinned to Spring Data 2.1 / Spring 5.1) — the hard blocker for the Spring Boot 2.7 upgrade — with **no behavior change**, keeping the AWS SDK v1 `@DynamoDBTable` model annotations (which live in five separate model jars) untouched.

> ⛓️ **Stacked on #648 (Stage 0).** Review/merge #648 first; this PR's base is `fix/634-stage0-smoke`, so it shows only Stage 1's diff. After #648 merges I'll retarget this to `development`.

## Facade
- **`DynamoDbCrudRepository<T, ID>`** — a generic CRUD base over the v1 `DynamoDBMapper` exposing exactly the methods the repos use (`save`/`saveAll`/`findById`/`findAllById`/`findAll`/`existsById`/`count`/`deleteById`/`deleteAll`), with the same `Optional`/`Iterable` signatures so callers compile unchanged. `findAll`/`count`/`deleteAll` scan, mirroring the former `@EnableScan`. `findAllById` uses `batchLoad` (preserves the PubMed retrieval path's batched behavior).
- **15 repositories** re-pointed from `CrudRepository` onto the facade as concrete `@Repository` classes. The 3 former derived queries (`ScienceMetrixRepository.findByEissn/findByIssn`, `ScienceMetrixDepartmentCategoryRepository.findByScienceMetrixJournalSubfieldId`) become explicit equality-filter scans on the real attribute names (`eissn`/`issn` as S, `scienceMetrixJournalSubfieldId` as N).

## Wiring
- Add an explicit **`DynamoDBMapper` `@Bean`** in `DynamoDbConfig` (`spring-data-dynamodb` used to auto-register it); it backs both the facade and `SchemaMigrationAspect`'s `@Autowired` mapper. Drop the now-unused `dynamoDBMapperConfig` bean.
- Remove both `@EnableDynamoDBRepositories` annotations (`DynamoDbConfig`, `Application`) + imports.
- Repoint `SchemaMigrationAspect`'s save pointcut from `CrudRepository.save(..)` → `DynamoDbCrudRepository+.save(..)` so schema-migration-on-save keeps firing.

## POM
- Remove `spring-data-dynamodb` and the `spring-data-releasetrain` (Lovelace-SR20) BOM import that existed only to satisfy it.
- Add **`spring-tx`** (`org.springframework.dao.*` used by `ReCiterController`/`ESearchResultServiceImpl`) and **`spring-boot-starter-validation`** (Hibernate Validator for `@Validated StrategyParameters`) explicitly — both were previously transitive via `spring-data-dynamodb`. The Stage 0 smoke test caught the missing validation provider, which would otherwise have been a prod startup failure.

## Verification
- `mvn clean install` (Java 17): **146 tests, 0 failures** (127 + 19 new mocked-`DynamoDBMapper` unit tests covering the facade CRUD ops + the 3 derived-query scans), jar built.
- The Stage 0 context-load smoke test boots the app on the facade with **zero** `spring-data-dynamodb` on the classpath.
- `dependency:tree` confirms `spring-data-dynamodb` / `spring-data-commons:2.1.20` / `spring-data-releasetrain` are gone; `spring-tx` + `hibernate-validator` present.

## Manual runtime check before deploy (two unit-invisible behaviors)
- [ ] **Schema migration on save** — the `SchemaMigrationAspect` pointcut repoint is Spring-AOP runtime behavior, not covered by unit tests. Verify a `VersionedItem` save still triggers default population.
- [ ] **Derived queries** — now scans (matching the old `@EnableScan`; the GSI creation was already commented out in `DynamoDbConfig`). Spot-check `findByEissn`/`findByIssn`/`findByScienceMetrixJournalSubfieldId` return correctly.

Part of #634 (Stage 1 of 4 toward the Boot 2.7 milestone).