### PR TITLE
fix: deserialize offloaded PubMedArticle on S3 read (large-user empty analysis)

### DIFF
--- a/src/main/java/reciter/database/dynamodb/DynamoDbS3Operations.java
+++ b/src/main/java/reciter/database/dynamodb/DynamoDbS3Operations.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import reciter.engine.analysis.ReCiterFeature;
 import reciter.model.identity.Identity;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -181,12 +180,16 @@ public class DynamoDbS3Operations {
 			try (ResponseInputStream<GetObjectResponse> s3Object = s3.getObject(getObjectRequest)) {
 			    String objectContent = IOUtils.toString(s3Object, StandardCharsets.UTF_8);
 
-			    if (objectClass == ReCiterFeature.class) {
-			        return OBJECT_MAPPER.readValue(objectContent, ReCiterFeature.class);
-			    }
+			    // Identity is stored as an array and returned as a List. Every other
+			    // offloaded type (ReCiterFeature, PubMedArticle, ...) deserializes
+			    // directly to objectClass. The previous code only had explicit
+			    // branches for ReCiterFeature and Identity, so any other type — most
+			    // importantly PubMedArticle — fell through to `return null`, silently
+			    // dropping the offloaded article and NPE-ing the caller.
 			    if (objectClass == Identity.class) {
 			        return Arrays.asList(OBJECT_MAPPER.readValue(objectContent, Identity[].class));
 			    }
+			    return OBJECT_MAPPER.readValue(objectContent, objectClass);
 			} catch (IOException | S3Exception e) {
 			    log.error("Error retrieving object from S3: {}", e.getMessage());
 			}

--- a/src/main/java/reciter/service/dynamo/PubMedServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/PubMedServiceImpl.java
@@ -78,6 +78,14 @@ public class PubMedServiceImpl implements PubMedService {
         	}
         	 if (pubMedArticle == null) continue; // Skip the rest of the loop for this null element
         	pubarticle = pubMedArticle.getPubMedArticle();
+        	// Skip articles whose body couldn't be loaded (e.g. S3 offload object
+        	// missing). Adding a null here would NPE downstream feature generation
+        	// and fail the whole run for one bad article.
+        	if (pubarticle == null) {
+        		log.warn("Skipping pmid {} in findByPmids: article body unavailable (usingS3={})",
+        				pubMedArticle.getPmid(), pubMedArticle.isUsingS3());
+        		continue;
+        	}
             pubMedArticles.add(pubarticle);
         }
         return pubMedArticles;


### PR DESCRIPTION
## Problem

Publication Manager shows **"Unable to load publications data. The page may be temporarily unavailable."** for certain users (haz2005, cmr2006, aae2001, wit2008, aog2001). `feature-generator/by/uid` returns an empty HTTP 200 because the user's `Analysis` DynamoDB row is a 190-byte stub (`usingS3=1`, no payload). Forcing a re-analysis 500s with a `NullPointerException`.

## Root cause

These are large users whose PubMedArticle payloads exceed DynamoDB's 400KB item limit, so they're offloaded to S3 (`usingS3=1`, object at `reciter-dynamodb/PubMedArticle/<pmid>`). The **write path works** (objects exist in S3), but the **read path was never implemented for PubMedArticle**:

`DynamoDbS3Operations.retrieveLargeItem` only had branches for `ReCiterFeature.class` and `Identity.class`. For `PubMedArticle.class` it read the S3 content and then fell through to `return null` — no exception, no log. The null article body then NPEs feature generation, the run aborts, and a stub Analysis row is written.

Confirmed against prod: the offloaded objects are valid `PubMedArticle` JSON (`{medlinecitation, pubmeddata}`); the S3 GET succeeds (no error logged); the value is simply never deserialized.

## Fix

- `retrieveLargeItem`: deserialize to `objectClass` generically, keeping the `Identity` array→List special case. Now handles PubMedArticle (and any future offloaded type). The three types ever passed by callers — Identity, ReCiterFeature, PubMedArticle — all behave correctly; no caller relied on the old null fall-through.
- `PubMedServiceImpl.findByPmids`: skip a null article body instead of adding it to the list, so a genuinely missing offload object degrades to one skipped article rather than failing the whole run.

## Verification

- Compiles clean (`mvn compile`, Java 17).
- Behavioral verification pending: deploy to `reciter-dev` and run `feature-generator/by/uid?uid=haz2005&analysisRefreshFlag=true`. Expected: HTTP 200 with a populated result, `Analysis` row rehydrated (>190 bytes), no `retrieved from the S3 is : null` NPE. Dev and prod share the same DynamoDB + S3 (`reciter-dynamodb`), so a successful dev run also repairs the affected rows.

## Notes

`DynamoDbS3Operations` and `PubMedServiceImpl` are byte-identical on `development` and `MigrationFromJDk11ToAWSCorretto17` (the branch prod runs), so this same fix carries to prod. This is separate from — and orthogonal to — the intermittent NCBI 429 handling in the PubMed retrieval service.