### PR TITLE
fix: guard null abstract element in ArticleTranslator

### DIFF
--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -132,7 +132,7 @@ public class ArticleTranslator {
         		pubmedArticle.getMedlinecitation().getArticle().getPublicationAbstract().getAbstractTexts() != null && !pubmedArticle.getMedlinecitation().getArticle().getPublicationAbstract().getAbstractTexts().isEmpty()) {
 	        String pubmedPublicationAbstract = pubmedArticle.getMedlinecitation().getArticle().getPublicationAbstract().getAbstractTexts()
 	        		.stream()
-	        		.map(pubAbstract -> ((pubAbstract.getAbstractTextLabel() != null)?pubAbstract.getAbstractTextLabel() + ": ":"") + pubAbstract.getAbstractText()).collect(Collectors.joining(" "));
+	        		.map(pubAbstract -> pubAbstract == null ? "" : ((pubAbstract.getAbstractTextLabel() != null)?pubAbstract.getAbstractTextLabel() + ": ":"") + pubAbstract.getAbstractText()).collect(Collectors.joining(" "));
 	        reCiterArticle.setPublicationAbstract(pubmedPublicationAbstract);
         }
         


### PR DESCRIPTION
Follow-up to #678, found during dev verification of haz2005.

## Problem
With the S3-offload read fixed (#678), large users now load their articles and reach `ArticleTranslator.translate`, where a **null element** inside `getPublicationAbstract().getAbstractTexts()` NPEs `pubAbstract.getAbstractTextLabel()` (ArticleTranslator.java:135). The code null-checks the list and the label, but not the list element. This latent bug was previously masked because the run died earlier at the S3 read.

Observed on reciter-dev (image 618):
```
NullPointerException: Cannot invoke "...MedlineCitationArticleAbstractText.getAbstractTextLabel()" because "pubAbstract" is null
  at reciter.algorithm.util.ArticleTranslator.lambda$translate$1(ArticleTranslator.java:135)
```

## Fix
Return `""` for a null element in the abstract-texts map, so the abstract still assembles from the remaining parts. Minimal one-line change; compiles clean (Java 17).

## Verification
Pending redeploy to reciter-dev + re-run `feature-generator/by/uid?uid=haz2005&analysisRefreshFlag=true`.