### PR TITLE
refactor(#634): Stage 2 — replace springfox with springdoc (OpenAPI 3)

### DIFF
--- a/docs/634-modernization/dependency-tree-stage2.txt
+++ b/docs/634-modernization/dependency-tree-stage2.txt
@@ -1,0 +1,255 @@
+edu.cornell.weill.reciter:reciter:jar:2.1.3
++- org.springframework.boot:spring-boot-starter-test:jar:2.5.0:test
+|  +- org.springframework.boot:spring-boot-starter:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-autoconfigure:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-starter-logging:jar:2.5.0:compile
+|  |  |  +- ch.qos.logback:logback-classic:jar:1.2.3:compile
+|  |  |  |  \- ch.qos.logback:logback-core:jar:1.2.3:compile
+|  |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.16.0:compile
+|  |  |  \- org.slf4j:jul-to-slf4j:jar:1.7.30:compile
+|  |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
+|  |  \- org.yaml:snakeyaml:jar:1.28:compile
+|  +- org.springframework.boot:spring-boot-test:jar:2.5.0:test
+|  +- org.springframework.boot:spring-boot-test-autoconfigure:jar:2.5.0:test
+|  +- com.jayway.jsonpath:json-path:jar:2.5.0:test
+|  |  \- net.minidev:json-smart:jar:2.4.7:test
+|  |     \- net.minidev:accessors-smart:jar:2.4.7:test
+|  |        \- org.ow2.asm:asm:jar:9.1:test
+|  +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
+|  |  \- jakarta.activation:jakarta.activation-api:jar:1.2.2:compile
+|  +- org.assertj:assertj-core:jar:3.19.0:test
+|  +- org.hamcrest:hamcrest:jar:2.2:compile
+|  +- org.junit.jupiter:junit-jupiter:jar:5.7.2:test
+|  |  +- org.junit.jupiter:junit-jupiter-api:jar:5.7.2:test
+|  |  +- org.junit.jupiter:junit-jupiter-params:jar:5.7.2:test
+|  |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.7.2:test
+|  +- org.mockito:mockito-junit-jupiter:jar:3.9.0:test
+|  +- org.skyscreamer:jsonassert:jar:1.5.0:test
+|  |  \- com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1:test
+|  +- org.springframework:spring-core:jar:5.3.7:compile
+|  |  \- org.springframework:spring-jcl:jar:5.3.7:compile
+|  +- org.springframework:spring-test:jar:5.3.7:test
+|  \- org.xmlunit:xmlunit-core:jar:2.8.2:test
++- org.junit.vintage:junit-vintage-engine:jar:5.7.2:test
+|  +- org.apiguardian:apiguardian-api:jar:1.1.0:test
+|  \- org.junit.platform:junit-platform-engine:jar:1.7.2:test
+|     +- org.opentest4j:opentest4j:jar:1.2.0:test
+|     \- org.junit.platform:junit-platform-commons:jar:1.7.2:test
++- com.google.code.gson:gson:jar:2.8.6:compile
++- org.springframework.security:spring-security-config:jar:5.5.0:compile
+|  +- org.springframework:spring-aop:jar:5.3.7:compile
+|  +- org.springframework:spring-beans:jar:5.3.7:compile
+|  +- org.springframework:spring-context:jar:5.3.7:compile
+|  \- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.0:compile
+|     +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.5.0:compile
+|     |  +- org.jetbrains:annotations:jar:13.0:compile
+|     |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.0:compile
+|     \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.0:compile
++- org.springframework.security:spring-security-web:jar:5.5.0:compile
+|  +- org.springframework:spring-expression:jar:5.3.7:compile
+|  \- org.springframework:spring-web:jar:5.3.7:compile
++- org.springframework.security:spring-security-core:jar:5.5.0:compile
+|  \- org.springframework.security:spring-security-crypto:jar:5.5.0:compile
++- org.springframework.boot:spring-boot-starter-websocket:jar:2.5.0:compile
+|  +- org.springframework.boot:spring-boot-starter-web:jar:2.5.0:compile
+|  |  +- org.springframework.boot:spring-boot-starter-json:jar:2.5.0:compile
+|  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.12.3:compile
+|  |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.12.3:compile
+|  |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:2.5.0:compile
+|  |  |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:9.0.46:compile
+|  |  |  \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:9.0.46:compile
+|  |  \- org.springframework:spring-webmvc:jar:5.3.7:compile
+|  +- org.springframework:spring-messaging:jar:5.3.7:compile
+|  \- org.springframework:spring-websocket:jar:5.3.7:compile
++- org.springframework.boot:spring-boot-starter-aop:jar:2.5.0:compile
+|  \- org.aspectj:aspectjweaver:jar:1.9.6:compile
++- org.apache.commons:commons-lang3:jar:3.12.0:compile
++- commons-io:commons-io:jar:2.14.0:compile
++- org.apache.commons:commons-csv:jar:1.9.0:compile
++- org.json:json:jar:20240303:compile
++- junit:junit:jar:4.13.2:compile
+|  \- org.hamcrest:hamcrest-core:jar:2.2:compile
++- com.unboundid:unboundid-ldapsdk:jar:4.0.14:compile
++- org.projectlombok:lombok:jar:1.18.44:compile
++- org.springframework:spring-tx:jar:5.3.7:compile
++- org.springframework.boot:spring-boot-starter-validation:jar:2.5.0:compile
+|  +- org.apache.tomcat.embed:tomcat-embed-el:jar:9.0.46:compile
+|  \- org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
+|     +- jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
+|     +- org.jboss.logging:jboss-logging:jar:3.4.1.Final:compile
+|     \- com.fasterxml:classmate:jar:1.5.1:compile
++- org.springdoc:springdoc-openapi-ui:jar:1.6.15:compile
+|  +- org.springdoc:springdoc-openapi-webmvc-core:jar:1.6.15:compile
+|  |  \- org.springdoc:springdoc-openapi-common:jar:1.6.15:compile
+|  |     \- io.swagger.core.v3:swagger-core:jar:2.2.8:compile
+|  |        +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.12.3:compile
+|  |        \- io.swagger.core.v3:swagger-annotations:jar:2.2.8:compile
+|  +- org.webjars:swagger-ui:jar:4.17.1:compile
+|  +- org.webjars:webjars-locator-core:jar:0.46:compile
+|  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.12.3:compile
+|  \- io.github.classgraph:classgraph:jar:4.8.149:compile
++- org.springframework.data:spring-data-commons:jar:2.5.1:compile
+|  \- org.slf4j:slf4j-api:jar:1.7.30:compile
++- com.amazonaws:DynamoDBLocal:jar:1.25.1:compile
+|  +- commons-cli:commons-cli:jar:1.6.0:compile
+|  +- com.almworks.sqlite4java:libsqlite4java-linux-amd64:so:1.0.392:runtime
+|  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.12.3:compile
+|  +- com.amazonaws:aws-java-sdk-dynamodb:jar:1.11.925:compile
+|  +- software.amazon.awssdk:cognitoidentity:jar:2.16.46:compile
+|  +- software.amazon.awssdk:cognitoidentityprovider:jar:2.16.46:compile
+|  +- software.amazon.awssdk:pinpoint:jar:2.16.46:compile
+|  +- software.amazon.awssdk:dynamodb:jar:2.16.46:compile
+|  |  \- software.amazon.awssdk:profiles:jar:2.16.46:compile
+|  +- software.amazon.awssdk:dynamodb-enhanced:jar:2.16.46:compile
+|  +- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
+|  +- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile
+|  +- org.eclipse.jetty:jetty-client:jar:9.4.41.v20210516:compile
+|  |  +- org.eclipse.jetty:jetty-http:jar:9.4.41.v20210516:compile
+|  |  |  \- org.eclipse.jetty:jetty-util:jar:9.4.41.v20210516:compile
+|  |  \- org.eclipse.jetty:jetty-io:jar:9.4.41.v20210516:compile
+|  +- org.eclipse.jetty:jetty-server:jar:9.4.41.v20210516:compile
+|  |  \- javax.servlet:javax.servlet-api:jar:4.0.1:compile
+|  \- com.google.guava:guava:jar:33.3.0-jre:compile
+|     +- com.google.guava:failureaccess:jar:1.0.2:compile
+|     +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
+|     +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
+|     \- com.google.j2objc:j2objc-annotations:jar:3.0.0:compile
++- com.almworks.sqlite4java:sqlite4java:jar:1.0.392:compile
++- com.almworks.sqlite4java:libsqlite4java-linux-i386:so:1.0.392:compile
++- com.almworks.sqlite4java:libsqlite4java-osx:dylib:1.0.392:compile
++- com.almworks.sqlite4java:sqlite4java-win32-x64:dll:1.0.392:compile
++- com.almworks.sqlite4java:sqlite4java-win32-x86:dll:1.0.392:compile
++- com.opencsv:opencsv:jar:4.2:compile
+|  +- org.apache.commons:commons-text:jar:1.3:compile
+|  +- commons-beanutils:commons-beanutils:jar:1.9.3:compile
+|  |  \- commons-collections:commons-collections:jar:3.2.2:compile
+|  \- org.apache.commons:commons-collections4:jar:4.1:compile
++- com.amazonaws:aws-java-sdk-sqs:jar:1.11.925:compile
+|  \- com.amazonaws:jmespath-java:jar:1.11.925:compile
++- com.amazonaws:aws-java-sdk-sts:jar:1.11.925:compile
++- com.amazonaws:amazon-sqs-java-extended-client-lib:jar:1.0.3:compile
+|  \- com.amazonaws:aws-java-sdk-s3:jar:1.11.925:compile
+|     \- com.amazonaws:aws-java-sdk-kms:jar:1.11.925:compile
++- javax.xml.bind:jaxb-api:jar:2.3.0:compile
++- org.springframework.boot:spring-boot-starter-security:jar:2.5.0:compile
++- software.amazon.awssdk:secretsmanager:jar:2.20.34:compile
+|  +- software.amazon.awssdk:aws-json-protocol:jar:2.20.34:compile
+|  |  \- software.amazon.awssdk:third-party-jackson-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:protocol-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:sdk-core:jar:2.20.34:compile
+|  |  \- org.reactivestreams:reactive-streams:jar:1.0.3:compile
+|  +- software.amazon.awssdk:auth:jar:2.20.34:compile
+|  |  \- software.amazon.eventstream:eventstream:jar:1.0.1:compile
+|  +- software.amazon.awssdk:http-client-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:regions:jar:2.20.34:compile
+|  +- software.amazon.awssdk:annotations:jar:2.20.34:compile
+|  +- software.amazon.awssdk:utils:jar:2.20.34:compile
+|  +- software.amazon.awssdk:aws-core:jar:2.20.34:compile
+|  +- software.amazon.awssdk:metrics-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:json-utils:jar:2.20.34:compile
+|  +- software.amazon.awssdk:endpoints-spi:jar:2.20.34:compile
+|  +- software.amazon.awssdk:apache-client:jar:2.20.34:runtime
+|  |  \- org.apache.httpcomponents:httpcore:jar:4.4.14:compile
+|  \- software.amazon.awssdk:netty-nio-client:jar:2.20.34:runtime
+|     +- io.netty:netty-codec-http:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-codec-http2:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-codec:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-transport:jar:4.1.65.Final:runtime
+|     |  \- io.netty:netty-resolver:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-common:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-buffer:jar:4.1.65.Final:runtime
+|     +- io.netty:netty-handler:jar:4.1.65.Final:runtime
+|     \- io.netty:netty-transport-classes-epoll:jar:4.1.86.Final:runtime
+|        \- io.netty:netty-transport-native-unix-common:jar:4.1.65.Final:runtime
++- com.auth0:java-jwt:jar:3.19.4:compile
+|  \- com.fasterxml.jackson.core:jackson-databind:jar:2.12.3:compile
++- com.nimbusds:nimbus-jose-jwt:jar:9.37.4:compile
+|  \- com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile
++- org.springframework.security:spring-security-oauth2-jose:jar:5.6.0:compile
+|  \- org.springframework.security:spring-security-oauth2-core:jar:5.5.0:compile
++- org.springframework.security:spring-security-oauth2-resource-server:jar:5.6.0:compile
++- edu.cornell.weill.reciter:reciter-scopus-model:jar:2.0.3:compile
+|  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.12.3:compile
+|  \- io.swagger:swagger-codegen-maven-plugin:jar:3.0.0-rc1:compile
+|     +- org.apache.maven:maven-core:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-model:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-settings:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-settings-builder:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-repository-metadata:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-artifact:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-model-builder:jar:3.2.5:compile
+|     |  +- org.apache.maven:maven-aether-provider:jar:3.2.5:compile
+|     |  |  \- org.eclipse.aether:aether-spi:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-impl:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-api:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.aether:aether-util:jar:1.0.0.v20140518:compile
+|     |  +- org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.3.0.M1:compile
+|     |  |  +- javax.enterprise:cdi-api:jar:1.0:compile
+|     |  |  |  \- javax.annotation:jsr250-api:jar:1.0:compile
+|     |  |  \- org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.3.0.M1:compile
+|     |  +- org.sonatype.sisu:sisu-guice:jar:no_aop:3.2.3:compile
+|     |  |  +- javax.inject:javax.inject:jar:1:compile
+|     |  |  \- aopalliance:aopalliance:jar:1.0:compile
+|     |  +- org.codehaus.plexus:plexus-interpolation:jar:1.21:compile
+|     |  +- org.codehaus.plexus:plexus-utils:jar:3.0.20:compile
+|     |  +- org.codehaus.plexus:plexus-classworlds:jar:2.5.2:compile
+|     |  +- org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
+|     |  \- org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:compile
+|     |     \- org.sonatype.plexus:plexus-cipher:jar:1.4:compile
+|     +- org.apache.maven:maven-compat:jar:3.2.5:compile
+|     |  \- org.apache.maven.wagon:wagon-provider-api:jar:2.8:compile
+|     +- org.apache.maven:maven-plugin-api:jar:3.2.5:compile
+|     +- org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.4:compile
+|     +- io.swagger:swagger-codegen:jar:3.0.0-rc1:compile
+|     |  +- io.swagger.core.v3:swagger-models:jar:2.2.8:compile
+|     |  +- io.swagger.parser.v3:swagger-parser-core:jar:2.0.0:compile
+|     |  +- io.swagger.parser.v3:swagger-parser-v3:jar:2.0.0:compile
+|     |  +- io.swagger.parser.v3:swagger-parser:jar:2.0.0:compile
+|     |  |  \- io.swagger.parser.v3:swagger-parser-v2-converter:jar:2.0.0:compile
+|     |  |     +- io.swagger:swagger-parser:jar:1.0.35:compile
+|     |  |     |  \- io.swagger:swagger-core:jar:1.5.19:compile
+|     |  |     |     +- io.swagger:swagger-models:jar:1.5.19:compile
+|     |  |     |     |  \- io.swagger:swagger-annotations:jar:1.5.19:compile
+|     |  |     |     \- javax.validation:validation-api:jar:2.0.1.Final:compile
+|     |  |     \- io.swagger:swagger-compat-spec-parser:jar:1.0.35:compile
+|     |  |        +- com.github.java-json-tools:json-schema-validator:jar:2.2.8:compile
+|     |  |        |  +- com.github.java-json-tools:json-schema-core:jar:1.2.8:compile
+|     |  |        |  |  \- com.github.fge:uri-template:jar:0.9:compile
+|     |  |        |  +- javax.mail:mailapi:jar:1.4.3:compile
+|     |  |        |  |  \- javax.activation:activation:jar:1.1:compile
+|     |  |        |  +- com.googlecode.libphonenumber:libphonenumber:jar:8.0.0:compile
+|     |  |        |  \- net.sf.jopt-simple:jopt-simple:jar:5.0.3:compile
+|     |  |        \- com.github.fge:json-patch:jar:1.6:compile
+|     |  |           \- com.github.fge:jackson-coreutils:jar:1.6:compile
+|     |  |              \- com.github.fge:msg-simple:jar:1.1:compile
+|     |  |                 \- com.github.fge:btf:jar:1.2:compile
+|     |  +- com.samskivert:jmustache:jar:1.15:compile
+|     |  +- org.slf4j:slf4j-ext:jar:1.7.30:compile
+|     |  +- com.atlassian.commonmark:commonmark:jar:0.9.0:compile
+|     |  \- com.github.jknack:handlebars:jar:4.0.6:compile
+|     |     \- org.mozilla:rhino:jar:1.7R4:compile
+|     \- io.swagger:swagger-codegen-generators:jar:1.0.0-rc1:compile
++- com.amazonaws:aws-java-sdk-lambda:jar:1.12.742:compile
++- com.amazonaws:aws-java-sdk-core:jar:1.12.742:compile
+|  +- commons-logging:commons-logging:jar:1.1.3:compile
+|  +- commons-codec:commons-codec:jar:1.15:compile
+|  +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
+|  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.12.3:compile
+|  \- joda-time:joda-time:jar:2.12.7:compile
++- com.amazonaws:aws-java-sdk-cognitoidp:jar:1.12.742:compile
++- edu.cornell.weill.reciter:reciter-pubmed-model:jar:2.0.3:compile
++- edu.cornell.weill.reciter:reciter-identity-model:jar:2.0.10:compile
++- edu.cornell.weill.reciter:reciter-article-model:jar:2.0.36:compile
+|  \- org.springframework.data:spring-data-commons-core:jar:1.4.1.RELEASE:compile
++- edu.cornell.weill.reciter:reciter-dynamodb-model:jar:2.0.15:compile
++- com.github.bohnman:squiggly-filter-jackson:jar:1.3.18:compile
+|  \- net.jcip:jcip-annotations:jar:1.0:compile
++- org.antlr:antlr4-runtime:jar:4.6:compile
++- org.mockito:mockito-core:jar:3.9.0:compile
+|  +- net.bytebuddy:byte-buddy:jar:1.10.22:compile
+|  +- net.bytebuddy:byte-buddy-agent:jar:1.10.22:compile
+|  \- org.objenesis:objenesis:jar:3.2:compile
+\- com.github.ben-manes.caffeine:caffeine:jar:2.9.3:compile
+   +- org.checkerframework:checker-qual:jar:3.19.0:compile
+   \- com.google.errorprone:error_prone_annotations:jar:2.10.0:compile

--- a/kubernetes/k8-configmap.yaml
+++ b/kubernetes/k8-configmap.yaml
@@ -81,7 +81,7 @@ data:
             proxy_connect_timeout 300;
         }
 
