### PR TITLE
Accept WORLDCAT prefix for external-source articles

### DIFF
--- a/src/main/java/reciter/controller/ExternalArticleController.java
+++ b/src/main/java/reciter/controller/ExternalArticleController.java
@@ -42,7 +42,7 @@ public class ExternalArticleController {
 
     private static final Logger log = LoggerFactory.getLogger(ExternalArticleController.class);
 
-    private static final Pattern ARTICLE_ID_PATTERN = Pattern.compile("^(SCOPUS|WOS|OPENALEX):\\S+$");
+    private static final Pattern ARTICLE_ID_PATTERN = Pattern.compile("^(SCOPUS|WOS|OPENALEX|WORLDCAT):\\S+$");
 
     @Autowired
     private ExternalArticleService externalArticleService;
@@ -132,7 +132,7 @@ public class ExternalArticleController {
     private String validate(ExternalArticle externalArticle) {
         if (externalArticle.getArticleId() == null
                 || !ARTICLE_ID_PATTERN.matcher(externalArticle.getArticleId().trim()).matches()) {
-            return "articleId is required and must be a prefixed identifier: SCOPUS:<id>, WOS:<id>, or OPENALEX:<id>.";
+            return "articleId is required and must be a prefixed identifier: SCOPUS:<id>, WOS:<id>, OPENALEX:<id>, or WORLDCAT:<id>.";
         }
         externalArticle.setArticleId(externalArticle.getArticleId().trim());
         if (externalArticle.getTitle() == null || externalArticle.getTitle().trim().isEmpty()) {

--- a/src/main/java/reciter/database/dynamodb/model/ExternalArticle.java
+++ b/src/main/java/reciter/database/dynamodb/model/ExternalArticle.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * A publication manually added from a non-PubMed source (Scopus, Web of Science,
- * OpenAlex). External articles never enter feature generation, scoring, or
+ * OpenAlex, WorldCat). External articles never enter feature generation, scoring, or
  * Analysis writes; they are appended to feature-generator API output at
  * serialization time when includeExternal=true is requested.
  */
@@ -44,7 +44,7 @@ public class ExternalArticle {
 
     private String publicationType;
 
-    /** SCOPUS | WOS | OPENALEX — must agree with the articleId prefix. */
+    /** SCOPUS | WOS | OPENALEX | WORLDCAT — must agree with the articleId prefix. */
     private String sourceType;
 
     private String addedBy;


### PR DESCRIPTION
Follow-up to #661: adds `WORLDCAT:` to the external-article ID validator (the single place sources are enumerated — the store, dup check, feature-generator merge, and supersede rule are all source-agnostic).

Note: WorldCat records (books/chapters) typically carry no DOI and never a PMID, so the hard-block dedup layers don't fire for them — duplicate detection falls back to the title+year warning with `force=true` override, which is the expected curator path for book-ish material.

Compile-verified; no behavior change for existing prefixes.