### PR TITLE
fix(goldstandard): atomic optimistic-locked accept/reject to stop lost updates

### DIFF
--- a/src/main/java/reciter/database/dynamodb/repository/DynamoDbGoldStandardRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/DynamoDbGoldStandardRepository.java
@@ -3,14 +3,19 @@ package reciter.database.dynamodb.repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
 import reciter.database.dynamodb.model.GoldStandard;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 
 @Repository
 public class DynamoDbGoldStandardRepository {
@@ -24,6 +29,71 @@ public class DynamoDbGoldStandardRepository {
 
 	public void save(GoldStandard goldStandard) {
 		goldStandardTable.putItem(goldStandard);
+	}
+
+	/**
+	 * Optimistic-concurrency persist: conditionally write the whole GoldStandard item only
+	 * if the stored knownpmids / rejectedpmids still equal the pre-image the caller read and
+	 * merged against. Guards the interactive single-accept path against lost updates when
+	 * multiple replicas do a read-modify-write on the same item concurrently.
+	 *
+	 * @param expectedKnown    the knownpmids list as it was read (the merge pre-image); null
+	 *                         means the attribute was absent
+	 * @param expectedRejected the rejectedpmids list as it was read; null means absent
+	 * @return {@code true} if the conditional write committed, {@code false} if another writer
+	 *         changed the item first (caller should re-read, re-merge and retry)
+	 */
+	public boolean saveIfUnchanged(GoldStandard goldStandard, List<Long> expectedKnown, List<Long> expectedRejected) {
+		try {
+			goldStandardTable.putItem(PutItemEnhancedRequest.builder(GoldStandard.class)
+					.item(goldStandard)
+					.conditionExpression(Expression.builder()
+							.expression("(attribute_not_exists(knownpmids) OR knownpmids = :ek) AND (attribute_not_exists(rejectedpmids) OR rejectedpmids = :er)")
+							.putExpressionValue(":ek", listAv(expectedKnown))
+							.putExpressionValue(":er", listAv(expectedRejected))
+							.build())
+					.build());
+			return true;
+		} catch (ConditionalCheckFailedException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Conditional create: write the item only if no GoldStandard already exists for this uid.
+	 * Guards the create path so a concurrent create from another replica is not clobbered.
+	 *
+	 * @return {@code true} if the create committed, {@code false} if an item already existed
+	 *         (caller should re-read and merge instead)
+	 */
+	public boolean saveIfAbsent(GoldStandard goldStandard) {
+		try {
+			goldStandardTable.putItem(PutItemEnhancedRequest.builder(GoldStandard.class)
+					.item(goldStandard)
+					.conditionExpression(Expression.builder()
+							.expression("attribute_not_exists(uid)")
+							.build())
+					.build());
+			return true;
+		} catch (ConditionalCheckFailedException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Build a DynamoDB list-of-number AttributeValue for a pmid list, to compare against the
+	 * stored knownpmids / rejectedpmids attributes. A null list is treated as an empty list;
+	 * the absent-attribute case is handled separately by the {@code attribute_not_exists(...)}
+	 * branch of the condition expression.
+	 */
+	private static AttributeValue listAv(List<Long> pmids) {
+		return AttributeValue.builder()
+				.l(pmids == null
+						? List.of()
+						: pmids.stream()
+								.map(p -> AttributeValue.builder().n(String.valueOf(p)).build())
+								.collect(Collectors.toList()))
+				.build();
 	}
 
 	public void saveAll(List<GoldStandard> goldStandards) {

--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -38,6 +39,8 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 
     private static final Logger log = LoggerFactory.getLogger(DynamoDbGoldStandardService.class);
     private static final String PM_MANUAL_STRATEGY = "PublicationManagerManual";
+    // Bounded optimistic-concurrency retries for the contended single-accept path.
+    private static final int MAX_ATTEMPTS = 8;
 
     private final DynamoDbGoldStandardRepository dynamoDbGoldStandardRepository;
     private final ESearchResultService eSearchResultService;
@@ -76,24 +79,53 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     	String strategy = (provenanceSource != null && !provenanceSource.isBlank())
     			? provenanceSource : PM_MANUAL_STRATEGY;
 
-    	// Capture incoming PMIDs before merge logic mutates them
+    	// Capture incoming request state before merge logic mutates it. Retries re-merge
+    	// from this clean slate so the read-merge-write is idempotent across attempts.
     	List<Long> incomingAcceptedPmids = (goldStandard.getKnownPmids() != null)
     			? new ArrayList<>(goldStandard.getKnownPmids()) : Collections.emptyList();
     	List<Long> incomingRejectedPmids = (goldStandard.getRejectedPmids() != null)
     			? new ArrayList<>(goldStandard.getRejectedPmids()) : Collections.emptyList();
+    	List<GoldStandardAuditLog> incomingAudit = (goldStandard.getAuditLog() == null)
+    			? null : new ArrayList<>(goldStandard.getAuditLog());
 
     	if(goldStandardUpdateFlag == GoldStandardUpdateFlag.REFRESH) {
     		dynamoDbGoldStandardRepository.save(goldStandard);
-    	} else {
+    		return;
+    	}
+
+    	// Optimistic-concurrency retry loop: read -> merge -> conditional write. On a
+    	// ConditionalCheckFailedException another replica committed first; re-read, re-merge
+    	// and retry. Side-effect writes (FeedbackLog / ArticleProvenance / PmidProvenance) are
+    	// deferred until AFTER the item durably commits so retries never duplicate them.
+    	boolean committed = false;
+    	List<Long> committedExistingAccepted = Collections.emptyList();
+    	List<Long> committedExistingRejected = Collections.emptyList();
+    	for (int attempt = 1; attempt <= MAX_ATTEMPTS && !committed; attempt++) {
+    		// Reset the request object to the incoming state so each attempt merges idempotently.
+    		goldStandard.setKnownPmids(new ArrayList<>(incomingAcceptedPmids));
+    		goldStandard.setRejectedPmids(new ArrayList<>(incomingRejectedPmids));
+    		goldStandard.setAuditLog(incomingAudit == null ? null : new ArrayList<>(incomingAudit));
+
     		GoldStandard goldStandardDdb = findByUid(goldStandard.getUid());
     		if(goldStandardDdb == null) {
-    			dynamoDbGoldStandardRepository.save(goldStandard);
-    		} else {
-    			List<Long> acceptedPmids = goldStandardDdb.getKnownPmids();
-    			List<Long> rejectedPmids = goldStandardDdb.getRejectedPmids();
-    			// Snapshot existing lists before merge mutates them (for audit log diff)
-    			List<Long> existingAccepted = (acceptedPmids != null) ? new ArrayList<>(acceptedPmids) : Collections.emptyList();
-    			List<Long> existingRejected = (rejectedPmids != null) ? new ArrayList<>(rejectedPmids) : Collections.emptyList();
+    			// Create path: conditional on absence so a concurrent create is not clobbered.
+    			// If another writer created it first, loop back to find + merge.
+    			if(dynamoDbGoldStandardRepository.saveIfAbsent(goldStandard)) {
+    				committed = true;
+    				committedExistingAccepted = Collections.emptyList();
+    				committedExistingRejected = Collections.emptyList();
+    			}
+    			continue;
+    		}
+    		List<Long> acceptedPmids = goldStandardDdb.getKnownPmids();
+    		List<Long> rejectedPmids = goldStandardDdb.getRejectedPmids();
+    		// Pre-image of the stored lists for the conditional write; null => attribute absent
+    		// (handled by the attribute_not_exists branch of the condition expression).
+    		List<Long> preKnown = (acceptedPmids != null) ? new ArrayList<>(acceptedPmids) : null;
+    		List<Long> preRejected = (rejectedPmids != null) ? new ArrayList<>(rejectedPmids) : null;
+    		// Snapshot existing lists before merge mutates them (for audit log diff)
+    		List<Long> existingAccepted = (acceptedPmids != null) ? new ArrayList<>(acceptedPmids) : Collections.emptyList();
+    		List<Long> existingRejected = (rejectedPmids != null) ? new ArrayList<>(rejectedPmids) : Collections.emptyList();
     			if(goldStandardUpdateFlag == GoldStandardUpdateFlag.DELETE) {
     				//This portion deals with cases when deleting a pmid from GoldStandard it will delete it from eSearchResult as well if it exists
     				ESearchResult eSearchResult = eSearchResultService.findByUid(goldStandard.getUid());
@@ -222,17 +254,36 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     					auditLog.addAll(newEntries);
     					goldStandard.setAuditLog(auditLog);
     				}
-    				// Phase 33-02: FeedbackLog rows + ArticleProvenance D-11/D-13 transitions
-    				// for the diff. Inside the same UPDATE branch where existingAccepted/Rejected
-    				// are in scope.
-    				recordFeedbackLogAndArticleProvenance(
-    						goldStandard.getUid(),
-    						incomingAcceptedPmids, incomingRejectedPmids,
-    						existingAccepted, existingRejected,
-    						entryPath,curatedBy);
     			}
-    			dynamoDbGoldStandardRepository.save(goldStandard);
+    			// Conditional persist guarded on the pre-image of knownpmids/rejectedpmids.
+    			// false => another replica committed first: back off briefly and retry.
+    			if(dynamoDbGoldStandardRepository.saveIfUnchanged(goldStandard, preKnown, preRejected)) {
+    				committed = true;
+    				committedExistingAccepted = existingAccepted;
+    				committedExistingRejected = existingRejected;
+    			} else {
+    				try {
+    					Thread.sleep(20 + ThreadLocalRandom.current().nextInt(60));
+    				} catch (InterruptedException ie) {
+    					Thread.currentThread().interrupt();
+    					throw new RuntimeException("Interrupted while retrying GoldStandard update for uid=" + goldStandard.getUid(), ie);
+    				}
+    			}
     		}
+
+    	if (!committed) {
+    		throw new RuntimeException("GoldStandard update contended after " + MAX_ATTEMPTS + " attempts for uid=" + goldStandard.getUid());
+    	}
+
+    	// Side-effect writes run once, AFTER the item is durably committed, using the
+    	// existing-state snapshot from the attempt that actually committed so the diff
+    	// reflects the true transition. Retries never reach here => no duplicate FeedbackLog.
+    	if (goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE) {
+    		recordFeedbackLogAndArticleProvenance(
+    				goldStandard.getUid(),
+    				incomingAcceptedPmids, incomingRejectedPmids,
+    				committedExistingAccepted, committedExistingRejected,
+    				entryPath, curatedBy);
     	}
 
     	// Track provenance for accepted PMIDs. saveIfNotExists ensures we
@@ -256,6 +307,7 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 		saveListInternal(goldStandard, goldStandardUpdateFlag, provenanceSource, entryPath);
 	}
 
+	// TODO(goldstandard-race): saveListInternal has the same non-atomic read-modify-write; apply saveIfUnchanged+retry here too (lower priority — interactive single-accept path is saveInternal).
 	private void saveListInternal(List<GoldStandard> goldStandard, GoldStandardUpdateFlag goldStandardUpdateFlag, String provenanceSource, EntryPath entryPath) {
 		// Resolve provenance strategy: caller-supplied source, or default
 		String strategy = (provenanceSource != null && !provenanceSource.isBlank())

--- a/src/test/java/reciter/service/dynamo/DynamoDbGoldStandardServiceRaceTest.java
+++ b/src/test/java/reciter/service/dynamo/DynamoDbGoldStandardServiceRaceTest.java
@@ -1,0 +1,118 @@
+package reciter.service.dynamo;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import reciter.api.parameters.GoldStandardUpdateFlag;
+import reciter.database.dynamodb.model.GoldStandard;
+import reciter.database.dynamodb.repository.DynamoDbGoldStandardRepository;
+import reciter.feedback.EntryPath;
+import reciter.service.ArticleProvenanceService;
+import reciter.service.ESearchResultService;
+import reciter.service.FeedbackLogService;
+import reciter.service.PmidProvenanceService;
+
+/**
+ * Regression coverage for the GoldStandard lost-update race: two concurrent single-pmid
+ * accepts against the same baseline used to clobber each other because the persist step was an
+ * unconditional putItem. The fix persists via a conditional putItem guarded on the pre-image of
+ * knownpmids/rejectedpmids and retries the read-merge-write on conflict, deferring side-effect
+ * writes until after a durable commit so retries do not duplicate them.
+ */
+@ExtendWith(MockitoExtension.class)
+public class DynamoDbGoldStandardServiceRaceTest {
+
+	@Mock
+	private DynamoDbGoldStandardRepository goldStandardRepository;
+	@Mock
+	private ESearchResultService eSearchResultService;
+	@Mock
+	private PmidProvenanceService pmidProvenanceService;
+	@Mock
+	private FeedbackLogService feedbackLogService;
+	@Mock
+	private ArticleProvenanceService articleProvenanceService;
+
+	private DynamoDbGoldStandardService service;
+
+	private static final String UID = "uid1";
+
+	@BeforeEach
+	public void setUp() {
+		service = new DynamoDbGoldStandardService(
+				goldStandardRepository,
+				eSearchResultService,
+				pmidProvenanceService,
+				feedbackLogService,
+				articleProvenanceService);
+	}
+
+	/** Fresh baseline on every read: a concurrent writer already committed pmid 100. */
+	private GoldStandard baselineWith100() {
+		return new GoldStandard(UID, new ArrayList<>(Collections.singletonList(100L)), new ArrayList<>(), null);
+	}
+
+	/**
+	 * The first conditional write loses the race (returns false); the service must re-read,
+	 * re-merge against the now-visible baseline [100], and commit [100, 200] on the retry —
+	 * with the FeedbackLog side effect for pmid 200 written exactly once, not per attempt.
+	 */
+	@Test
+	public void retryOnConflictMergesBothPmidsAndWritesSideEffectOnce() {
+		// Every read sees the concurrent writer's 100 (fresh copy so attempts don't alias state).
+		when(goldStandardRepository.findById(UID)).thenAnswer(inv -> Optional.of(baselineWith100()));
+		// First persist conflicts, second succeeds.
+		when(goldStandardRepository.saveIfUnchanged(any(GoldStandard.class), any(), any()))
+				.thenReturn(false)
+				.thenReturn(true);
+
+		GoldStandard request = new GoldStandard(UID, new ArrayList<>(Collections.singletonList(200L)), null, null);
+		service.save(request, GoldStandardUpdateFlag.UPDATE, "TestSource", EntryPath.CANDIDATE_LIST, 7);
+
+		// Persisted twice (one conflict, one success); the committed item carries BOTH pmids.
+		ArgumentCaptor<GoldStandard> persisted = ArgumentCaptor.forClass(GoldStandard.class);
+		verify(goldStandardRepository, times(2)).saveIfUnchanged(persisted.capture(), any(), any());
+		GoldStandard committed = persisted.getAllValues().get(persisted.getAllValues().size() - 1);
+		assertTrue(committed.getKnownPmids().contains(100L), "lost update: 100 missing after retry");
+		assertTrue(committed.getKnownPmids().contains(200L), "lost update: 200 missing after retry");
+
+		// The single-accept side effect for pmid 200 fires exactly once despite the retry.
+		verify(feedbackLogService, times(1))
+				.recordAction(argThat(fl -> "200".equals(fl.getArticleId())));
+	}
+
+	/** No contention: a single conditional write commits and there is no retry. */
+	@Test
+	public void noConflictCommitsInOneAttempt() {
+		when(goldStandardRepository.findById(UID))
+				.thenReturn(Optional.of(new GoldStandard(UID, new ArrayList<>(Arrays.asList(100L)), new ArrayList<>(), null)));
+		when(goldStandardRepository.saveIfUnchanged(any(GoldStandard.class), any(), any())).thenReturn(true);
+
+		GoldStandard request = new GoldStandard(UID, new ArrayList<>(Collections.singletonList(200L)), null, null);
+		service.save(request, GoldStandardUpdateFlag.UPDATE, "TestSource", EntryPath.CANDIDATE_LIST, 7);
+
+		ArgumentCaptor<GoldStandard> persisted = ArgumentCaptor.forClass(GoldStandard.class);
+		verify(goldStandardRepository, times(1)).saveIfUnchanged(persisted.capture(), any(), any());
+		List<Long> known = persisted.getValue().getKnownPmids();
+		assertTrue(known.contains(100L) && known.contains(200L), "merge must union existing and incoming pmids");
+		verify(feedbackLogService, times(1))
+				.recordAction(argThat(fl -> "200".equals(fl.getArticleId())));
+	}
+}


### PR DESCRIPTION
## Problem

Curator accepts/rejects in Publication Manager intermittently do not stick: the article stays "pending", never reaches `person_article`, and the Curation History popup still shows "Accepted". Drew reported it (example rol3004/PMID 42236910, accepted three times over three days, never persisted). A scan of `FeedbackLog` vs `GoldStandard.knownpmids` found **~90 genuinely lost recent accepts across 94 people** (35 of them since the 2026-07-16 cutover), plus rol3004.

## Root cause

`DynamoDbGoldStandardService.saveInternal` (UPDATE/DELETE) is a **non-atomic read-modify-write**:

1. `findByUid` reads the item (eventually-consistent `getItem`)
2. merges the incoming pmid into the list in Java
3. writes the whole item back with an **unconditional** `putItem` (`DynamoDbGoldStandardRepository.save`)

With 6 prod replicas and a curator clicking Accept on several articles within a few seconds, two requests read the same baseline, each adds only its own pmid, and the later `putItem` **clobbers** the earlier — a classic lost update. There is no optimistic locking (`GoldStandard` has no `@DynamoDbVersionAttribute`; the enhanced client registers no `VersionedRecordExtension`). `FeedbackLog` is a separate append-only table written *before* the `putItem`, so the vote is logged even though `knownpmids` loses it — which is why the History popup and the durable state disagree.

## Fix (optimistic concurrency, in-repo only — no model change)

- **`DynamoDbGoldStandardRepository`** — new `saveIfUnchanged(gs, expectedKnown, expectedRejected)`: conditional `putItem` guarded on the pre-image of `knownpmids`/`rejectedpmids` (`(attribute_not_exists(knownpmids) OR knownpmids = :ek) AND (…rejectedpmids…)`), returns `false` on `ConditionalCheckFailedException`. Plus `saveIfAbsent(gs)` for the create path. Attribute names verified against the `reciter-dynamodb-model` 3.0.5 bean.
- **`DynamoDbGoldStandardService.saveInternal`** — the read→merge→write is wrapped in a bounded (`MAX_ATTEMPTS=8`) optimistic-retry loop with jittered backoff. The merge / DELETE / audit-log logic is **unchanged**. Side-effect writes (`FeedbackLog`, `ArticleProvenance`, `PmidProvenance`) now run **once, after** the item durably commits, so a retry can't duplicate them. Throws if contended past 8 attempts. `REFRESH` path unchanged.
- **Test** — `DynamoDbGoldStandardServiceRaceTest` simulates a conflict (first conditional write fails, retry succeeds) and asserts the committed item keeps **both** pmids (no lost update) and `recordAction` fires exactly once.

`mvn compile` and the new test both pass.

## Notes / follow-ups

- **Behavior change:** a first-ever accept that *creates* a person's GoldStandard now also logs a FeedbackLog row (previously it didn't) — makes create consistent with the merge path; low-risk (GoldStandard is normally seeded by REFRESH/batch first).
- **`saveListInternal` (batch PUT)** has the same non-atomic pattern; left with a `TODO` — the interactive single-accept path (`saveInternal`) is where the reported losses occur.
- **Separate pre-existing issue (not addressed here):** a single-pmid accept re-logs every other accepted article as "PENDING" in FeedbackLog (`recordFeedbackLogAndArticleProvenance` treats the partial incoming set as de-classifying the rest) — write amplification worth a look.
- **Already remediated in prod data:** the 35 post-cutover lost accepts + rol3004 were backfilled directly into `knownpmids` (atomic conditional appends, each spot-checked first). This PR prevents recurrence.

## Rollout

The Corretto17 line has no auto-deploy; base branch is `MigrationFromJDk11ToAWSCorretto17` (current prod). Suggest a concurrency smoke-test on reciter-dev (two simultaneous accepts for one uid → both land in `knownpmids`) before rolling prod.
