### PR TITLE
fix(retrieval): roll retrievalDate watermark back on PubMed failures (#689)

### DIFF
--- a/src/main/java/reciter/pubmed/retriever/PubMedArticleRetriever.java
+++ b/src/main/java/reciter/pubmed/retriever/PubMedArticleRetriever.java
@@ -53,6 +53,9 @@ public class PubMedArticleRetriever {
             log.error("Unable to retrieve via external REST api=[" + nodeUrl + "]", e);
         }
         if (responseEntity == null) {
+            // Fetch failed (tool 500 / NCBI 429). Flag the run so the engine rolls the
+            // retrievalDate watermark back instead of treating this as "no articles". #689
+            reciter.xml.retriever.pubmed.RetrievalErrorTracker.markError();
             return Collections.emptyList();
         }
         PubMedArticle[] pubMedArticles = responseEntity.getBody();

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -60,6 +60,7 @@ import reciter.utils.AuthorNameSanitizationUtils;
 import reciter.utils.ReCiterStringUtil;
 import reciter.xml.retriever.pubmed.AbstractRetrievalStrategy.RetrievalResult;
 import reciter.xml.retriever.pubmed.PubMedQueryType;
+import reciter.xml.retriever.pubmed.RetrievalErrorTracker;
 
 @Component("aliasReCiterRetrievalEngine")
 public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine {
@@ -490,6 +491,13 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		Set<Long> backfillPmids = new HashSet<>(pmidProvenanceService.findPmidsByUidAndStrategy(uid, "BACKFILL_FROM_ESEARCHRESULT"));
 		Set<Long> existingPmids = new HashSet<>();
 		reciter.database.dynamodb.model.ESearchResult existingESearch = eSearchResultService.findByUid(uid);
+		// Watermark guard (#689): remember where retrievalDate stood before this run and clear the
+		// per-run error flag. savePubMedArticles advances retrievalDate to now() as strategies run;
+		// if any strategy's PubMed call fails below, we roll it back at the end so the next
+		// ONLY_NEWLY_ADDED run re-covers this window instead of skipping past a silently-missed day.
+		java.time.Instant preRunRetrievalDate = existingESearch != null ? existingESearch.getRetrievalDate() : null;
+		RetrievalErrorTracker.reset();
+		try { // body left un-reindented to keep the diff reviewable; the finally rolls the watermark back
 		if (existingESearch != null && existingESearch.getESearchPmids() != null) {
 			for (reciter.database.dynamodb.model.ESearchPmid esp : existingESearch.getESearchPmids()) {
 				if (esp.getPmids() != null) {
@@ -780,7 +788,27 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			scopusService.save(scopusArticlesByDoi);
 		}
 		slf4jLogger.info("Finished retrieval for uid=[{}], uniquePmids={}", identity.getUid(), uniquePmids.size());
-		
+		} finally {
+			// Watermark guard (#689): ALWAYS runs — even if a strategy threw after savePubMedArticles
+			// already advanced retrievalDate — so a failed run never leaves the watermark skipped past
+			// a silently-dropped window. Only rolls back when a prior watermark existed; ALL_PUBLICATIONS
+			// deletes the ESearchResult first, so preRunRetrievalDate is null there and nothing rolls back.
+			// The rollback is self-guarded so a DynamoDB hiccup here cannot mask the original exception.
+			if (RetrievalErrorTracker.hadError() && preRunRetrievalDate != null) {
+				try {
+					reciter.database.dynamodb.model.ESearchResult esr = eSearchResultService.findByUid(uid);
+					if (esr != null) {
+						esr.setRetrievalDate(preRunRetrievalDate);
+						eSearchResultService.save(esr);
+						slf4jLogger.warn("Retrieval for uid=[{}] hit PubMed failures; rolled retrievalDate back to [{}] "
+								+ "so the next ONLY_NEWLY_ADDED run re-covers this window.", uid, preRunRetrievalDate);
+					}
+				} catch (Exception rollbackEx) {
+					slf4jLogger.error("Failed to roll retrievalDate back for uid=[{}]", uid, rollbackEx);
+				}
+			}
+		}
+
 	}
 	
 	

--- a/src/main/java/reciter/xml/retriever/pubmed/AbstractRetrievalStrategy.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/AbstractRetrievalStrategy.java
@@ -284,6 +284,9 @@ public abstract class AbstractRetrievalStrategy implements RetrievalStrategy {
 			slf4jLogger.error("Unable to retrieve via external REST api=[" + nodeUrl + "]", e);
 		}
 		if (responseEntity == null) {
+			// Count query failed (tool 500 / NCBI error). Flag the run so the engine rolls the
+			// retrievalDate watermark back instead of treating this as a legitimate "0 results". #689
+			RetrievalErrorTracker.markError();
 			return 0;
 		}
 		int results = responseEntity.getBody();

--- a/src/main/java/reciter/xml/retriever/pubmed/RetrievalErrorTracker.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/RetrievalErrorTracker.java
@@ -1,0 +1,37 @@
+package reciter.xml.retriever.pubmed;
+
+/**
+ * Thread-scoped "this retrieval run hit a PubMed/REST failure" flag.
+ *
+ * ONLY_NEWLY_ADDED retrieval advances the ESearchResult.retrievalDate watermark on every run.
+ * When a PubMed call is swallowed (tool 500 / NCBI 429 → empty result), the run looks like
+ * "no new papers" and the watermark still advances, so the missed window is never re-scanned
+ * and the article is lost until a full ALL_PUBLICATIONS re-scan (see ReCiter#689).
+ *
+ * Retrieval for a single uid runs synchronously on one AsyncRetrievalEngine thread, so a
+ * ThreadLocal cleanly scopes the flag to that run: the engine calls {@link #reset()} before a
+ * run and checks {@link #hadError()} after, rolling the watermark back on failure. Fail-safe —
+ * a stale or unset flag at worst triggers an extra (idempotent) re-scan, never data loss.
+ */
+public final class RetrievalErrorTracker {
+
+    private static final ThreadLocal<Boolean> ERROR = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    private RetrievalErrorTracker() {
+    }
+
+    /** Clear the flag at the start of a retrieval run (also guards against thread reuse). */
+    public static void reset() {
+        ERROR.set(Boolean.FALSE);
+    }
+
+    /** Record that a PubMed/REST call failed during the current run. */
+    public static void markError() {
+        ERROR.set(Boolean.TRUE);
+    }
+
+    /** True if any PubMed/REST call failed since the last {@link #reset()} on this thread. */
+    public static boolean hadError() {
+        return ERROR.get();
+    }
+}

--- a/src/test/java/reciter/xml/retriever/pubmed/RetrievalErrorTrackerTest.java
+++ b/src/test/java/reciter/xml/retriever/pubmed/RetrievalErrorTrackerTest.java
@@ -1,0 +1,38 @@
+package reciter.xml.retriever.pubmed;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+class RetrievalErrorTrackerTest {
+
+    @Test
+    void resetClearsFlagAndMarkErrorSetsIt() {
+        RetrievalErrorTracker.reset();
+        assertFalse(RetrievalErrorTracker.hadError());
+
+        RetrievalErrorTracker.markError();
+        assertTrue(RetrievalErrorTracker.hadError());
+
+        RetrievalErrorTracker.reset();
+        assertFalse(RetrievalErrorTracker.hadError());
+    }
+
+    /** Each uid retrieval runs on its own thread — one run's failure must not leak to another. */
+    @Test
+    void errorFlagIsThreadScoped() throws InterruptedException {
+        RetrievalErrorTracker.reset();
+        RetrievalErrorTracker.markError();
+        assertTrue(RetrievalErrorTracker.hadError());
+
+        AtomicBoolean otherThreadSawError = new AtomicBoolean(true);
+        Thread other = new Thread(() -> otherThreadSawError.set(RetrievalErrorTracker.hadError()));
+        other.start();
+        other.join();
+
+        assertFalse(otherThreadSawError.get(), "a different thread must not see another run's error flag");
+    }
+}


### PR DESCRIPTION
Part of #689. Pairs with the PubMed-tool throttle (wcmc-its/ReCiter-PubMed-Retrieval-Tool#167).

## What

Stop `ONLY_NEWLY_ADDED_PUBLICATIONS` retrieval from advancing the `retrievalDate` watermark on a run that hit a PubMed failure — so a swallowed 429 / tool-500 no longer turns into a **permanent** gap.

## Why

`retrieveDataByDateRange` queries the window `[retrievalDate − N, today]`, and `savePubMedArticles` advances `retrievalDate` to `now()` as strategies run. When a PubMed call is swallowed (returns 0 / empty), the run looks like "no new papers" and the watermark still advances — so an article indexed on a rate-limited day falls outside every future window and is lost until a full `ALL_PUBLICATIONS` re-scan. This is the sri9003 freeze (frozen at 2026-05-28; `ALL_PUBLICATIONS` recovered the July papers).

## How

- **`RetrievalErrorTracker`** — a thread-scoped (`ThreadLocal`) "this run hit a PubMed failure" flag. Retrieval for one uid runs synchronously on a single `AsyncRetrievalEngine` thread, so the flag is cleanly scoped to the run.
- The two swallow points call `markError()` when a REST call fails: `AbstractRetrievalStrategy.getNumberOfResults` (count) and `PubMedArticleRetriever.retrievePubMed` (fetch), both on `responseEntity == null`. (With the paired tool PR, the count endpoint now returns 500 on an NCBI error page instead of `0`, so this fires on NCBI-side failures too.)
- **`AliasReCiterRetrievalEngine.retrieveDataByDateRange`** captures `preRunRetrievalDate` and `reset()`s the flag at the start; in a **`finally`** it rolls `retrievalDate` back to the pre-run value when the run errored. `ALL_PUBLICATIONS` deletes the `ESearchResult` first, so `preRunRetrievalDate` is null there and nothing rolls back.

Fail-safe: a stale/unset flag at worst causes an extra idempotent re-scan, never data loss. The rollback is in `finally` (survives a mid-run exception) and self-guarded (a DynamoDB hiccup there can't mask the original exception).

## Adversarial review

This diff went through a multi-agent adversarial review before opening. Confirmed findings were applied:
- **Rollback moved into `finally`** (was plain end-of-method code — an exception after a strategy advanced the watermark would have skipped it).
- Rollback self-guarded so it can't mask the original exception.
- The count-path swallow (tool returns 200-with-0 on a hidden 429) is addressed in the paired tool PR by surfacing a 500, which makes `markError` fire here.

## Testing

- `mvn test -Dtest=RetrievalErrorTrackerTest` → **BUILD SUCCESS, 2/2** (incl. a thread-scoping isolation test — one uid's failure must not leak to another).
- Whole module compiles.
- Smoke-test suggestion on `reciter-dev`: point PUBMED_SERVICE at an unreachable host, run `feature-generator/by/uid?...&retrievalRefreshFlag=ONLY_NEWLY_ADDED_PUBLICATIONS`, confirm the log shows the watermark rolled back and `retrievalDate` is unchanged in DynamoDB.

## Notes

- `development`-based per the ReCiter workflow. The touched lines are identical on the deployed `MigrationFromJDk11ToAWSCorretto17` prod branch, so it ports cleanly.
- Independently safe from the tool PR (composes with it; no bad interaction if only one is deployed).