-        location /reciter/v2 {
+        location /reciter/v3 {
             rewrite ^/reciter/(.*)$ /$1 break;
             proxy_pass http://localhost:5000;
             proxy_redirect off;

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,25 @@
         			<type>pom</type>
         			<scope>import</scope>
       		</dependency>
+            <!-- Pin the OpenAPI 3 model/core/annotation stack to the version springdoc 1.6.15
+                 ships with. Without this, the legacy swagger-codegen-maven-plugin (a compile
+                 dependency) wins Maven mediation with swagger-models 2.0.0, which lacks methods
+                 springdoc calls at runtime (NoSuchMethodError Schema.getExampleSetFlag). #634 Stage 2. -->
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-models</artifactId>
+                <version>2.2.8</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-core</artifactId>
+                <version>2.2.8</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>2.2.8</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -238,10 +257,20 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <!-- springdoc-openapi replaces the abandoned springfox (#634 Stage 2). 1.6.x is the
+             Boot 2.x line; it bundles the OpenAPI 3 (io.swagger.v3) annotations + swagger-ui. -->
         <dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-boot-starter</artifactId>
-			<version>3.0.0</version>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.6.15</version>
+		</dependency>
+        <!-- springdoc 1.6.x eagerly introspects its spring-data-web customizers
+             (PageableDefault/SortDefault), so spring-data-commons must be on the classpath
+             for the context to load. Inert otherwise — no repository scanning is enabled
+             (spring-data-dynamodb was removed in Stage 1). Version managed by the Boot parent. -->
+        <dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
 		</dependency>
         <!-- Uncomment this dependency if you want to use dynamodb locally -->
         <dependency>

--- a/src/main/java/reciter/controller/IdentityController.java
+++ b/src/main/java/reciter/controller/IdentityController.java
@@ -35,11 +35,13 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
 import reciter.service.IdentityService;
@@ -53,15 +55,15 @@ public class IdentityController {
     @Value("${identity.dynamodb.mandatory.fields}")
     private String mandatoryFields;
 
-    @ApiOperation(value = "Add an identity to Identity table in DynamoDb", notes = "This api creates an identity in the Identity table in dynamoDb by collecting identity data from different system of records.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Add an identity to Identity table in DynamoDb", description = "This api creates an identity in the Identity table in dynamoDb by collecting identity data from different system of records.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Identity creation successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Identity creation successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/identity/", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody
@@ -83,15 +85,15 @@ public class IdentityController {
         return ResponseEntity.ok().build();
     }
 
-    @ApiOperation(value = "Add list of identities to Identity table in DynamoDb", notes = "This api creates list of identities in the Identity table in dynamoDb by collecting identity data from different system of records.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Add list of identities to Identity table in DynamoDb", description = "This api creates list of identities in the Identity table in dynamoDb by collecting identity data from different system of records.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Identity List creation successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Identity List creation successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/save/identities/", method = RequestMethod.PUT, produces = "application/json")
     @ResponseBody
@@ -125,15 +127,15 @@ public class IdentityController {
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
     }
 
-    @ApiOperation(value = "Search the identity table for a given ID", response = ResponseEntity.class, notes = "This api searches for a given identity in identity table.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Search the identity table for a given ID", description = "This api searches for a given identity in identity table.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Identity found successfully"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Identity found successfully"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/find/identity/by/uid", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -152,15 +154,15 @@ public class IdentityController {
         return new ResponseEntity<>(identity, HttpStatus.OK);
     }
 
-    @ApiOperation(value = "Search the identity table for a list of ID supplied", response = Identity.class, notes = "This api searches for a list of identities in identity table.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Search the identity table for a list of ID supplied", description = "This api searches for a list of identities in identity table.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Identity List found successfully"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Identity List found successfully"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/find/identity/by/uids/", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -182,15 +184,15 @@ public class IdentityController {
         return new ResponseEntity<>(identities, HttpStatus.OK);
     }
     
-    @ApiOperation(value = "Get all identity from Identity table", response = Identity.class, notes = "This api scans identity table and returns all identitites.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Get all identity from Identity table", description = "This api scans identity table and returns all identitites.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Identities found successfully"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Identities found successfully"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/find/all/identity", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -211,15 +213,15 @@ public class IdentityController {
         return new ResponseEntity<>(identities, HttpStatus.OK);
     }
     
-    @ApiOperation(value = "Delete an identity by uid", notes = "This api deletes a single identity from the Identity table by uid.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Delete an identity by uid", description = "This api deletes a single identity from the Identity table by uid.")
+    @Parameters({
+        @Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Identity deletion successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Identity deletion successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/identity/{uid}", method = RequestMethod.DELETE, produces = "application/json")
     @ResponseBody

--- a/src/main/java/reciter/controller/PingController.java
+++ b/src/main/java/reciter/controller/PingController.java
@@ -1,7 +1,7 @@
 package reciter.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,10 +10,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping("/reciter")
-@Api(value = "PingController", tags = {"Health Check"})
+@Tag(name = "Health Check")
 public class PingController {
 
-    @ApiOperation(value = "Health check", response = ResponseEntity.class)
+    @Operation(summary = "Health check")
     @GetMapping(value = "/ping", produces = "text/plain")
     @ResponseBody
     public ResponseEntity<String> ping() {

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -49,12 +49,14 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import reciter.algorithm.evidence.targetauthor.TargetAuthorSelection;
 import reciter.algorithm.util.ArticleTranslator;
 import reciter.api.parameters.FilterFeedbackType;
@@ -93,7 +95,7 @@ import reciter.utils.GenderProbability;
 import reciter.utils.InstitutionSanitizationUtil;
 import reciter.xml.retriever.engine.ReCiterRetrievalEngine;
 
-@Api(value = "ReCiterController", description = "Operations on ReCiter API.")
+@Tag(name = "ReCiterController", description = "Operations on ReCiter API.")
 @Controller
 public class ReCiterController {
 
@@ -144,15 +146,15 @@ public class ReCiterController {
     @Autowired
     private OrcidService orcidService;
 
-    @ApiOperation(value = "Update the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids)", notes = "This api updates the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids).")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Update the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids)", description = "This api updates the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids).")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "GoldStandard creation successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "GoldStandard creation successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/goldstandard", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody
@@ -183,15 +185,15 @@ public class ReCiterController {
         return ResponseEntity.ok(goldStandard);
     }
 
-    @ApiOperation(value = "Update the goldstandard by passing  a list of GoldStandard model(uid, knownPmids, rejectedPmids)", notes = "This api updates the goldstandard by passing list of GoldStandard model(uid, knownPmids, rejectedPmids).")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Update the goldstandard by passing  a list of GoldStandard model(uid, knownPmids, rejectedPmids)", description = "This api updates the goldstandard by passing list of GoldStandard model(uid, knownPmids, rejectedPmids).")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "GoldStandard List creation successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "GoldStandard List creation successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/goldstandard", method = RequestMethod.PUT, produces = "application/json")
     @ResponseBody
@@ -216,15 +218,15 @@ public class ReCiterController {
         return ResponseEntity.ok(goldStandard);
     }
 
-    @ApiOperation(value = "Get the goldStandard by passing an uid", notes = "This api gets the goldStandard by passing an uid.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Get the goldStandard by passing an uid", description = "This api gets the goldStandard by passing an uid.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "The goldstandard retrieval for supplied uid is successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "The goldstandard retrieval for supplied uid is successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/goldstandard/{uid}", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -237,16 +239,16 @@ public class ReCiterController {
         return ResponseEntity.ok(goldStandard);
     }
 
-    @ApiOperation(value = "Get curation audit history (FeedbackLog + ArticleProvenance) for a uid",
-            notes = "Returns the curator action history (accept/reject/pending) for the person, newest first, each row enriched with how the PMID first arrived (ArticleProvenance).")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Get curation audit history (FeedbackLog + ArticleProvenance) for a uid",
+            description = "Returns the curator action history (accept/reject/pending) for the person, newest first, each row enriched with how the PMID first arrived (ArticleProvenance).")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Audit history retrieval successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Audit history retrieval successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/feedback-log/{uid}", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -259,15 +261,15 @@ public class ReCiterController {
         return ResponseEntity.ok(history);
     }
 
-    @ApiOperation(value = "Delete a gold standard record by uid", notes = "This api deletes a gold standard record from the GoldStandard table by uid.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Delete a gold standard record by uid", description = "This api deletes a gold standard record from the GoldStandard table by uid.")
+    @Parameters({
+        @Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "GoldStandard deletion successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "GoldStandard deletion successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/goldstandard/{uid}", method = RequestMethod.DELETE, produces = "application/json")
     @ResponseBody
@@ -280,15 +282,15 @@ public class ReCiterController {
         return ResponseEntity.ok().build();
     }
 
-    @ApiOperation(value = "Delete an analysis output by uid", notes = "This api deletes an analysis output record from the AnalysisOutput table by uid.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Delete an analysis output by uid", description = "This api deletes an analysis output record from the AnalysisOutput table by uid.")
+    @Parameters({
+        @Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "AnalysisOutput deletion successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "AnalysisOutput deletion successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/analysis/{uid}", method = RequestMethod.DELETE, produces = "application/json")
     @ResponseBody
@@ -301,15 +303,15 @@ public class ReCiterController {
         return ResponseEntity.ok().build();
     }
 
-    @ApiOperation(value = "Delete an ESearchResult by uid", notes = "This api deletes an ESearchResult record by uid.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Delete an ESearchResult by uid", description = "This api deletes an ESearchResult record by uid.")
+    @Parameters({
+        @Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "ESearchResult deletion successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "ESearchResult deletion successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/esearchresult/{uid}", method = RequestMethod.DELETE, produces = "application/json")
     @ResponseBody
@@ -322,14 +324,14 @@ public class ReCiterController {
         return ResponseEntity.ok().build();
     }
 
-    @ApiOperation(value = "Bulk cleanup: delete records from all UID-keyed tables", notes = "Deletes Identity, GoldStandard, AnalysisOutput, and ESearchResult records for a list of UIDs. Intended for external validation cleanup.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Bulk cleanup: delete records from all UID-keyed tables", description = "Deletes Identity, GoldStandard, AnalysisOutput, and ESearchResult records for a list of UIDs. Intended for external validation cleanup.")
+    @Parameters({
+        @Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Bulk cleanup successful"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Bulk cleanup successful"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden")
     })
     @RequestMapping(value = "/reciter/cleanup/by/uids", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody
@@ -361,15 +363,15 @@ public class ReCiterController {
         return new ResponseEntity<>(results, HttpStatus.OK);
     }
 
-    @ApiOperation(value = "Retrieve Articles for all UID in Identity Table", response = ResponseEntity.class, notes = "This API retrieves candidate articles for all uid in Identity Table from pubmed and its complementing articles from scopus")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Retrieve Articles for all UID in Identity Table", description = "This API retrieves candidate articles for all uid in Identity Table from pubmed and its complementing articles from scopus")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved list for given list of uid"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list for given list of uid"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/retrieve/articles/", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -392,15 +394,15 @@ public class ReCiterController {
         return ResponseEntity.ok().build();
     }
 
-    @ApiOperation(value = "Retrieve Articles for an UID.", response = ResponseEntity.class, notes = "This API retrieves candidate articles for a given uid from pubmed and its complementing articles from scopus")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Retrieve Articles for an UID.", description = "This API retrieves candidate articles for a given uid from pubmed and its complementing articles from scopus")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved list"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/retrieve/articles/by/uid", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -477,15 +479,15 @@ public class ReCiterController {
         return ResponseEntity.ok().body("Successfully retrieved all candidate articles for " + uid + " and refreshed all search results");
     }
     
-    @ApiOperation(value = "Retrieve pending articles for a group of users.", response = ResponseEntity.class, notes = "Retrieve pending articles for a group of users.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Retrieve pending articles for a group of users.", description = "Retrieve pending articles for a group of users.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved list"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/feature-generator/by/group", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody
@@ -597,17 +599,17 @@ public class ReCiterController {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body("There is no publications data for the group. Please wait while feature-generator re-runs tonight.");
     }
 
-    @ApiOperation(value = "Feature generation for UID.", response = ReCiterFeature.class, notes = "This api generates all the suggestion for a given uid along with its relevant evidence.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class),
-    	@ApiImplicitParam(name = "fields", value = "Fields to return (e.g., reCiterArticleFeatures.pmid,reCiterArticleFeatures.publicationType.publicationTypeCanonical). Default is all.", paramType = "query", dataTypeClass = String.class)
+    @Operation(summary = "Feature generation for UID.", description = "This api generates all the suggestion for a given uid along with its relevant evidence.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string")),
+    	@Parameter(name = "fields", description = "Fields to return (e.g., reCiterArticleFeatures.pmid,reCiterArticleFeatures.publicationType.publicationTypeCanonical). Default is all.", in = ParameterIn.QUERY, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved list", response = ReCiterFeature.class),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found"),
-            @ApiResponse(code = 500, message = "The uid provided was not found in the Identity table")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found"),
+            @ApiResponse(responseCode = "500", description = "The uid provided was not found in the Identity table")
     })
     @RequestMapping(value = "/reciter/feature-generator/by/uid", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -920,17 +922,17 @@ public class ReCiterController {
         return new ResponseEntity<>(reCiterOutputFeature, HttpStatus.OK);
     }
     
-    @ApiOperation(value = "Article retrieval by UID.", response = ReCiterFeature.class, notes = "This api returns all the publication for a supplied uid.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class),
-    	@ApiImplicitParam(name = "fields", value = "Fields to return (e.g., reCiterArticleFeatures.pmid,reCiterArticleFeatures.publicationType.publicationTypeCanonical). Default is all.", paramType = "query", dataTypeClass = String.class)
+    @Operation(summary = "Article retrieval by UID.", description = "This api returns all the publication for a supplied uid.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string")),
+    	@Parameter(name = "fields", description = "Fields to return (e.g., reCiterArticleFeatures.pmid,reCiterArticleFeatures.publicationType.publicationTypeCanonical). Default is all.", in = ParameterIn.QUERY, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved list", response = ReCiterFeature.class),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found"),
-            @ApiResponse(code = 500, message = "The uid provided was not found in the Identity table")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found"),
+            @ApiResponse(responseCode = "500", description = "The uid provided was not found in the Identity table")
     })
     @RequestMapping(value = "/reciter/article-retrieval/by/uid", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -1160,15 +1162,15 @@ public class ReCiterController {
         return parameters;
     }
 
-    @ApiOperation(value = "Get all identity ORCIDs", notes = "This api retrieves all ORCIDs stored in the identity table.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+    @Operation(summary = "Get all identity ORCIDs", description = "This api retrieves all ORCIDs stored in the identity table.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-	    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successfully retrieved Map"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+	    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved Map"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
 
     @RequestMapping(value = "/reciter/article-identityOrcids", method = RequestMethod.GET, produces = "application/json")

--- a/src/main/java/reciter/controller/ReCiterPubManagerController.java
+++ b/src/main/java/reciter/controller/ReCiterPubManagerController.java
@@ -10,17 +10,19 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import reciter.database.dynamodb.model.ApplicationUser;
 import reciter.service.ApplicationUserService;
 
 
-@Api(value = "ReCiterPubManagerController", description = "Operations on ReCiter publication manager.")
+@Tag(name = "ReCiterPubManagerController", description = "Operations on ReCiter publication manager.")
 @Controller
 public class ReCiterPubManagerController {
 	
@@ -29,15 +31,15 @@ public class ReCiterPubManagerController {
 	@Autowired
 	private ApplicationUserService applicationUserService;
 	
-	@ApiOperation(value = "Authenticate user for ReCiter publications manager", response = Boolean.class, notes = "This api checks for credentials for access to reciter publication manager app.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+	@Operation(summary = "Authenticate user for ReCiter publications manager", description = "This api checks for credentials for access to reciter publication manager app.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "User authenticated"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User authenticated"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/publication/manager/authenticate", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody
@@ -58,15 +60,15 @@ public class ReCiterPubManagerController {
         return false;
     }
 	
-	@ApiOperation(value = "Create user for ReCiter publications manager", response = Boolean.class, notes = "This api create user for reciter publication manager app.")
-    @ApiImplicitParams({
-    	@ApiImplicitParam(name = "api-key", value = "api-key for this resource", paramType = "header", dataTypeClass = String.class)
+	@Operation(summary = "Create user for ReCiter publications manager", description = "This api create user for reciter publication manager app.")
+    @Parameters({
+    	@Parameter(name = "api-key", description = "api-key for this resource", in = ParameterIn.HEADER, schema = @Schema(type = "string"))
     })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "User created"),
-            @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
-            @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
-            @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User created"),
+            @ApiResponse(responseCode = "401", description = "You are not authorized to view the resource"),
+            @ApiResponse(responseCode = "403", description = "Accessing the resource you were trying to reach is forbidden"),
+            @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @RequestMapping(value = "/reciter/publication/manager/user/create", method = RequestMethod.POST, produces = "application/json")
     @ResponseBody

--- a/src/main/java/reciter/controller/ScopusController.java
+++ b/src/main/java/reciter/controller/ScopusController.java
@@ -33,9 +33,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import reciter.model.scopus.ScopusArticle;
 import reciter.scopus.retriever.ScopusArticleRetriever;
 import reciter.service.ScopusService;

--- a/src/main/java/reciter/swagger/SwaggerConfig.java
+++ b/src/main/java/reciter/swagger/SwaggerConfig.java
@@ -1,43 +1,44 @@
 package reciter.swagger;
 
-import static springfox.documentation.builders.PathSelectors.regex;
-
+import org.springdoc.core.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 
+/**
+ * springdoc-openapi configuration (replaces the abandoned springfox in #634 Stage 2).
+ * Preserves the former springfox {@code Docket} scope (controllers under
+ * {@code reciter.controller}, paths under {@code /reciter/**}) and API info/contact/license.
+ */
 @Configuration
 public class SwaggerConfig {
-    @Bean
-    public Docket productApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("reciter.controller"))
-                .paths(regex("/reciter.*"))
-                .build()
-                .apiInfo(apiInfo());
-//                .securitySchemes(Arrays.asList(apiKey()));
-    }
-    
-   private ApiInfo apiInfo() {
-       return new ApiInfoBuilder().title("ReCiter publication management system")
-               .description("Populate and retrieve identity data for a scholar. Trigger publication lookups and scoring for a scholar. Retrieve publications for a scholar. Interact with ReCiter Publication Manager. More info here: http://github.com/wcmc-its/ReCiter/").termsOfServiceUrl("")
-               .contact(new Contact("Paul J. Albert", "https://github.com/wcmc-its/ReCiter", "paa2013@med.cornell.edu"))
-               .license("Apache License Version 2.0")
-               .licenseUrl("https://www.apache.org/licenses/LICENSE-2.0")
-               .version("2.1.3")
-               .build();
-   }
 
-   /*
-   private ApiKey apiKey() {
-       return new ApiKey("reciter", "reciter", "header");
-   }
-   */
+    @Bean
+    public GroupedOpenApi reciterApi() {
+        return GroupedOpenApi.builder()
+                .group("reciter")
+                .packagesToScan("reciter.controller")
+                .pathsToMatch("/reciter/**")
+                .build();
+    }
+
+    @Bean
+    public OpenAPI reciterOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("ReCiter publication management system")
+                        .description("Populate and retrieve identity data for a scholar. Trigger publication lookups and scoring for a scholar. Retrieve publications for a scholar. Interact with ReCiter Publication Manager. More info here: http://github.com/wcmc-its/ReCiter/")
+                        .version("2.1.3")
+                        .contact(new Contact()
+                                .name("Paul J. Albert")
+                                .url("https://github.com/wcmc-its/ReCiter")
+                                .email("paa2013@med.cornell.edu"))
+                        .license(new License()
+                                .name("Apache License Version 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0")));
+    }
 }

--- a/src/test/java/reciter/ApplicationContextSmokeTest.java
+++ b/src/test/java/reciter/ApplicationContextSmokeTest.java
@@ -1,15 +1,21 @@
 package reciter;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.s3.AmazonS3;
@@ -41,10 +47,13 @@ import reciter.service.dynamo.DynamoDbMeshTermService;
  * </ul>
  *
  * <p>This is the per-stage gate for #634: every framework/wiring change (Stages 1-3)
- * must keep this green, proving the context still wires end to end.
+ * must keep this green, proving the context still wires end to end. Stage 2 also
+ * asserts that springdoc (which replaced springfox) actually generates the OpenAPI
+ * document for the {@code reciter} controller group.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
 public class ApplicationContextSmokeTest {
 
@@ -83,11 +92,29 @@ public class ApplicationContextSmokeTest {
     @Autowired
     private ApplicationContext context;
 
+    @Autowired
+    private MockMvc mockMvc;
+
     @Test
     public void contextLoads() {
         assertNotNull("Spring application context should load", context);
         // A concrete bean from the DynamoDB wiring path proves the persistence config
         // wired (the surface Stage 1 will rework when spring-data-dynamodb is removed).
         assertNotNull("DynamoDbConfig should be wired", context.getBean(DynamoDbConfig.class));
+    }
+
+    /**
+     * Stage 2: springdoc generates the OpenAPI document for the {@code reciter} group
+     * (GroupedOpenApi scoped to reciter.controller / {@code /reciter/**}). Proves the
+     * springfox-&gt;springdoc migration and the v1-&gt;v3 annotation conversion actually
+     * produce docs, not just that the context loads.
+     */
+    @Test
+    public void springdocApiDocsAreGenerated() throws Exception {
+        mockMvc.perform(get("/v3/api-docs/reciter"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("\"openapi\"")))
+                .andExpect(content().string(containsString("/reciter/ping")))
+                .andExpect(content().string(containsString("ReCiter publication management system")));
     }
 }


### PR DESCRIPTION
Stage 2 of #634. Removes the abandoned **springfox** (`springfox-boot-starter:3.0.0`) — the second hard blocker for the Spring Boot 2.7 upgrade (springfox breaks on Boot 2.6+ with a PathPatternParser NPE and has no 3.x support). Stages 0 + 1 (#648/#649) are already merged to `development`.

## POM
- `springfox-boot-starter:3.0.0` → `springdoc-openapi-ui:1.6.15` (the Boot 2.x line).
- Add `spring-data-commons` (Boot-managed): springdoc 1.6.x eagerly introspects its spring-data-web customizers (`PageableDefault`/`SortDefault`), so the class must be on the classpath for the context to load. **Inert** otherwise — no repository scanning is enabled.
- Pin `io.swagger.core.v3:*` to **2.2.8** so the legacy `swagger-codegen-maven-plugin` (an odd compile-scoped dependency) doesn't win Maven mediation with `swagger-models:2.0.0`, which lacks methods springdoc calls at runtime (`NoSuchMethodError: Schema.getExampleSetFlag`).

## Config + controllers
- `SwaggerConfig`: springfox `Docket` → springdoc `GroupedOpenApi` (group `reciter`, `packagesToScan=reciter.controller`, `pathsToMatch=/reciter/**`) + an `OpenAPI` bean preserving title/description/contact/license/version.
- **5 controllers**: migrate ~160 `io.swagger` v1 annotations → `io.swagger.v3` (OpenAPI 3): `@Api`→`@Tag`, `@ApiOperation(value/notes)`→`@Operation(summary/description)`, `@ApiResponse(code/message)`→`@ApiResponse(responseCode/description)`, `@ApiImplicitParam`→`@Parameter(in=ParameterIn…, schema=@Schema)`. (`ScopusController`'s Swagger annotations were all in commented-out code; its v1 imports were removed.)

## Infra
- nginx (`k8-configmap.yaml`): `/reciter/v2` (springfox `/v2/api-docs`) → `/reciter/v3` (springdoc `/v3/api-docs`). The `swagger-ui` / `swagger` / `webjars` rewrites already match springdoc's paths.

## Verification
- `ApplicationContextSmokeTest` gains a **MockMvc** assertion: `GET /v3/api-docs/reciter` returns 200 containing the controller paths (`/reciter/ping`) + the API title — proving springdoc actually **generates** the docs, not just that the context loads.
- `mvn clean install` (Java 17): **147 tests, 0 failures**, jar built; context boots on springdoc with no springfox on the classpath.

## Deploy note (coordinate with #639)
Full **Swagger-UI-behind-the-nginx-prefix** verification and the **prod swagger-off gating** remain a deploy-time step coordinated with the deferred #639 work. This PR makes the api-docs path correct (`/v3`) and proves doc generation in CI; confirming the UI renders behind the `/reciter` proxy prefix happens on dev EKS.

Part of #634 (Stage 2 of 4 toward the Boot 2.7 milestone). Next: Stage 3 (Boot 2.5→2.7 + `SecurityFilterChain`).