### PR TITLE
fix: never flag a record S3-backed unless the payload actually landed

### DIFF
--- a/src/main/java/reciter/database/dynamodb/DynamoDbS3Operations.java
+++ b/src/main/java/reciter/database/dynamodb/DynamoDbS3Operations.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import reciter.engine.analysis.ReCiterFeature;
 import reciter.model.identity.Identity;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -60,85 +61,38 @@ public class DynamoDbS3Operations {
 	 * @param object
 	 * @param keyName
 	 */
-	public void saveLargeItem(String bucketName, Object object, String keyName) {
+	public boolean saveLargeItem(String bucketName, Object object, String keyName) {
 		// Skip S3 entirely when client or bucket is unavailable (e.g., standalone
-		// local mode with aws.s3.use=false). The previous code's else branch
-		// dereferenced bucketName.toLowerCase() unconditionally, producing
-		// NullPointerException for any Analysis object large enough to spill
-		// (>400KB DynamoDB item limit). The S3 cache is best-effort; callers
-		// don't depend on it for the API response.
+		// local mode with aws.s3.use=false).
 		if (s3 == null || bucketName == null) {
-			return;
+			return false;
 		}
 
-		if(s3 != null && bucketName != null && !s3ObjectExists(bucketName.toLowerCase(), keyName)) {
-			
-			//AmazonS3Config.createFolder(bucketName, AnalysisOutput.class.getName(), s3);
-			String objectContentString = null;
-			try {
-				objectContentString = OBJECT_MAPPER.writeValueAsString(object);
-			} catch (JsonProcessingException e) {
-				log.error(e.getMessage());
-			}
-			byte[] objectContentBytes;
-			if(objectContentString!=null)
-			{	
-				objectContentBytes = objectContentString.getBytes(StandardCharsets.UTF_8);
-				InputStream fileInputStream = new ByteArrayInputStream(objectContentBytes);
-				PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-				        .bucket(bucketName.toLowerCase())
-				        .key(keyName)
-				        .contentType(CONTENT_TYPE)
-				        .contentLength((long) objectContentBytes.length)
-				        .build();
-	
-				
-	
-				try{
-					s3.putObject(putObjectRequest, RequestBody.fromInputStream(fileInputStream, objectContentBytes.length));
-				} catch(SdkServiceException e) {
-					// The call was transmitted successfully, but Amazon S3 couldn't process 
-		            // it, so it returned an error response.
-					log.error("S3 putObject failed for bucket={} key={}: {}", bucketName, keyName, e.getMessage(), e);
-				}
-			}
-		} else {
-			log.info("Deleting Object from bucket " + bucketName + " with keyName " + keyName);
-			DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
-			        .bucket(bucketName.toLowerCase())
-			        .key(keyName)
-			        .build();
+		byte[] objectContentBytes;
+		try {
+			objectContentBytes = OBJECT_MAPPER.writeValueAsString(object).getBytes(StandardCharsets.UTF_8);
+		} catch (JsonProcessingException e) {
+			log.error("S3 offload failed to serialize key={}: {}", keyName, e.getMessage(), e);
+			return false;
+		}
 
-			s3.deleteObject(deleteObjectRequest);
+		PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+				.bucket(bucketName.toLowerCase())
+				.key(keyName)
+				.contentType(CONTENT_TYPE)
+				.contentLength((long) objectContentBytes.length)
+				.build();
 
-			//s3.deleteObject(bucketName.toLowerCase(), keyName);
-			//Delete the object and insert it again
-			String objectContentString = null;
-			try {
-				objectContentString = OBJECT_MAPPER.writeValueAsString(object);
-			} catch (JsonProcessingException e) {
-				log.error(e.getMessage());
-			}
-			byte[] objectContentBytes;
-			if(objectContentString!=null)
-			{
-				objectContentBytes = objectContentString.getBytes(StandardCharsets.UTF_8);
-				InputStream fileInputStream = new ByteArrayInputStream(objectContentBytes);
-				PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-				        .bucket(bucketName.toLowerCase())
-				        .key(keyName)
-				        .contentType(CONTENT_TYPE)
-				        .contentLength((long) objectContentBytes.length)
-				        .build();
-				try{
-					s3.putObject(putObjectRequest, RequestBody.fromInputStream(fileInputStream, objectContentBytes.length));
-				}
-				catch(SdkServiceException e) {
-					// The call was transmitted successfully, but Amazon S3 couldn't process 
-		            // it, so it returned an error response.
-					log.error("S3 putObject (replace) failed for bucket={} key={}: {}", bucketName, keyName, e.getMessage(), e);
-				}
-			}
+		try {
+			// putObject overwrites an existing key in place. The previous code deleted the
+			// object first and only then re-uploaded, so a failed re-upload destroyed the
+			// payload while the DynamoDB row still claimed the record was S3-backed.
+			s3.putObject(putObjectRequest,
+					RequestBody.fromInputStream(new ByteArrayInputStream(objectContentBytes), objectContentBytes.length));
+			return true;
+		} catch (SdkException e) {
+			log.error("S3 putObject failed for bucket={} key={}: {}", bucketName, keyName, e.getMessage(), e);
+			return false;
 		}
 	}
 	

--- a/src/main/java/reciter/service/dynamo/AnalysisServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/AnalysisServiceImpl.java
@@ -44,7 +44,13 @@ public class AnalysisServiceImpl implements AnalysisService{
 		} catch(DynamoDbException addbe) {
 			if(isS3Use && !isDynamoDbLocal) {
 				log.info("Storing item in s3 since it item size exceeds more than 400kb");
-				ddbs3.saveLargeItem(AmazonS3Config.BUCKET_NAME, analysis.getReCiterFeature(), AnalysisOutput.class.getSimpleName() + "/" + analysis.getUid());
+				if(!ddbs3.saveLargeItem(AmazonS3Config.BUCKET_NAME, analysis.getReCiterFeature(), AnalysisOutput.class.getSimpleName() + "/" + analysis.getUid())) {
+					// Saving the row with the S3 flag set after a failed upload leaves a record
+					// pointing at a payload that does not exist, which reads back as an empty
+					// analysis forever. Leave the previous record in place and fail loudly.
+					throw new IllegalStateException("S3 offload failed for uid " + analysis.getUid()
+							+ "; previous Analysis record left intact", addbe);
+				}
 				analysis.setReCiterFeature(null);
 				analysis.setUsingS3(true);
 				analysisOutputRepository.save(analysis);
@@ -71,10 +77,17 @@ public class AnalysisServiceImpl implements AnalysisService{
 				&&
 				analysisOutput.isUsingS3()) {
 			log.info("Retreving analysis from s3 for {} " , uid);
-			
+
 			ReCiterFeature reCiterFeature = (ReCiterFeature) ddbs3.retrieveLargeItem(AmazonS3Config.BUCKET_NAME, AnalysisOutput.class.getSimpleName() + "/" + uid.trim(), ReCiterFeature.class);
+			if(reCiterFeature == null) {
+				// The row says the payload lives in S3 but nothing came back. Callers see an
+				// analysis with no features, which is indistinguishable from "this person has
+				// no articles" -- name it here so it shows up as an error rather than silence.
+				log.error("Analysis for uid {} is flagged S3-backed but no payload was read from bucket {}; "
+						+ "returning a record with no features", uid, AmazonS3Config.BUCKET_NAME);
+			}
 			analysisOutput.setReCiterFeature(reCiterFeature);
-		} 
+		}
 		return analysisOutput;
 	}
 

--- a/src/main/java/reciter/service/dynamo/PubMedServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/PubMedServiceImpl.java
@@ -115,7 +115,11 @@ public class PubMedServiceImpl implements PubMedService {
 	            if (sizeInBytes > 400 * 1024 && isS3Use && !isDynamoDbLocal) 
 	            {
 	         		log.info("Storing item in s3 since it item size exceeds more than 400kb PMID: "+article.getPmid() + " and Size :" + sizeInBytes/1024 +" KB");
-					ddbs3.saveLargeItem(AmazonS3Config.BUCKET_NAME, article.getPubMedArticle(), PubMedArticle.class.getSimpleName() + "/" + article.getPmid());
+					if(!ddbs3.saveLargeItem(AmazonS3Config.BUCKET_NAME, article.getPubMedArticle(), PubMedArticle.class.getSimpleName() + "/" + article.getPmid())) {
+						// Same reasoning as AnalysisServiceImpl.save: never flag the row S3-backed
+						// unless the payload actually landed, or the article body is lost.
+						throw new IllegalStateException("S3 offload failed for pmid " + article.getPmid());
+					}
 					article.setPubMedArticle(null);
 					article.setUsingS3(true);
 	            } else if(isDynamoDbLocal){

--- a/src/test/java/reciter/database/dynamodb/DynamoDbS3OperationsTest.java
+++ b/src/test/java/reciter/database/dynamodb/DynamoDbS3OperationsTest.java
@@ -1,0 +1,69 @@
+package reciter.database.dynamodb;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+/**
+ * Guards the two ways an S3 offload used to corrupt a record:
+ *   1. the payload was deleted before the re-upload, so a failed upload destroyed it;
+ *   2. the failure was swallowed, so callers flagged the row S3-backed with nothing behind it.
+ */
+public class DynamoDbS3OperationsTest {
+
+	@Mock
+	private S3Client s3;
+
+	private DynamoDbS3Operations ddbs3;
+
+	@BeforeEach
+	public void setUp() {
+		MockitoAnnotations.openMocks(this);
+		ddbs3 = new DynamoDbS3Operations();
+		ReflectionTestUtils.setField(ddbs3, "s3", s3);
+	}
+
+	@Test
+	public void saveLargeItem_reportsSuccess_andNeverDeletesFirst() {
+		when(s3.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+				.thenReturn(PutObjectResponse.builder().build());
+
+		assertTrue(ddbs3.saveLargeItem("reciter-dynamodb", "payload", "AnalysisOutput/abc1234"));
+
+		// An overwriting putObject is sufficient. Deleting first opens a window where a
+		// failed re-upload leaves the record with no payload at all.
+		verify(s3, never()).deleteObject(any(DeleteObjectRequest.class));
+	}
+
+	@Test
+	public void saveLargeItem_reportsFailure_whenUploadFails() {
+		when(s3.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+				.thenThrow(SdkClientException.create("connection reset"));
+
+		// Must be false: callers use this to decide whether to set the S3 flag on the row.
+		assertFalse(ddbs3.saveLargeItem("reciter-dynamodb", "payload", "AnalysisOutput/abc1234"));
+	}
+
+	@Test
+	public void saveLargeItem_reportsFailure_whenS3Unavailable() {
+		ReflectionTestUtils.setField(ddbs3, "s3", null);
+
+		assertFalse(ddbs3.saveLargeItem("reciter-dynamodb", "payload", "AnalysisOutput/abc1234"));
+	}
+}


### PR DESCRIPTION
## Why

`mog4005` served two-week-old publication data for 14 consecutive nights and nobody knew. Chasing that turned up a set of related defects in the S3 offload layer, which only runs for the ~2,500 largest users — which is exactly why they went unnoticed.

Today the `Analysis` table contains:
- **6 rows** flagged S3-backed with **no payload behind them** (`_lal2055`, `_pac2224`, `fwo9003`, `lmr9021`, `maf2086`, `pag2026`) — permanently empty records.
- **1,558 orphaned S3 payloads**, 1,288 of them belonging to records that shrank back inline.

## What was wrong

**1. `saveLargeItem` deleted before it re-uploaded.** When the key already existed it issued a `deleteObject` and *then* a `putObject`. If the put failed, the payload that was already there was gone — and the row still claimed the record was S3-backed. `putObject` overwrites in place, so the delete only ever created a window to lose data.

**2. Upload failures were swallowed.** `putObject` was wrapped in a `catch(SdkServiceException)` that logged and moved on, and `saveLargeItem` returned `void`. So `AnalysisServiceImpl.save` and `PubMedServiceImpl.offloadLargeFields` went on to `setUsingS3(true)` and persist the row whether or not the payload landed.

The result reads back as a record with **no features**, which is indistinguishable from *"this person has no articles."* No exception, no alarm — it just quietly serves stale or empty data.

## What this changes

- `saveLargeItem` returns whether the payload was written, and overwrites in place rather than deleting first. The duplicated write branch collapses (81 lines → 34).
- It now catches `SdkException` rather than `SdkServiceException`, so client-side and network failures also count as failures instead of passing as success.
- `AnalysisServiceImpl.save` and `PubMedServiceImpl.offloadLargeFields` leave the previous record intact and fail loudly when the upload did not happen, rather than persisting a row that points at nothing.
- `findByUid` logs an error when a row is flagged S3-backed but no payload comes back, instead of returning an empty record in silence.

## Behaviour change worth flagging

A transient S3 failure now surfaces as an error for that uid instead of "succeeding" by writing a broken record. That is the intended trade: a loud failure that keeps the last good data beats a silent one that destroys it.

## Deliberately not in scope

- **The `usingS3` vs `s3StorageFlag` attribute split.** ~25,000 rows carry the legacy name and dynamodb-model `v3.0.4` currently *writes* it, so the split is still widening. That needs a writer decision plus a one-shot migration, separately.
- **Sweeping the 1,558 orphaned payloads** and repairing the 6 dead rows — data cleanup, not code.
- **`AnalysisServiceImpl.save` detects >400KB by catching `DynamoDbException`** rather than measuring the item, so any DynamoDB error routes into the S3 branch. `PubMedServiceImpl` already measures the size directly; worth aligning, but it is a behaviour change I did not want to bundle with a data-integrity fix.

## Testing

- Full suite: **183 tests, 0 failures** (`mvn test`).
- New `DynamoDbS3OperationsTest` covers the two regressions: the upload failure must report `false` so callers never set the flag, and the write path must never `deleteObject` first.

Needs a port to `MigrationFromJDk11ToAWSCorretto17` (what prod runs) — the files are identical on both branches.