### PR TITLE
fix(retrieval): widen ONLY_NEWLY_ADDED window to a configurable rolling lookback (#689)

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -155,6 +155,16 @@ public class ReCiterController {
     @Value("${reciter.feature.generator.keywordCountMax}")
     private double keywordsMax;
 
+    // Rolling lookback for ONLY_NEWLY_ADDED_PUBLICATIONS retrieval. A transient PubMed
+    // failure (429 / HTML error) that returns 0 articles still advances the retrievalDate
+    // watermark, so a fixed 1-day window would slide past the missed day forever. Re-scanning
+    // a wider [EDAT] buffer each run lets the next run pick up anything a failed run dropped.
+    // Queries are author-name-scoped, so a wider date filter adds only a few PMIDs — no extra
+    // requests, no approach to the count thresholds. Gaps longer than this window are covered
+    // by the periodic ALL_PUBLICATIONS sweep + error-aware watermark tracked in #689.
+    @Value("${reciter.retrieval.onlyNewlyAdded.lookbackDays:30}")
+    private int onlyNewlyAddedLookbackDays;
+
     @Value("${reciter.feature.generator.group.uids.maxCount}")
     private int uidsMaxCount;
     
@@ -443,7 +453,7 @@ public class ReCiterController {
                     identities.add(identity);
             	eSearchResult = eSearchResultService.findByUid(uid.trim()) ;
             	if (eSearchResult != null) {
-            		startDate = LocalDate.parse(new SimpleDateFormat("yyyy-MM-dd").format(Date.from(eSearchResult.getRetrievalDate()))).minusDays(1);
+            		startDate = LocalDate.parse(new SimpleDateFormat("yyyy-MM-dd").format(Date.from(eSearchResult.getRetrievalDate()))).minusDays(onlyNewlyAddedLookbackDays);
             	} else {
             		return ResponseEntity.status(HttpStatus.NOT_FOUND).body("The uid supplied failed to retrieve articles. Try running with ALL_PUBLICATIONS refreshFlag");
             	}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -363,6 +363,13 @@ reciter.feature.generator.keywordCountMax=10
 # Maximum UIDs allowed in the group feature-generator endpoint
 reciter.feature.generator.group.uids.maxCount=100
 
+# Rolling lookback (days) for ONLY_NEWLY_ADDED_PUBLICATIONS retrieval. The incremental
+# window starts this many days before the stored retrievalDate, so an article missed during
+# a transient PubMed failure is re-attempted on later runs instead of being lost permanently.
+# Queries are author-scoped, so a wider window adds no requests and does not approach the
+# retrieval count thresholds. Increase for cohorts refreshed less often than daily. See #689.
+reciter.retrieval.onlyNewlyAdded.lookbackDays=30
+
 # Mandatory identity fields for DynamoDB insert/update
 identity.dynamodb.mandatory.fields=uid,firstName,firstInitial,lastName
 # Bump this constant whenever reciter-article-model or reciter-dynamodb-model


### PR DESCRIPTION
## What

Widen the `ONLY_NEWLY_ADDED_PUBLICATIONS` incremental retrieval window from a fixed 1-day lower bound to a configurable rolling lookback (`reciter.retrieval.onlyNewlyAdded.lookbackDays`, default **30**).

Fixes the root cause in #689: transient PubMed failures becoming **permanent** `person_article` gaps.

## Why

`ReCiterController.retrieveArticlesByUid` computed the incremental window as `[retrievalDate − 1 day, open-ended]`. But:

- A PubMed 429 / HTML-error page is swallowed and returns **0 articles** (`AbstractRetrievalStrategy`).
- The `retrievalDate` watermark advances to `now` **even on a 0-article run** (`AbstractReCiterRetrievalEngine.savePubMedArticles`).

So an article indexed on a day whose run got rate-limited falls outside every future 1-day window → it never reaches `Analysis`/`person_article` until a full `ALL_PUBLICATIONS` re-scan. Live evidence: `sri9003` frozen at 2026-05-28; `ALL_PUBLICATIONS` recovered `42413043` (EDAT 07-07) and `42427057` (EDAT 07-10, scores 100). 110× 429 + 168× HTML errors in the last 24h on `reciter-pubmed-prod`.

With a rolling buffer, any article missed during a transient failure is re-attempted on subsequent runs.

## Why it's safe

Every retrieval strategy query is author-name-scoped (`.author(true, false, identityNames)`), so widening the `[EDAT]` date filter returns only that author's handful of extra PMIDs:

- **No extra PubMed requests** — same query count, just a wider date range (so no added 429 pressure).
- **No threshold interaction** — an author-scoped window stays far below `DEFAULT_THRESHOLD=2000` / `STRICT_THRESHOLD=1000`.
- **Idempotent** — re-fetched articles are saved by PMID; the `#640-B` per-strategy `ESearchPmid` upsert prevents item growth.

## Changes

- `ReCiterController.java` — new `@Value` field `onlyNewlyAddedLookbackDays`; use it in `.minusDays(...)`.
- `application.properties` — documented `reciter.retrieval.onlyNewlyAdded.lookbackDays=30`.

## Scope / follow-ups (tracked in #689)

This is the immediate, low-risk mitigation. It fully covers the fully-failed-run case; it does **not** by itself cover a *partial* failure (one strategy rate-limited among several) beyond the lookback window. Deeper hardening tracked in #689:

- Error-aware watermark (don't advance `retrievalDate` when a strategy errored).
- Periodic `ALL_PUBLICATIONS` safety-net sweep (also covers the non-FT cohort's monthly cadence).
- PubMed-tool 429 backoff + host fix: wcmc-its/ReCiter-PubMed-Retrieval-Tool#166.

## Testing

- Change is config-driven; default preserves a strict superset of current behavior (`minusDays(30) ⊇ minusDays(1)`).
- Recommend smoke-test on `reciter-dev`: run `feature-generator/by/uid?uid=sri9003&retrievalRefreshFlag=ONLY_NEWLY_ADDED_PUBLICATIONS` and confirm the July papers land without a full `ALL_PUBLICATIONS`.

## Prod note

`ReCiterController.java:446` is identical on `development` and the deployed `MigrationFromJDk11ToAWSCorretto17` branch that prod actually runs, so this cherry-picks/merges cleanly for the prod line.
