### PR TITLE
External source publications: ExternalArticle store, CRUD endpoints, feature-generator merge (#659)

### DIFF
--- a/src/main/java/reciter/controller/ExternalArticleController.java
+++ b/src/main/java/reciter/controller/ExternalArticleController.java
@@ -1,0 +1,176 @@
+package reciter.controller;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import reciter.database.dynamodb.model.AnalysisOutput;
+import reciter.database.dynamodb.model.ExternalArticle;
+import reciter.database.dynamodb.model.GoldStandard;
+import reciter.engine.analysis.ReCiterArticleFeature;
+import reciter.service.AnalysisService;
+import reciter.service.ExternalArticleService;
+import reciter.service.dynamo.ExternalArticleDupCheck;
+import reciter.service.dynamo.IDynamoDbGoldStandardService;
+
+/**
+ * CRUD for publications manually added from non-PubMed sources (Scopus, Web of
+ * Science, OpenAlex). These records never enter feature generation or scoring;
+ * they surface in feature-generator output only via includeExternal=true.
+ */
+@Tag(name = "ExternalArticleController", description = "Operations on manually added external-source articles.")
+@Controller
+public class ExternalArticleController {
+
+    private static final Logger log = LoggerFactory.getLogger(ExternalArticleController.class);
+
+    private static final Pattern ARTICLE_ID_PATTERN = Pattern.compile("^(SCOPUS|WOS|OPENALEX):\\S+$");
+
+    @Autowired
+    private ExternalArticleService externalArticleService;
+
+    @Autowired
+    private IDynamoDbGoldStandardService dynamoDbGoldStandardService;
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Operation(summary = "Add an external-source article for a person.",
+            description = "Adds a publication from Scopus, Web of Science, or OpenAlex. Blocks on PMID/DOI duplicates "
+                    + "against the person's PubMed record and existing external articles; warns on fuzzy title+year "
+                    + "collisions unless force=true.")
+    @RequestMapping(value = "/reciter/external-article/by/uid", method = RequestMethod.POST, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity<Object> addExternalArticle(@RequestParam(value = "uid") String uid,
+                                                     @RequestParam(value = "force", required = false, defaultValue = "false") boolean force,
+                                                     @RequestBody ExternalArticle externalArticle) {
+        externalArticle.setUid(uid.trim());
+        String validationError = validate(externalArticle);
+        if (validationError != null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorBody(validationError));
+        }
+
+        ExternalArticleDupCheck.Result result = ExternalArticleDupCheck.check(
+                externalArticle,
+                knownPmids(externalArticle.getUid()),
+                candidateArticles(externalArticle.getUid()),
+                externalArticleService.findByUid(externalArticle.getUid()));
+
+        if (result.getLevel() == ExternalArticleDupCheck.Level.BLOCKED) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(conflictBody("BLOCKED", result,
+                    "This article already exists in the person's record."));
+        }
+        if (result.getLevel() == ExternalArticleDupCheck.Level.WARNING && !force) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(conflictBody("WARNING", result,
+                    "Possible duplicate. Retry with force=true to add anyway."));
+        }
+
+        if (externalArticle.getDateAdded() == null || externalArticle.getDateAdded().trim().isEmpty()) {
+            externalArticle.setDateAdded(Instant.now().toString());
+        }
+        if (externalArticle.getSuppressed() == null) {
+            externalArticle.setSuppressed(Boolean.FALSE);
+        }
+        externalArticleService.save(externalArticle);
+        log.info("External article {} added for uid {} from {} (method={}, force={})",
+                externalArticle.getArticleId(), externalArticle.getUid(), externalArticle.getSourceType(),
+                externalArticle.getMethod(), force);
+        return ResponseEntity.status(HttpStatus.CREATED).body(externalArticle);
+    }
+
+    @Operation(summary = "List external-source articles for a person.",
+            description = "Returns all manually added external articles for the uid, including suppressed rows.")
+    @RequestMapping(value = "/reciter/external-article/by/uid", method = RequestMethod.GET, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity<List<ExternalArticle>> findExternalArticles(@RequestParam(value = "uid") String uid) {
+        return new ResponseEntity<>(externalArticleService.findByUid(uid.trim()), HttpStatus.OK);
+    }
+
+    @Operation(summary = "Delete an external-source article for a person.",
+            description = "Deleting is the revoke path — there is deliberately no sameAs assert/revoke model.")
+    @RequestMapping(value = "/reciter/external-article/by/uid", method = RequestMethod.DELETE, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity<Object> deleteExternalArticle(@RequestParam(value = "uid") String uid,
+                                                        @RequestParam(value = "articleId") String articleId) {
+        ExternalArticle existing = externalArticleService.find(uid.trim(), articleId.trim());
+        if (existing == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(errorBody("No external article '" + articleId + "' found for uid '" + uid + "'."));
+        }
+        externalArticleService.delete(uid.trim(), articleId.trim());
+        log.info("External article {} deleted for uid {}", articleId, uid);
+        return new ResponseEntity<>(existing, HttpStatus.OK);
+    }
+
+    private String validate(ExternalArticle externalArticle) {
+        if (externalArticle.getArticleId() == null
+                || !ARTICLE_ID_PATTERN.matcher(externalArticle.getArticleId().trim()).matches()) {
+            return "articleId is required and must be a prefixed identifier: SCOPUS:<id>, WOS:<id>, or OPENALEX:<id>.";
+        }
+        externalArticle.setArticleId(externalArticle.getArticleId().trim());
+        if (externalArticle.getTitle() == null || externalArticle.getTitle().trim().isEmpty()) {
+            return "title is required.";
+        }
+        String prefix = externalArticle.getArticleId().substring(0, externalArticle.getArticleId().indexOf(':'));
+        if (externalArticle.getSourceType() == null || externalArticle.getSourceType().trim().isEmpty()) {
+            externalArticle.setSourceType(prefix);
+        } else if (!prefix.equals(externalArticle.getSourceType().trim())) {
+            return "sourceType '" + externalArticle.getSourceType() + "' does not match articleId prefix '" + prefix + "'.";
+        }
+        return null;
+    }
+
+    private List<Long> knownPmids(String uid) {
+        GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(uid);
+        if (goldStandard == null || goldStandard.getKnownPmids() == null) {
+            return new ArrayList<>();
+        }
+        return goldStandard.getKnownPmids();
+    }
+
+    private List<ReCiterArticleFeature> candidateArticles(String uid) {
+        try {
+            AnalysisOutput analysis = analysisService.findByUid(uid);
+            if (analysis != null && analysis.getReCiterFeature() != null
+                    && analysis.getReCiterFeature().getReCiterArticleFeatures() != null) {
+                return analysis.getReCiterFeature().getReCiterArticleFeatures();
+            }
+        } catch (Exception e) {
+            // Weakened dup check (gold standard PMIDs still block) is better than failing the add.
+            log.warn("Could not load Analysis for uid {} during external-article dup check: {}", uid, e.getMessage());
+        }
+        return new ArrayList<>();
+    }
+
+    private Map<String, Object> conflictBody(String status, ExternalArticleDupCheck.Result result, String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", status);
+        body.put("message", message);
+        body.put("matches", result.getMatches());
+        return body;
+    }
+
+    private Map<String, Object> errorBody(String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", "INVALID");
+        body.put("message", message);
+        return body;
+    }
+}

--- a/src/main/java/reciter/controller/ExternalArticleController.java
+++ b/src/main/java/reciter/controller/ExternalArticleController.java
@@ -27,6 +27,7 @@ import reciter.database.dynamodb.model.GoldStandard;
 import reciter.engine.analysis.ReCiterArticleFeature;
 import reciter.service.AnalysisService;
 import reciter.service.ExternalArticleService;
+import reciter.service.IdentityService;
 import reciter.service.dynamo.ExternalArticleDupCheck;
 import reciter.service.dynamo.IDynamoDbGoldStandardService;
 
@@ -52,6 +53,9 @@ public class ExternalArticleController {
     @Autowired
     private AnalysisService analysisService;
 
+    @Autowired
+    private IdentityService identityService;
+
     @Operation(summary = "Add an external-source article for a person.",
             description = "Adds a publication from Scopus, Web of Science, or OpenAlex. Blocks on PMID/DOI duplicates "
                     + "against the person's PubMed record and existing external articles; warns on fuzzy title+year "
@@ -66,10 +70,16 @@ public class ExternalArticleController {
         if (validationError != null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorBody(validationError));
         }
+        if (identityService.findByUid(externalArticle.getUid()) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(errorBody("The uid provided '" + externalArticle.getUid() + "' was not found in the Identity table"));
+        }
 
+        GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(externalArticle.getUid());
         ExternalArticleDupCheck.Result result = ExternalArticleDupCheck.check(
                 externalArticle,
-                knownPmids(externalArticle.getUid()),
+                goldStandard == null ? null : goldStandard.getKnownPmids(),
+                goldStandard == null ? null : goldStandard.getRejectedPmids(),
                 candidateArticles(externalArticle.getUid()),
                 externalArticleService.findByUid(externalArticle.getUid()));
 
@@ -85,9 +95,9 @@ public class ExternalArticleController {
         if (externalArticle.getDateAdded() == null || externalArticle.getDateAdded().trim().isEmpty()) {
             externalArticle.setDateAdded(Instant.now().toString());
         }
-        if (externalArticle.getSuppressed() == null) {
-            externalArticle.setSuppressed(Boolean.FALSE);
-        }
+        // Owned by the supersede rule (#660), never by the client.
+        externalArticle.setSuppressed(Boolean.FALSE);
+        externalArticle.setSupersededByPmid(null);
         externalArticleService.save(externalArticle);
         log.info("External article {} added for uid {} from {} (method={}, force={})",
                 externalArticle.getArticleId(), externalArticle.getUid(), externalArticle.getSourceType(),
@@ -135,14 +145,6 @@ public class ExternalArticleController {
             return "sourceType '" + externalArticle.getSourceType() + "' does not match articleId prefix '" + prefix + "'.";
         }
         return null;
-    }
-
-    private List<Long> knownPmids(String uid) {
-        GoldStandard goldStandard = dynamoDbGoldStandardService.findByUid(uid);
-        if (goldStandard == null || goldStandard.getKnownPmids() == null) {
-            return new ArrayList<>();
-        }
-        return goldStandard.getKnownPmids();
     }
 
     private List<ReCiterArticleFeature> candidateArticles(String uid) {

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -49,6 +49,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -66,6 +69,7 @@ import reciter.api.parameters.UseGoldStandard;
 import reciter.database.dynamodb.model.AnalysisOutput;
 import reciter.database.dynamodb.model.ESearchPmid;
 import reciter.database.dynamodb.model.ESearchResult;
+import reciter.database.dynamodb.model.ExternalArticle;
 import reciter.database.dynamodb.model.GoldStandard;
 import reciter.engine.Engine;
 import reciter.engine.EngineOutput;
@@ -83,6 +87,7 @@ import reciter.model.pubmed.PubMedArticle;
 import reciter.model.scopus.ScopusArticle;
 import reciter.service.AnalysisService;
 import reciter.service.ESearchResultService;
+import reciter.service.ExternalArticleService;
 import reciter.service.IdentityService;
 import reciter.service.OrcidService;
 import reciter.service.PubMedService;
@@ -127,6 +132,12 @@ public class ReCiterController {
 
     @Autowired
     private FeedbackLogQueryService feedbackLogQueryService;
+
+    @Autowired
+    private ExternalArticleService externalArticleService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Value("${use.scopus.articles}")
     private boolean useScopusArticles;
@@ -613,7 +624,8 @@ public class ReCiterController {
     })
     @RequestMapping(value = "/reciter/feature-generator/by/uid", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
-    public ResponseEntity runFeatureGenerator(@RequestParam(value = "uid") String uid, Double authorshipLikelihoodScore, UseGoldStandard useGoldStandard, FilterFeedbackType filterByFeedback, boolean analysisRefreshFlag, RetrievalRefreshFlag retrievalRefreshFlag) {
+    public ResponseEntity runFeatureGenerator(@RequestParam(value = "uid") String uid, Double authorshipLikelihoodScore, UseGoldStandard useGoldStandard, FilterFeedbackType filterByFeedback, boolean analysisRefreshFlag, RetrievalRefreshFlag retrievalRefreshFlag,
+    		@RequestParam(value = "includeExternal", required = false, defaultValue = "false") boolean includeExternal) {
     	StopWatch stopWatch = new StopWatch("Feature generation for UID "+uid);
         stopWatch.start("Feature generation for UID");
         
@@ -772,7 +784,7 @@ public class ReCiterController {
 			}	
             stopWatch.stop();
             log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
-            return new ResponseEntity<>(analysis.getReCiterFeature(), HttpStatus.OK);
+            return featureGeneratorResponse(analysis.getReCiterFeature(), uid, includeExternal);
         } else {
             if (useGoldStandard == null) {
                 strategyParameters.setUseGoldStandardEvidence(true);
@@ -919,7 +931,25 @@ public class ReCiterController {
         }
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
-        return new ResponseEntity<>(reCiterOutputFeature, HttpStatus.OK);
+        return featureGeneratorResponse(reCiterOutputFeature, uid, includeExternal);
+    }
+
+    /**
+     * With includeExternal=true, appends the person's manually added external-source
+     * articles (Scopus/WoS/OpenAlex) as a sibling "externalArticles" field — they are
+     * read at serialization time and never enter feature generation or Analysis.
+     * Suppressed rows (superseded by a PubMed record with the same DOI) are excluded.
+     */
+    private ResponseEntity<Object> featureGeneratorResponse(ReCiterFeature reCiterFeature, String uid, boolean includeExternal) {
+        if (!includeExternal) {
+            return new ResponseEntity<>(reCiterFeature, HttpStatus.OK);
+        }
+        List<ExternalArticle> externalArticles = externalArticleService.findByUid(uid.trim()).stream()
+                .filter(externalArticle -> !Boolean.TRUE.equals(externalArticle.getSuppressed()))
+                .collect(Collectors.toList());
+        ObjectNode responseBody = objectMapper.valueToTree(reCiterFeature);
+        responseBody.set("externalArticles", objectMapper.valueToTree(externalArticles));
+        return new ResponseEntity<>(responseBody, HttpStatus.OK);
     }
     
     @Operation(summary = "Article retrieval by UID.", description = "This api returns all the publication for a supplied uid.")

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -941,15 +941,23 @@ public class ReCiterController {
      * Suppressed rows (superseded by a PubMed record with the same DOI) are excluded.
      */
     private ResponseEntity<Object> featureGeneratorResponse(ReCiterFeature reCiterFeature, String uid, boolean includeExternal) {
-        if (!includeExternal) {
+        if (!includeExternal || reCiterFeature == null) {
             return new ResponseEntity<>(reCiterFeature, HttpStatus.OK);
         }
-        List<ExternalArticle> externalArticles = externalArticleService.findByUid(uid.trim()).stream()
-                .filter(externalArticle -> !Boolean.TRUE.equals(externalArticle.getSuppressed()))
-                .collect(Collectors.toList());
-        ObjectNode responseBody = objectMapper.valueToTree(reCiterFeature);
-        responseBody.set("externalArticles", objectMapper.valueToTree(externalArticles));
-        return new ResponseEntity<>(responseBody, HttpStatus.OK);
+        try {
+            List<ExternalArticle> externalArticles = externalArticleService.findByUid(uid.trim()).stream()
+                    .filter(externalArticle -> !Boolean.TRUE.equals(externalArticle.getSuppressed()))
+                    .collect(Collectors.toList());
+            ObjectNode responseBody = objectMapper.valueToTree(reCiterFeature);
+            responseBody.set("externalArticles", objectMapper.valueToTree(externalArticles));
+            return new ResponseEntity<>(responseBody, HttpStatus.OK);
+        } catch (Exception e) {
+            // The scoring result must never fail on the optional external-article sidecar;
+            // the absent externalArticles field (vs empty array) signals the degradation.
+            log.warn("Could not append external articles for uid {}; returning scoring result without them: {}",
+                    uid, e.getMessage());
+            return new ResponseEntity<>(reCiterFeature, HttpStatus.OK);
+        }
     }
     
     @Operation(summary = "Article retrieval by UID.", description = "This api returns all the publication for a supplied uid.")

--- a/src/main/java/reciter/database/dynamodb/model/ExternalArticle.java
+++ b/src/main/java/reciter/database/dynamodb/model/ExternalArticle.java
@@ -1,0 +1,65 @@
+package reciter.database.dynamodb.model;
+
+import java.util.List;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A publication manually added from a non-PubMed source (Scopus, Web of Science,
+ * OpenAlex). External articles never enter feature generation, scoring, or
+ * Analysis writes; they are appended to feature-generator API output at
+ * serialization time when includeExternal=true is requested.
+ */
+@Data
+@NoArgsConstructor
+@DynamoDBTable(tableName = "ExternalArticle")
+public class ExternalArticle {
+
+    @DynamoDBHashKey
+    private String uid;
+
+    /**
+     * Prefixed canonical identifier, e.g. "SCOPUS:85123456789",
+     * "OPENALEX:W2741809807", "WOS:000123456700001".
+     */
+    @DynamoDBRangeKey
+    private String articleId;
+
+    private String doi;
+
+    /** Present only when the source record carries a PMID (should normally be blocked at add time). */
+    private Long pmid;
+
+    private String title;
+    private String journalOrVenue;
+    private List<String> authors;
+
+    /** Publication date as provided by the source, ideally ISO-8601 (yyyy or yyyy-MM-dd). */
+    private String pubDate;
+
+    private String publicationType;
+
+    /** SCOPUS | WOS | OPENALEX — must agree with the articleId prefix. */
+    private String sourceType;
+
+    private String addedBy;
+
+    /** ISO-8601 instant, set server-side at add time. */
+    private String dateAdded;
+
+    /** dropdown-search | scopus-authorships-tab */
+    private String method;
+
+    /** True once superseded by a PubMed record with the same DOI; excluded from API merge. */
+    private Boolean suppressed;
+
+    private Long supersededByPmid;
+
+    /** Raw source API record as a JSON string, for provenance/debugging. */
+    private String rawRecord;
+}

--- a/src/main/java/reciter/service/ExternalArticleService.java
+++ b/src/main/java/reciter/service/ExternalArticleService.java
@@ -1,0 +1,16 @@
+package reciter.service;
+
+import java.util.List;
+
+import reciter.database.dynamodb.model.ExternalArticle;
+
+public interface ExternalArticleService {
+
+    void save(ExternalArticle externalArticle);
+
+    List<ExternalArticle> findByUid(String uid);
+
+    ExternalArticle find(String uid, String articleId);
+
+    void delete(String uid, String articleId);
+}

--- a/src/main/java/reciter/service/dynamo/ExternalArticleDupCheck.java
+++ b/src/main/java/reciter/service/dynamo/ExternalArticleDupCheck.java
@@ -1,0 +1,169 @@
+package reciter.service.dynamo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import reciter.database.dynamodb.model.ExternalArticle;
+import reciter.engine.analysis.ReCiterArticleFeature;
+
+/**
+ * Duplicate detection for manually added external-source articles.
+ *
+ * BLOCKED: the work already exists in the person's PubMed-domain record (gold
+ * standard or retrieved candidates, matched by PMID or DOI) or was already added
+ * from another external source. No override.
+ *
+ * WARNING: a fuzzy title+year collision. Overridable with force=true at the API.
+ */
+public final class ExternalArticleDupCheck {
+
+    public enum Level {
+        OK, WARNING, BLOCKED
+    }
+
+    public static final class Match {
+        private final String type;
+        private final String matchedId;
+        private final String detail;
+
+        Match(String type, String matchedId, String detail) {
+            this.type = type;
+            this.matchedId = matchedId;
+            this.detail = detail;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getMatchedId() {
+            return matchedId;
+        }
+
+        public String getDetail() {
+            return detail;
+        }
+    }
+
+    public static final class Result {
+        private final Level level;
+        private final List<Match> matches;
+
+        Result(Level level, List<Match> matches) {
+            this.level = level;
+            this.matches = matches;
+        }
+
+        public Level getLevel() {
+            return level;
+        }
+
+        public List<Match> getMatches() {
+            return matches;
+        }
+    }
+
+    private ExternalArticleDupCheck() {
+    }
+
+    public static Result check(ExternalArticle candidate,
+                               List<Long> knownPmids,
+                               List<ReCiterArticleFeature> candidateArticles,
+                               List<ExternalArticle> existingExternal) {
+        List<Match> blocked = new ArrayList<>();
+        List<Match> warnings = new ArrayList<>();
+        String candidateDoi = normalizeDoi(candidate.getDoi());
+        String candidateTitle = normalizeTitle(candidate.getTitle());
+        String candidateYear = year(candidate.getPubDate());
+
+        for (ExternalArticle existing : safe(existingExternal)) {
+            if (existing.getArticleId() != null && existing.getArticleId().equals(candidate.getArticleId())) {
+                blocked.add(new Match("ALREADY_ADDED", existing.getArticleId(),
+                        "This external article was already added for this person."));
+            } else if (candidateDoi != null && candidateDoi.equals(normalizeDoi(existing.getDoi()))) {
+                blocked.add(new Match("DOI_MATCH_EXTERNAL", existing.getArticleId(),
+                        "An external article with the same DOI was already added from " + existing.getSourceType() + "."));
+            } else if (titleYearCollision(candidateTitle, candidateYear,
+                    normalizeTitle(existing.getTitle()), year(existing.getPubDate()))) {
+                warnings.add(new Match("TITLE_YEAR_MATCH_EXTERNAL", existing.getArticleId(),
+                        "An external article with a matching title and year was already added: " + existing.getTitle()));
+            }
+        }
+
+        if (candidate.getPmid() != null && knownPmids != null && knownPmids.contains(candidate.getPmid())) {
+            blocked.add(new Match("PMID_IN_GOLD_STANDARD", String.valueOf(candidate.getPmid()),
+                    "This PMID is already accepted in the person's gold standard."));
+        }
+
+        for (ReCiterArticleFeature feature : safe(candidateArticles)) {
+            if (candidate.getPmid() != null && feature.getPmid() == candidate.getPmid()) {
+                blocked.add(new Match("PMID_IN_CANDIDATES", String.valueOf(feature.getPmid()),
+                        "This PMID exists in the person's PubMed candidate set; adjudicate it via normal feedback instead."));
+            } else if (candidateDoi != null && candidateDoi.equals(normalizeDoi(feature.getDoi()))) {
+                blocked.add(new Match("DOI_MATCH", String.valueOf(feature.getPmid()),
+                        "A PubMed article with the same DOI exists in the person's candidate set (PMID " + feature.getPmid() + ")."));
+            } else if (titleYearCollision(candidateTitle, candidateYear,
+                    normalizeTitle(feature.getArticleTitle()), year(feature.getPublicationDateStandardized()))) {
+                warnings.add(new Match("TITLE_YEAR_MATCH", String.valueOf(feature.getPmid()),
+                        "A PubMed article with a matching title and year exists (PMID " + feature.getPmid() + "): " + feature.getArticleTitle()));
+            }
+        }
+
+        if (!blocked.isEmpty()) {
+            blocked.addAll(warnings);
+            return new Result(Level.BLOCKED, blocked);
+        }
+        if (!warnings.isEmpty()) {
+            return new Result(Level.WARNING, warnings);
+        }
+        return new Result(Level.OK, new ArrayList<>());
+    }
+
+    // ponytail: exact match on normalized title + same year. Upgrade to token-overlap
+    // similarity if real-world misses (subtitle variants, punctuation-heavy titles) show up.
+    private static boolean titleYearCollision(String titleA, String yearA, String titleB, String yearB) {
+        if (titleA == null || titleB == null || !titleA.equals(titleB)) {
+            return false;
+        }
+        // Identical titles with both years unknown still warrant a warning.
+        if (yearA == null || yearB == null) {
+            return yearA == null && yearB == null;
+        }
+        return yearA.equals(yearB);
+    }
+
+    /** Lowercase, trim, strip any doi.org URL prefix. Returns null for blank input. */
+    static String normalizeDoi(String doi) {
+        if (doi == null) {
+            return null;
+        }
+        String normalized = doi.trim().toLowerCase(Locale.ROOT)
+                .replaceFirst("^https?://(dx\\.)?doi\\.org/", "");
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    /** Lowercase, collapse all non-alphanumerics to single spaces. Returns null for blank input. */
+    static String normalizeTitle(String title) {
+        if (title == null) {
+            return null;
+        }
+        String normalized = title.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", " ")
+                .trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    /** First 4-digit year found in a date string, or null. */
+    static String year(String date) {
+        if (date == null) {
+            return null;
+        }
+        java.util.regex.Matcher m = java.util.regex.Pattern.compile("\\d{4}").matcher(date);
+        return m.find() ? m.group() : null;
+    }
+
+    private static <T> List<T> safe(List<T> list) {
+        return list == null ? new ArrayList<>() : list;
+    }
+}

--- a/src/main/java/reciter/service/dynamo/ExternalArticleDupCheck.java
+++ b/src/main/java/reciter/service/dynamo/ExternalArticleDupCheck.java
@@ -69,6 +69,7 @@ public final class ExternalArticleDupCheck {
 
     public static Result check(ExternalArticle candidate,
                                List<Long> knownPmids,
+                               List<Long> rejectedPmids,
                                List<ReCiterArticleFeature> candidateArticles,
                                List<ExternalArticle> existingExternal) {
         List<Match> blocked = new ArrayList<>();
@@ -81,6 +82,9 @@ public final class ExternalArticleDupCheck {
             if (existing.getArticleId() != null && existing.getArticleId().equals(candidate.getArticleId())) {
                 blocked.add(new Match("ALREADY_ADDED", existing.getArticleId(),
                         "This external article was already added for this person."));
+            } else if (candidate.getPmid() != null && candidate.getPmid().equals(existing.getPmid())) {
+                blocked.add(new Match("PMID_MATCH_EXTERNAL", existing.getArticleId(),
+                        "An external article with the same PMID was already added from " + existing.getSourceType() + "."));
             } else if (candidateDoi != null && candidateDoi.equals(normalizeDoi(existing.getDoi()))) {
                 blocked.add(new Match("DOI_MATCH_EXTERNAL", existing.getArticleId(),
                         "An external article with the same DOI was already added from " + existing.getSourceType() + "."));
@@ -94,6 +98,10 @@ public final class ExternalArticleDupCheck {
         if (candidate.getPmid() != null && knownPmids != null && knownPmids.contains(candidate.getPmid())) {
             blocked.add(new Match("PMID_IN_GOLD_STANDARD", String.valueOf(candidate.getPmid()),
                     "This PMID is already accepted in the person's gold standard."));
+        }
+        if (candidate.getPmid() != null && rejectedPmids != null && rejectedPmids.contains(candidate.getPmid())) {
+            blocked.add(new Match("PMID_REJECTED_IN_GOLD_STANDARD", String.valueOf(candidate.getPmid()),
+                    "This PMID was explicitly rejected by a curator; do not re-add it from an external source."));
         }
 
         for (ReCiterArticleFeature feature : safe(candidateArticles)) {
@@ -126,11 +134,8 @@ public final class ExternalArticleDupCheck {
         if (titleA == null || titleB == null || !titleA.equals(titleB)) {
             return false;
         }
-        // Identical titles with both years unknown still warrant a warning.
-        if (yearA == null || yearB == null) {
-            return yearA == null && yearB == null;
-        }
-        return yearA.equals(yearB);
+        // Identical titles collide unless both years are known and differ.
+        return yearA == null || yearB == null || yearA.equals(yearB);
     }
 
     /** Lowercase, trim, strip any doi.org URL prefix. Returns null for blank input. */

--- a/src/main/java/reciter/service/dynamo/ExternalArticleServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ExternalArticleServiceImpl.java
@@ -32,7 +32,7 @@ public class ExternalArticleServiceImpl implements ExternalArticleService {
         DynamoDBQueryExpression<ExternalArticle> queryExpression =
                 new DynamoDBQueryExpression<ExternalArticle>()
                         .withHashKeyValues(hashKey)
-                        .withConsistentRead(false);
+                        .withConsistentRead(true);
         return dynamoDBMapper.query(ExternalArticle.class, queryExpression);
     }
 

--- a/src/main/java/reciter/service/dynamo/ExternalArticleServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ExternalArticleServiceImpl.java
@@ -1,0 +1,51 @@
+package reciter.service.dynamo;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+
+import reciter.database.dynamodb.model.ExternalArticle;
+import reciter.service.ExternalArticleService;
+
+@Service
+public class ExternalArticleServiceImpl implements ExternalArticleService {
+
+    private final DynamoDBMapper dynamoDBMapper;
+
+    public ExternalArticleServiceImpl(AmazonDynamoDB amazonDynamoDB) {
+        this.dynamoDBMapper = new DynamoDBMapper(amazonDynamoDB);
+    }
+
+    @Override
+    public void save(ExternalArticle externalArticle) {
+        dynamoDBMapper.save(externalArticle);
+    }
+
+    @Override
+    public List<ExternalArticle> findByUid(String uid) {
+        ExternalArticle hashKey = new ExternalArticle();
+        hashKey.setUid(uid);
+        DynamoDBQueryExpression<ExternalArticle> queryExpression =
+                new DynamoDBQueryExpression<ExternalArticle>()
+                        .withHashKeyValues(hashKey)
+                        .withConsistentRead(false);
+        return dynamoDBMapper.query(ExternalArticle.class, queryExpression);
+    }
+
+    @Override
+    public ExternalArticle find(String uid, String articleId) {
+        return dynamoDBMapper.load(ExternalArticle.class, uid, articleId);
+    }
+
+    @Override
+    public void delete(String uid, String articleId) {
+        ExternalArticle key = new ExternalArticle();
+        key.setUid(uid);
+        key.setArticleId(articleId);
+        dynamoDBMapper.delete(key);
+    }
+}

--- a/src/test/java/reciter/service/dynamo/ExternalArticleDupCheckTest.java
+++ b/src/test/java/reciter/service/dynamo/ExternalArticleDupCheckTest.java
@@ -1,0 +1,148 @@
+package reciter.service.dynamo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import reciter.database.dynamodb.model.ExternalArticle;
+import reciter.engine.analysis.ReCiterArticleFeature;
+import reciter.service.dynamo.ExternalArticleDupCheck.Level;
+import reciter.service.dynamo.ExternalArticleDupCheck.Result;
+
+public class ExternalArticleDupCheckTest {
+
+    private ExternalArticle candidate(String articleId, Long pmid, String doi, String title, String pubDate) {
+        ExternalArticle externalArticle = new ExternalArticle();
+        externalArticle.setUid("test1234");
+        externalArticle.setArticleId(articleId);
+        externalArticle.setPmid(pmid);
+        externalArticle.setDoi(doi);
+        externalArticle.setTitle(title);
+        externalArticle.setPubDate(pubDate);
+        return externalArticle;
+    }
+
+    private ReCiterArticleFeature pubmedArticle(long pmid, String doi, String title, String dateStandardized) {
+        ReCiterArticleFeature feature = new ReCiterArticleFeature();
+        feature.setPmid(pmid);
+        feature.setDoi(doi);
+        feature.setArticleTitle(title);
+        feature.setPublicationDateStandardized(dateStandardized);
+        return feature;
+    }
+
+    @Test
+    public void cleanAddIsOk() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("OPENALEX:W123", null, "10.1000/xyz", "A Novel Finding", "2025-06-01"),
+                Arrays.asList(11111L),
+                Arrays.asList(pubmedArticle(11111L, "10.1000/abc", "Something Else Entirely", "2020-01-01")),
+                Collections.emptyList());
+        assertEquals(Level.OK, result.getLevel());
+    }
+
+    @Test
+    public void pmidInGoldStandardBlocks() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("SCOPUS:850001", 11111L, null, "Any Title", "2020"),
+                Arrays.asList(11111L),
+                Collections.emptyList(),
+                Collections.emptyList());
+        assertEquals(Level.BLOCKED, result.getLevel());
+        assertEquals("PMID_IN_GOLD_STANDARD", result.getMatches().get(0).getType());
+    }
+
+    @Test
+    public void pmidInCandidateSetBlocks() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("SCOPUS:850001", 22222L, null, "Any Title", "2020"),
+                Collections.emptyList(),
+                Arrays.asList(pubmedArticle(22222L, null, "Any Title", "2020-01-01")),
+                Collections.emptyList());
+        assertEquals(Level.BLOCKED, result.getLevel());
+        assertEquals("PMID_IN_CANDIDATES", result.getMatches().get(0).getType());
+    }
+
+    @Test
+    public void doiMatchAgainstCandidatesBlocksDespiteUrlPrefixAndCase() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("OPENALEX:W123", null, "https://doi.org/10.1000/ABC", "Different Title", "2021"),
+                Collections.emptyList(),
+                Arrays.asList(pubmedArticle(33333L, "10.1000/abc", "Original Title", "2021-05-01")),
+                Collections.emptyList());
+        assertEquals(Level.BLOCKED, result.getLevel());
+        assertEquals("DOI_MATCH", result.getMatches().get(0).getType());
+    }
+
+    @Test
+    public void doiMatchAgainstExistingExternalBlocks() {
+        ExternalArticle existing = candidate("SCOPUS:850002", null, "10.1000/xyz", "Same Work From Scopus", "2022");
+        Result result = ExternalArticleDupCheck.check(
+                candidate("OPENALEX:W456", null, "10.1000/xyz", "Same Work From OpenAlex", "2022"),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Arrays.asList(existing));
+        assertEquals(Level.BLOCKED, result.getLevel());
+        assertEquals("DOI_MATCH_EXTERNAL", result.getMatches().get(0).getType());
+    }
+
+    @Test
+    public void sameArticleIdBlocks() {
+        ExternalArticle existing = candidate("OPENALEX:W123", null, null, "A Title", "2020");
+        Result result = ExternalArticleDupCheck.check(
+                candidate("OPENALEX:W123", null, null, "A Title", "2020"),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Arrays.asList(existing));
+        assertEquals(Level.BLOCKED, result.getLevel());
+        assertEquals("ALREADY_ADDED", result.getMatches().get(0).getType());
+    }
+
+    @Test
+    public void titleAndYearCollisionWarns() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("OPENALEX:W123", null, null, "Deep Learning for Author Disambiguation!", "2023"),
+                Collections.emptyList(),
+                Arrays.asList(pubmedArticle(44444L, null, "Deep learning for author disambiguation", "2023-09-15")),
+                Collections.emptyList());
+        assertEquals(Level.WARNING, result.getLevel());
+        assertEquals("TITLE_YEAR_MATCH", result.getMatches().get(0).getType());
+    }
+
+    @Test
+    public void sameTitleDifferentYearIsOk() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("OPENALEX:W123", null, null, "Annual Report on Disambiguation", "2024"),
+                Collections.emptyList(),
+                Arrays.asList(pubmedArticle(55555L, null, "Annual Report on Disambiguation", "2023-01-01")),
+                Collections.emptyList());
+        assertEquals(Level.OK, result.getLevel());
+    }
+
+    @Test
+    public void blockedOutranksWarning() {
+        List<ReCiterArticleFeature> candidates = Arrays.asList(
+                pubmedArticle(66666L, "10.1000/dup", "A Fuzzy Title Match", "2022-01-01"),
+                pubmedArticle(77777L, null, "A Fuzzy Title Match", "2022-03-01"));
+        Result result = ExternalArticleDupCheck.check(
+                candidate("SCOPUS:850003", null, "10.1000/dup", "A Fuzzy Title Match", "2022"),
+                Collections.emptyList(),
+                candidates,
+                Collections.emptyList());
+        assertEquals(Level.BLOCKED, result.getLevel());
+    }
+
+    @Test
+    public void normalizers() {
+        assertEquals("10.1000/abc", ExternalArticleDupCheck.normalizeDoi(" https://dx.doi.org/10.1000/ABC "));
+        assertNull(ExternalArticleDupCheck.normalizeDoi("  "));
+        assertEquals("deep learning 2 0", ExternalArticleDupCheck.normalizeTitle("Deep-Learning: 2.0?"));
+        assertEquals("2023", ExternalArticleDupCheck.year("2023-09-15"));
+        assertNull(ExternalArticleDupCheck.year("n.d."));
+    }
+}

--- a/src/test/java/reciter/service/dynamo/ExternalArticleDupCheckTest.java
+++ b/src/test/java/reciter/service/dynamo/ExternalArticleDupCheckTest.java
@@ -41,6 +41,7 @@ public class ExternalArticleDupCheckTest {
         Result result = ExternalArticleDupCheck.check(
                 candidate("OPENALEX:W123", null, "10.1000/xyz", "A Novel Finding", "2025-06-01"),
                 Arrays.asList(11111L),
+                Collections.emptyList(),
                 Arrays.asList(pubmedArticle(11111L, "10.1000/abc", "Something Else Entirely", "2020-01-01")),
                 Collections.emptyList());
         assertEquals(Level.OK, result.getLevel());
@@ -52,15 +53,29 @@ public class ExternalArticleDupCheckTest {
                 candidate("SCOPUS:850001", 11111L, null, "Any Title", "2020"),
                 Arrays.asList(11111L),
                 Collections.emptyList(),
+                Collections.emptyList(),
                 Collections.emptyList());
         assertEquals(Level.BLOCKED, result.getLevel());
         assertEquals("PMID_IN_GOLD_STANDARD", result.getMatches().get(0).getType());
     }
 
     @Test
+    public void rejectedPmidBlocks() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("SCOPUS:850001", 99999L, null, "Any Title", "2020"),
+                Collections.emptyList(),
+                Arrays.asList(99999L),
+                Collections.emptyList(),
+                Collections.emptyList());
+        assertEquals(Level.BLOCKED, result.getLevel());
+        assertEquals("PMID_REJECTED_IN_GOLD_STANDARD", result.getMatches().get(0).getType());
+    }
+
+    @Test
     public void pmidInCandidateSetBlocks() {
         Result result = ExternalArticleDupCheck.check(
                 candidate("SCOPUS:850001", 22222L, null, "Any Title", "2020"),
+                Collections.emptyList(),
                 Collections.emptyList(),
                 Arrays.asList(pubmedArticle(22222L, null, "Any Title", "2020-01-01")),
                 Collections.emptyList());
@@ -69,9 +84,23 @@ public class ExternalArticleDupCheckTest {
     }
 
     @Test
+    public void pmidMatchAgainstExistingExternalBlocks() {
+        ExternalArticle existing = candidate("SCOPUS:850002", 88888L, null, "From Scopus", "2022");
+        Result result = ExternalArticleDupCheck.check(
+                candidate("OPENALEX:W456", 88888L, null, "From OpenAlex", "2022"),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Arrays.asList(existing));
+        assertEquals(Level.BLOCKED, result.getLevel());
+        assertEquals("PMID_MATCH_EXTERNAL", result.getMatches().get(0).getType());
+    }
+
+    @Test
     public void doiMatchAgainstCandidatesBlocksDespiteUrlPrefixAndCase() {
         Result result = ExternalArticleDupCheck.check(
                 candidate("OPENALEX:W123", null, "https://doi.org/10.1000/ABC", "Different Title", "2021"),
+                Collections.emptyList(),
                 Collections.emptyList(),
                 Arrays.asList(pubmedArticle(33333L, "10.1000/abc", "Original Title", "2021-05-01")),
                 Collections.emptyList());
@@ -86,6 +115,7 @@ public class ExternalArticleDupCheckTest {
                 candidate("OPENALEX:W456", null, "10.1000/xyz", "Same Work From OpenAlex", "2022"),
                 Collections.emptyList(),
                 Collections.emptyList(),
+                Collections.emptyList(),
                 Arrays.asList(existing));
         assertEquals(Level.BLOCKED, result.getLevel());
         assertEquals("DOI_MATCH_EXTERNAL", result.getMatches().get(0).getType());
@@ -98,6 +128,7 @@ public class ExternalArticleDupCheckTest {
                 candidate("OPENALEX:W123", null, null, "A Title", "2020"),
                 Collections.emptyList(),
                 Collections.emptyList(),
+                Collections.emptyList(),
                 Arrays.asList(existing));
         assertEquals(Level.BLOCKED, result.getLevel());
         assertEquals("ALREADY_ADDED", result.getMatches().get(0).getType());
@@ -108,7 +139,20 @@ public class ExternalArticleDupCheckTest {
         Result result = ExternalArticleDupCheck.check(
                 candidate("OPENALEX:W123", null, null, "Deep Learning for Author Disambiguation!", "2023"),
                 Collections.emptyList(),
+                Collections.emptyList(),
                 Arrays.asList(pubmedArticle(44444L, null, "Deep learning for author disambiguation", "2023-09-15")),
+                Collections.emptyList());
+        assertEquals(Level.WARNING, result.getLevel());
+        assertEquals("TITLE_YEAR_MATCH", result.getMatches().get(0).getType());
+    }
+
+    @Test
+    public void titleCollisionWithOneMissingYearStillWarns() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("OPENALEX:W123", null, null, "Deep Learning for Author Disambiguation", "2023"),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Arrays.asList(pubmedArticle(44444L, null, "Deep learning for author disambiguation", null)),
                 Collections.emptyList());
         assertEquals(Level.WARNING, result.getLevel());
         assertEquals("TITLE_YEAR_MATCH", result.getMatches().get(0).getType());
@@ -118,6 +162,7 @@ public class ExternalArticleDupCheckTest {
     public void sameTitleDifferentYearIsOk() {
         Result result = ExternalArticleDupCheck.check(
                 candidate("OPENALEX:W123", null, null, "Annual Report on Disambiguation", "2024"),
+                Collections.emptyList(),
                 Collections.emptyList(),
                 Arrays.asList(pubmedArticle(55555L, null, "Annual Report on Disambiguation", "2023-01-01")),
                 Collections.emptyList());
@@ -131,6 +176,7 @@ public class ExternalArticleDupCheckTest {
                 pubmedArticle(77777L, null, "A Fuzzy Title Match", "2022-03-01"));
         Result result = ExternalArticleDupCheck.check(
                 candidate("SCOPUS:850003", null, "10.1000/dup", "A Fuzzy Title Match", "2022"),
+                Collections.emptyList(),
                 Collections.emptyList(),
                 candidates,
                 Collections.emptyList());


### PR DESCRIPTION
Implements #659 — Phase 1 of the external source publications plan.

## What this adds

Curators will be able to add publications from non-PubMed sources (Scopus, Web of Science, OpenAlex). External articles are **fully excluded from disambiguation** — they never enter feature generation, scoring, or Analysis writes — but surface in feature-generator output on request.

- **`ExternalArticle` DynamoDB table** — PK `uid`, SK `articleId` as a prefixed string (`SCOPUS:…`, `WOS:…`, `OPENALEX:W…`, matching the provenance identifier convention). First model class defined in-repo under `reciter.database.dynamodb.model`; the existing `DynamoDbConfig` classpath scan auto-creates the table on startup (`table.create=true`, PAY_PER_REQUEST). Provenance fields inline: `addedBy`, `dateAdded`, `method`, `sourceType`, `rawRecord`.
- **`POST/GET/DELETE /reciter/external-article/by/uid`** — add validates uid against Identity (404 on unknown) and runs a server-side duplicate check:
  - **Blocks** (no override): PMID in gold standard knownPmids **or rejectedPmids**, PMID in the Analysis candidate set, DOI match against candidates or existing external rows (doi.org-prefix/case-insensitive), PMID match across external rows, same articleId.
  - **Warns** (overridable with `force=true`): normalized title match with same year, or with either year missing.
  - `suppressed`/`supersededByPmid` are server-owned (reserved for the #660 supersede rule) — client-supplied values are reset.
- **`feature-generator/by/uid?includeExternal=true`** (default **false**) — appends non-suppressed external rows as a sibling `externalArticles` field at serialization time. Default output is byte-identical to current behavior. If the sidecar read fails, the scoring result still returns (absent `externalArticles` field signals degradation). Null-feature cached rows return exactly as before.

## Verification

- `mvn test` full suite: **158 tests, 0 failures, 0 errors, 1 skipped** (pre-existing skip) — includes 13 new dup-check unit tests and the Spring context smoke test (new beans wire correctly).
- High-effort multi-agent adversarial code review run on the diff; all CONFIRMED correctness findings fixed in the second commit (null-feature 500, rejectedPmids gap, cross-source PMID gap, one-null-year miss, uid validation, client-settable suppressed, consistent reads).
- **Not yet verified live** (needs dev deploy): table auto-creation on startup against real DynamoDB, and an end-to-end add → includeExternal round-trip. Will smoke-test on reciter-dev after merge/deploy.

## Known limitations (deliberate)

- If a person's Analysis row is missing/corrupt, DOI-based blocking degrades (gold standard PMID/rejected blocking still applies). A gold-standard-DOI cross-check via the PubMedArticle cache is possible but deferred — the Analysis row self-heals on the nightly run.
- `suppressed` has no writer yet — that is the #660 supersede rule (next PR).
- Title matching is exact-on-normalized-text; upgrade to token-overlap similarity if real-world misses show up.
- Interaction of the squiggly `fields` filter with `includeExternal=true` responses (ObjectNode path) is untested; the param is opt-in and new, so no existing consumer is affected.

Closes #659.