### PR TITLE
fix(consumer): Cognito token client hardcoded to us-west-2 → use us-east-1

### DIFF
--- a/src/main/java/reciter/consumer/service/CognitoAuthService.java
+++ b/src/main/java/reciter/consumer/service/CognitoAuthService.java
@@ -80,7 +80,7 @@ public class CognitoAuthService {
     // v2: CognitoIdentityProviderClient replaces AWSCognitoIdentityProvider
     // v2: .builder().region() replaces .withRegion()
     private final CognitoIdentityProviderClient cognitoClient = CognitoIdentityProviderClient.builder()
-            .region(Region.of("us-west-2"))
+            .region(Region.of(AWS_REGION))
             .build();
 
     public String authenticateConsumer(String username, String password) {


### PR DESCRIPTION
## Problem

`reciter-consumer.weill.cornell.edu` `POST /reciter/generate-access-token` returns **HTTP 401** for external consumers (reported by NYP find-a-doctor). The failure is server-side and happens **before** the consumer's credentials are validated.

The error surfaced to the client:
> `User: ...assumed-role/eksctl-reciter-addon-iamserviceaccount-recit-Role1-.../... is not authorized to perform: cognito-idp:AdminInitiateAuth on resource: arn:aws:cognito-idp:us-west-2:665083158573:userpool/us-east-1_WhdgPmkLj because no identity-based policy allows the cognito-idp:AdminInitiateAuth action`

## Root cause

`CognitoAuthService` hardcoded the token client to `us-west-2` during the AWS SDK v1→v2 migration:

```java
private final CognitoIdentityProviderClient cognitoClient = CognitoIdentityProviderClient.builder()
        .region(Region.of("us-west-2"))   // wrong
        .build();
```

But the Cognito user pool (`us-east-1_WhdgPmkLj`) and the IAM grant (`ReciterCognitoClientReader`, scoped to the `us-east-1` pool ARN) are both in **us-east-1**. So `AdminInitiateAuth` is issued against us-west-2 → IAM `AccessDenied` → 401.

`git grep us-west-2` confirms this was the **only** occurrence in `src/main/java`. The sibling `CognitoClientRegistry` client is already correct (`Region.of(awsRegion)`).

## Fix

Reuse the existing `AWS_REGION` field (line 38, `System.getenv("AWS_REGION")` = `us-east-1` in the pods, declared/initialized before the client field), restoring pre-migration behavior:

```java
.region(Region.of(AWS_REGION))
```

## Deploy note

The bug is live in prod image `613...288eb132` (deployed 2026-07-06, from the `MigrationFromJDk11ToAWSCorretto17` line) and present on `development`. Prod runs the Corretto17 image out-of-band, so **prod needs a rebuild/redeploy off whichever branch feeds the prod image** — merging this to `development` alone will not fix prod.