### PR TITLE
Fix prod DynamoDB "Connection pool shut down" outage (shared IRSA credentials provider closed by per-call AWS clients)

### DIFF
--- a/src/main/java/reciter/algorithm/article/score/predictor/NeuralNetworkModelArticlesScorer.java
+++ b/src/main/java/reciter/algorithm/article/score/predictor/NeuralNetworkModelArticlesScorer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import reciter.storage.s3.AwsScoringClients;
 import reciter.utils.PropertiesUtils;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
@@ -179,8 +180,7 @@ public class NeuralNetworkModelArticlesScorer {
 	private JSONArray callAwsLambda(String goldStandardModelName, String articleDataFilename, String s3BucketName,
 			String isS3UploadRequiredString, String lambdaFunctionName) {
 
-		LambdaClient client = LambdaClient.builder().region(Region.of(PropertiesUtils.get(LAMBDA_FUNCTION_REGION)))
-				.credentialsProvider(DefaultCredentialsProvider.create()).build();
+		LambdaClient client = AwsScoringClients.lambda(PropertiesUtils.get(LAMBDA_FUNCTION_REGION));
 
 		ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
+++ b/src/main/java/reciter/algorithm/cluster/article/scorer/ReCiterArticleScorer.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import reciter.algorithm.article.score.predictor.NeuralNetworkModelArticlesScorer;
 import reciter.algorithm.evidence.StrategyContext;
 import reciter.algorithm.evidence.article.RemoveReCiterArticleStrategyContext;
+import reciter.storage.s3.AwsScoringClients;
 import reciter.algorithm.evidence.author.authorcount.AuthorCountStrategyContext;
 import reciter.algorithm.evidence.author.authorcount.strategy.AuthorCountStrategy;
 import reciter.algorithm.evidence.targetauthor.TargetAuthorStrategyContext;
@@ -609,10 +610,7 @@ public class ReCiterArticleScorer extends AbstractArticleScorer {
 		// Upload the python file
         try {
         	
-        	final S3Client s3 = S3Client.builder()
-    			    .credentialsProvider(DefaultCredentialsProvider.create())
-    			    .region(Region.of(System.getenv("AWS_REGION"))) 
-    			    .build();
+        	final S3Client s3 = AwsScoringClients.s3();
         	try {
                 HeadBucketRequest headBucketRequest = HeadBucketRequest.builder()
                         .bucket(feedbackScoreBucketName)

--- a/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
+++ b/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import reciter.algorithm.article.score.predictor.NeuralNetworkModelArticlesScorer;
 import reciter.algorithm.evidence.StrategyContext;
 import reciter.algorithm.evidence.article.ReCiterArticleStrategyContext;
+import reciter.storage.s3.AwsScoringClients;
 import reciter.algorithm.evidence.article.feedbackevidence.FeedbackEvidenceStrategyContext;
 import reciter.algorithm.evidence.article.feedbackevidence.strategy.FeedbackEvidenceStrategy;
 import reciter.algorithm.evidence.feedback.targetauthor.TargetAuthorFeedbackStrategyContext;
@@ -443,10 +444,7 @@ public class ReciterFeedbackArticleScorer extends AbstractFeedbackArticleScorer 
         
         // Upload the CSV file
         try {
-        	final S3Client s3 = S3Client.builder()
-       			 .credentialsProvider(DefaultCredentialsProvider.create())
-    	            .region(Region.of(System.getenv("AWS_REGION")))
-    	            .build();
+        	final S3Client s3 = AwsScoringClients.s3();
         	// Check if the bucket exists
 	        HeadBucketRequest headBucketRequest = HeadBucketRequest.builder()
 	                .bucket(feedbackScoreBucketName)
@@ -845,10 +843,8 @@ public class ReciterFeedbackArticleScorer extends AbstractFeedbackArticleScorer 
 		String feedbackScoreBucketName = PropertiesUtils.get("aws.s3.feedback.score.bucketName");
         
 		// Upload the python file
-				 try (S3Client s3 = S3Client.builder()
-				            .credentialsProvider(DefaultCredentialsProvider.create())
-				            .region(Region.of(System.getenv("AWS_REGION")))
-				            .build()) {
+				 S3Client s3 = AwsScoringClients.s3();
+				 try {
 					// Check if the bucket exists
 				        HeadBucketRequest headBucketRequest = HeadBucketRequest.builder()
 				                .bucket(feedbackScoreBucketName)

--- a/src/main/java/reciter/storage/s3/AmazonS3Config.java
+++ b/src/main/java/reciter/storage/s3/AmazonS3Config.java
@@ -124,13 +124,15 @@ public class AmazonS3Config {
     }
     
 	private String getAccountIDUsingAccessKey(String accessKey, String secretKey) {
-		try (StsClient stsClient = StsClient.builder().credentialsProvider(DefaultCredentialsProvider.create())
-				.build()) {
-
-			GetCallerIdentityResponse callerIdentity = stsClient
-					.getCallerIdentity(GetCallerIdentityRequest.builder().build());
-			return callerIdentity.account();
-		}
+		// Do NOT close this StsClient. DefaultCredentialsProvider.create() is a JVM-wide singleton;
+		// closing any client built with it shuts down the shared IRSA STS connection pool, which
+		// then breaks credential refresh for every other client (incl. DynamoDB) after ~1h. This
+		// runs once at startup, so the single un-closed client lives harmlessly for the app lifetime.
+		StsClient stsClient = StsClient.builder().credentialsProvider(DefaultCredentialsProvider.create())
+				.build();
+		GetCallerIdentityResponse callerIdentity = stsClient
+				.getCallerIdentity(GetCallerIdentityRequest.builder().build());
+		return callerIdentity.account();
 	}
     
 }

--- a/src/main/java/reciter/storage/s3/AwsScoringClients.java
+++ b/src/main/java/reciter/storage/s3/AwsScoringClients.java
@@ -1,0 +1,60 @@
+package reciter.storage.s3;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Shared, application-lifetime AWS clients used by the scoring path.
+ *
+ * <p>{@link DefaultCredentialsProvider#create()} returns a JVM-wide singleton that is
+ * {@code SdkAutoCloseable}. Every client built with it shares that one provider and its single
+ * IRSA STS ({@code AssumeRoleWithWebIdentity}) connection pool. Closing any such client shuts
+ * that pool down, so once the ~1h IRSA session expires every other client — including the
+ * long-lived DynamoDB client — fails credential refresh with "Connection pool shut down".
+ *
+ * <p>These clients are therefore built once and never closed. SDK v2 clients are thread-safe and
+ * meant to be shared for the app lifetime (AWS best practice); the JVM reclaims them at shutdown.
+ */
+public final class AwsScoringClients {
+
+    private AwsScoringClients() {}
+
+    private static volatile S3Client s3;
+    private static volatile LambdaClient lambda;
+
+    public static S3Client s3() {
+        S3Client c = s3;
+        if (c == null) {
+            synchronized (AwsScoringClients.class) {
+                c = s3;
+                if (c == null) {
+                    c = S3Client.builder()
+                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .region(Region.of(System.getenv("AWS_REGION")))
+                            .build();
+                    s3 = c;
+                }
+            }
+        }
+        return c;
+    }
+
+    public static LambdaClient lambda(String region) {
+        LambdaClient c = lambda;
+        if (c == null) {
+            synchronized (AwsScoringClients.class) {
+                c = lambda;
+                if (c == null) {
+                    c = LambdaClient.builder()
+                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .region(Region.of(region))
+                            .build();
+                    lambda = c;
+                }
+            }
+        }
+        return c;
+    }
+}


### PR DESCRIPTION
## Symptom
Prod `feature-generator` (and any DynamoDB read) returns **500** ~1 hour after each pod starts, on all pods simultaneously, and does not self-recover. Root exception:

```
java.lang.IllegalStateException: Connection pool shut down
  at ...WebIdentityTokenFileCredentialsProvider / StsAssumeRoleWithWebIdentity...
  at reciter.database.dynamodb.repository.IdentityRepository.findById
  at IdentityServiceImpl.findByUid -> ReCiterController
```

Observed live on prod today: pods started 13:56 UTC, all failed 14:59; after a rolling restart, the fresh pods failed again at ~60 min. Restart is only a ~1h band-aid.

## Root cause
`DefaultCredentialsProvider.create()` returns a **JVM-wide singleton** that is `SdkAutoCloseable` (see aws-sdk-java-v2 source). The SDK v2 migration built several AWS clients with it and then **closed** them:

- `AmazonS3Config.getAccountIDUsingAccessKey` — `StsClient` in try-with-resources (fires once at **startup**, during S3 bean init) — the primary trigger.
- `ReciterFeedbackArticleScorer.uploadJsonFileIntoS3` — `S3Client` in try-with-resources (per scoring call).

Closing any client built with the shared provider shuts down its single IRSA STS (`AssumeRoleWithWebIdentity`) connection pool. Cached credentials mask it for the ~1h IRSA session; at the first refresh, every client — including the long-lived `DynamoDbClient` bean — throws `Connection pool shut down`. This exactly matches the startup+1h death pattern.

## Fix
- **`AwsScoringClients`** (new): shared, application-lifetime `S3Client` and `LambdaClient`, built once and **never closed**. SDK v2 clients are thread-safe and meant to be shared for the app lifetime.
- Reuse the shared S3 client in both scorers' `uploadJsonFileIntoS3` — removes per-call client creation **and** the try-with-resources auto-close.
- Reuse a shared Lambda client in `NeuralNetworkModelArticlesScorer` (previously a new client leaked per scoring call).
- Stop closing the startup `StsClient` in `AmazonS3Config.getAccountIDUsingAccessKey`.

Net: no client that shares the JVM-wide `DefaultCredentialsProvider` is ever closed at runtime, so the IRSA STS pool stays alive. Also removes per-call client/connection-pool leaks in the scoring path.

## Verification
- `mvn -DskipTests compile` on JDK 17 — **BUILD SUCCESS** (277 files).
- Not yet runtime-tested on a live pod (requires building + deploying the image).

## ⚠️ Deployment note
Prod currently runs this branch's image (`611…3dee2863`) rolled out **out-of-band** (the `ReCiter-Production` pipeline watches `master`, which does not have this migration). After merge, a **new image must be built and manually rolled to prod** to stop the hourly recurrence. Until then, prod needs a rolling restart roughly every hour.