### PR TITLE
chore(#634): drop unused javax.xml.bind:jaxb-api (within-2.7 cleanup)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,11 +326,6 @@
 	    	<version>1.0.3</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
 	        <groupId>org.springframework.boot</groupId>
 	        <artifactId>spring-boot-starter-security</artifactId>
     	</dependency>


### PR DESCRIPTION
## Summary

Removes the unused `javax.xml.bind:jaxb-api` 2.3.0 direct dependency — the "within-2.7 quick win" from the #634 Stage 4 plan (`docs/634-modernization/634-stage4-boot3-research.md`): **drop it rather than bump to 2.3.1**, since it's moot once on jakarta/Boot 3.

## Why it's safe (not just unused)

- **No source usage** — no `javax.xml.bind` / `jakarta.xml.bind` / `JAXBContext` / `@Xml*` references anywhere in `src/main/java`.
- **JAXB API stays on the classpath** — `dependency:tree` confirms `jakarta.xml.bind:jakarta.xml.bind-api:2.3.3` is still pulled transitively (same `javax.xml.bind.*` packages). So any transitive consumer (e.g. AWS SDK v1 XML paths) keeps the API; this just drops a redundant/duplicate API jar.

## Verification

- **Local (JDK 17):** `mvn clean install` → `BUILD SUCCESS`, full suite **151 tests / 0 failures / 0 skipped**.
- `dependency:tree` → JAXB API still present via `jakarta.xml.bind-api 2.3.3`.
- **Dev runtime:** validated post-deploy with a `meb7002` feature-generator run (exercises the S3 / DynamoDB / Lambda AWS-SDK-v1 paths) to confirm no runtime JAXB regression.

## Notes

- Stacked on the Java 17 work (#653) conceptually; branched off the post-#653 `development` (so it carries `java.version=17`). Independent of the #626 prod promotion.
