### PR TITLE
chore(#634): run on Java 17 (Boot 2.7 runtime upgrade)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:11-alpine
+FROM amazoncorretto:17-alpine
 RUN mkdir -p /app
 WORKDIR /app
 ARG JAR_FILE=target/reciter-*.jar

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: corretto11
+      java: corretto17
     commands:
       - kubectl version --client  
       - java -version 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	</scm>
     
     <properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
     	<sqlite4java.version>1.0.392</sqlite4java.version>
 		<lombok.version>1.18.44</lombok.version>
   	</properties>


### PR DESCRIPTION
## Summary

Moves the build and runtime from **Java 11 → 17**, staying on Spring Boot 2.7.18. Boot 2.7 fully supports Java 17, so this is a low-risk standalone step that pulls the Java-17 piece of the #634 Stage 4 plan forward — and **de-risks the eventual Boot 3 jump**, which afterward carries only the framework/jakarta churn rather than also a Java change.

## Changes (3 files)

- **`pom.xml`** — `java.version` 11 → 17 (this property drives `maven.compiler.source`/`target`, so the whole build moves to 17)
- **`Dockerfile`** — `amazoncorretto:11-alpine` → `amazoncorretto:17-alpine`
- **`k8-buildspec.yml`** — CodeBuild runtime `corretto11` → `corretto17`

No code changes; no dependency version changes. Lombok 1.18.44 and maven-compiler-plugin already support 17.

## Verification

- **Local (JDK 17, source/target 17):** `mvn clean install` → `BUILD SUCCESS`, full suite **151 tests / 0 failures / 0 errors / 0 skipped** (with `ADMIN_API_KEY`/`CONSUMER_API_KEY` set so `SecurityFilterChainIntegrationTest` runs). Zero compile/release errors.
- **Runtime container** on `corretto:17-alpine` is validated at the **dev deploy** (build the image → `/reciter/ping` 200 → confirm New Relic agent attaches). The Stage 4 research rated the alpine/musl native risk low: DynamoDB Local is test-scope only (not in the runtime image) and the New Relic agent is pure-Java.

## Notes

- The deprecated, unused `buildspec.yml` still references `openjdk11`. `k8-buildspec.yml` is the live build that gates the deploy; `buildspec.yml` is slated for separate deletion, so I left it out of this focused diff.
- Independent of the #626 prod promotion and of the larger Stage 4 work; can soak on dev on its own.
