### PR TITLE
fix(retrieval): floor the incremental lookback window; skip re-persisting known PMIDs

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -20,7 +20,6 @@ package reciter.controller;
 
 import java.io.IOException;
 import java.sql.Date;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -161,12 +160,6 @@ public class ReCiterController {
 
     @Value("${retrieval.incremental.lookback-days:90}")
     private int incrementalLookbackDays;
-
-    @Value("${retrieval.full-sweep.max-age-days:180}")
-    private int fullSweepMaxAgeDays;
-
-    @Value("${retrieval.full-sweep.jitter-days:45}")
-    private int fullSweepJitterDays;
 
 
     @Operation(summary = "Update the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids)", description ="This api updates the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids).")
@@ -456,29 +449,17 @@ public class ReCiterController {
             		return ResponseEntity.status(HttpStatus.NOT_FOUND).body("The uid supplied failed to retrieve articles. Try running with ALL_PUBLICATIONS refreshFlag");
             	}
 
-            	// Coverage guard: a passed retrieval window is never revisited, so an article missed
-            	// by one run stays missed forever. Bound both sides of that — floor how far back an
-            	// incremental run reaches, and cap how stale the last full sweep may get. See
-            	// RetrievalWindow for the reasoning; both bounds are config-tunable and can be
-            	// switched off by setting their *-days properties to 0.
-            	RetrievalRefreshFlag effectiveFlag = refreshFlag;
-            	Instant lastFullSweep = RetrievalWindow.lastFullSweep(eSearchResult);
-            	if (RetrievalWindow.fullSweepDue(lastFullSweep, initial, uid, fullSweepMaxAgeDays, fullSweepJitterDays)) {
-            		// Deliberately NOT deleting the ESearchResult the way the manual ALL_PUBLICATIONS
-            		// path does: savePubMedArticles upserts per strategy, so the sweep refreshes the
-            		// entries in place. That keeps the uid's candidate pmids intact if the sweep dies
-            		// midway, and leaves #691's watermark rollback able to schedule a retry.
-            		effectiveFlag = RetrievalRefreshFlag.ALL_PUBLICATIONS;
-            		log.info("Retrieval coverage: uid=[{}] last full sweep=[{}] exceeds maxAge={}d (+jitter {}d) - escalating ONLY_NEWLY_ADDED to ALL_PUBLICATIONS",
-            				uid, lastFullSweep, fullSweepMaxAgeDays, fullSweepJitterDays);
-            	} else {
-            		startDate = RetrievalWindow.incrementalStart(eSearchResult.getRetrievalDate(), initial, incrementalLookbackDays);
-            		log.info("Retrieval coverage: uid=[{}] incremental window start=[{}] (watermark=[{}], floor={}d)",
-            				uid, startDate, eSearchResult.getRetrievalDate(), incrementalLookbackDays);
-            	}
+            	// Coverage floor (#695): a passed retrieval window is never revisited, so an article
+            	// missed by one run — a swallowed PubMed failure, a client timeout, a night the job
+            	// did not run — stayed missed forever. Flooring how far back the window reaches turns
+            	// that permanent loss into a bounded delay. See RetrievalWindow for the reasoning;
+            	// set retrieval.incremental.lookback-days=0 to restore the watermark-only window.
+            	startDate = RetrievalWindow.incrementalStart(eSearchResult.getRetrievalDate(), initial, incrementalLookbackDays);
+            	log.info("Retrieval coverage: uid=[{}] incremental window start=[{}] (watermark=[{}], floor={}d)",
+            			uid, startDate, eSearchResult.getRetrievalDate(), incrementalLookbackDays);
 
             	try {
-                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), effectiveFlag);
+                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), refreshFlag);
                 } catch (IOException e) {
                     log.error("Failed to retrieve articles."+e);
                     stopWatch.stop();

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -20,7 +20,7 @@ package reciter.controller;
 
 import java.io.IOException;
 import java.sql.Date;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -102,6 +102,7 @@ import reciter.utils.AuthorNameSanitizationUtils;
 import reciter.utils.GenderProbability;
 import reciter.utils.InstitutionSanitizationUtil;
 import reciter.xml.retriever.engine.ReCiterRetrievalEngine;
+import reciter.xml.retriever.pubmed.RetrievalWindow;
 
 @Tag(name = "ReCiterController", description = "Operations on ReCiter API.")
 @RestController
@@ -157,7 +158,16 @@ public class ReCiterController {
 
     @Value("${reciter.feature.generator.group.uids.maxCount}")
     private int uidsMaxCount;
-    
+
+    @Value("${retrieval.incremental.lookback-days:90}")
+    private int incrementalLookbackDays;
+
+    @Value("${retrieval.full-sweep.max-age-days:180}")
+    private int fullSweepMaxAgeDays;
+
+    @Value("${retrieval.full-sweep.jitter-days:45}")
+    private int fullSweepJitterDays;
+
 
     @Operation(summary = "Update the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids)", description ="This api updates the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids).")
     @Parameters({
@@ -442,14 +452,33 @@ public class ReCiterController {
             	if (identity != null)
                     identities.add(identity);
             	eSearchResult = eSearchResultService.findByUid(uid.trim()) ;
-            	if (eSearchResult != null) {
-            		startDate = LocalDate.parse(new SimpleDateFormat("yyyy-MM-dd").format(Date.from(eSearchResult.getRetrievalDate()))).minusDays(1);
-            	} else {
+            	if (eSearchResult == null) {
             		return ResponseEntity.status(HttpStatus.NOT_FOUND).body("The uid supplied failed to retrieve articles. Try running with ALL_PUBLICATIONS refreshFlag");
             	}
-            	
+
+            	// Coverage guard: a passed retrieval window is never revisited, so an article missed
+            	// by one run stays missed forever. Bound both sides of that — floor how far back an
+            	// incremental run reaches, and cap how stale the last full sweep may get. See
+            	// RetrievalWindow for the reasoning; both bounds are config-tunable and can be
+            	// switched off by setting their *-days properties to 0.
+            	RetrievalRefreshFlag effectiveFlag = refreshFlag;
+            	Instant lastFullSweep = RetrievalWindow.lastFullSweep(eSearchResult);
+            	if (RetrievalWindow.fullSweepDue(lastFullSweep, initial, uid, fullSweepMaxAgeDays, fullSweepJitterDays)) {
+            		// Deliberately NOT deleting the ESearchResult the way the manual ALL_PUBLICATIONS
+            		// path does: savePubMedArticles upserts per strategy, so the sweep refreshes the
+            		// entries in place. That keeps the uid's candidate pmids intact if the sweep dies
+            		// midway, and leaves #691's watermark rollback able to schedule a retry.
+            		effectiveFlag = RetrievalRefreshFlag.ALL_PUBLICATIONS;
+            		log.info("Retrieval coverage: uid=[{}] last full sweep=[{}] exceeds maxAge={}d (+jitter {}d) - escalating ONLY_NEWLY_ADDED to ALL_PUBLICATIONS",
+            				uid, lastFullSweep, fullSweepMaxAgeDays, fullSweepJitterDays);
+            	} else {
+            		startDate = RetrievalWindow.incrementalStart(eSearchResult.getRetrievalDate(), initial, incrementalLookbackDays);
+            		log.info("Retrieval coverage: uid=[{}] incremental window start=[{}] (watermark=[{}], floor={}d)",
+            				uid, startDate, eSearchResult.getRetrievalDate(), incrementalLookbackDays);
+            	}
+
             	try {
-                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), refreshFlag);
+                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), effectiveFlag);
                 } catch (IOException e) {
                     log.error("Failed to retrieve articles."+e);
                     stopWatch.stop();

--- a/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
@@ -21,7 +21,9 @@ package reciter.xml.retriever.engine;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,19 +112,26 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 	 * @param uid
 	 */
 	protected void savePubMedArticles(Collection<PubMedArticle> pubMedArticles, String uid, String retrievalStrategyName, List<PubMedQueryResult> pubMedQueryResults, QueryType queryType, RetrievalRefreshFlag refreshFlag) {
-		// Save the articles.
-		List<PubMedArticle> pubMedArticleList = new ArrayList<>(pubMedArticles);
-		if(pubMedArticleList != null) {
-			log.info("pubMedArticleList size {}", pubMedArticleList.size());
-		}
+		// Read the existing search result first: it receives the upserted strategy entry
+		// below, and it also tells us which pmids this uid already has persisted.
+		ESearchResult eSearchResultDb = eSearchResultService.findByUid(uid);
+
+		// Save the articles. On incremental runs, skip articles whose pmid is already on
+		// the uid's ESearchResult (#695): the floored lookback window re-retrieves the same
+		// span nightly, and without this every run would re-write that whole span to
+		// DynamoDB/S3. Full sweeps still re-persist everything, so revised PubMed records
+		// are refreshed at sweep cadence.
+		List<PubMedArticle> pubMedArticleList = articlesToPersist(pubMedArticles, eSearchResultDb, refreshFlag);
+		log.info("pubMedArticleList size {} (retrieved {})", pubMedArticleList.size(), pubMedArticles.size());
 		pubMedService.save(pubMedArticleList);
 
-		// Save the search result.
+		// Save the search result. The strategy entry always records every retrieved pmid,
+		// including ones whose article write was skipped above.
 		List<Long> pmids = new ArrayList<>();
 		for (PubMedArticle pubMedArticle : pubMedArticles) {
 			pmids.add(pubMedArticle.getMedlinecitation().getMedlinecitationpmid().getPmid());
 		}
-		
+
 		ESearchPmid eSearchPmid = null;
 		if(!pmids.isEmpty()){
 			reciter.database.dynamodb.model.ESearchPmid.RetrievalRefreshFlag eSearchPmidRefreshFlag;
@@ -138,7 +147,6 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 				log.info("eSearchPmid {} ",eSearchPmid);
 			}
 		}
-		ESearchResult eSearchResultDb = eSearchResultService.findByUid(uid);
 		if (eSearchResultDb == null) {
 			List<ESearchPmid> eSearchPmids = new ArrayList<>();
 			if(eSearchPmid != null) {
@@ -167,5 +175,35 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 				eSearchResultService.save(eSearchResultDb);
 			}
 		}
+	}
+
+	/**
+	 * Articles worth persisting from this retrieval. On an ONLY_NEWLY_ADDED run, pmids
+	 * already recorded on the uid's ESearchResult (under any strategy) were persisted by
+	 * an earlier run and are dropped here; everything else — full sweeps, uids with no
+	 * prior result — is persisted unchanged. Pure so the filter is unit-testable.
+	 */
+	static List<PubMedArticle> articlesToPersist(Collection<PubMedArticle> pubMedArticles, ESearchResult existingResult, RetrievalRefreshFlag refreshFlag) {
+		List<PubMedArticle> articles = new ArrayList<>(pubMedArticles);
+		if (refreshFlag != RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS
+				|| existingResult == null || existingResult.getESearchPmids() == null) {
+			return articles;
+		}
+		Set<Long> knownPmids = new HashSet<>();
+		for (ESearchPmid entry : existingResult.getESearchPmids()) {
+			if (entry != null && entry.getPmids() != null) {
+				knownPmids.addAll(entry.getPmids());
+			}
+		}
+		if (knownPmids.isEmpty()) {
+			return articles;
+		}
+		List<PubMedArticle> toPersist = new ArrayList<>(articles.size());
+		for (PubMedArticle article : articles) {
+			if (!knownPmids.contains(article.getMedlinecitation().getMedlinecitationpmid().getPmid())) {
+				toPersist.add(article);
+			}
+		}
+		return toPersist;
 	}
 }

--- a/src/main/java/reciter/xml/retriever/pubmed/RetrievalWindow.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/RetrievalWindow.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package reciter.xml.retriever.pubmed;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import reciter.database.dynamodb.model.ESearchPmid;
+import reciter.database.dynamodb.model.ESearchResult;
+
+/**
+ * Decides how far back an ONLY_NEWLY_ADDED retrieval reaches, and when a uid is
+ * overdue for a full ALL_PUBLICATIONS sweep.
+ *
+ * <p>Background: the incremental window used to be {@code retrievalDate - 1 day}, and
+ * nothing ever revisits a window once it has been passed. So any single run that
+ * failed to surface an article — a day the uid was not scheduled, an identity that
+ * only later gained the alternate name / grant / email that makes an article findable,
+ * or a PubMed record revised after the fact — dropped that article permanently, until
+ * somebody noticed and triggered a manual full sweep. (#691 closed the narrower case
+ * where a PubMed call errored and the watermark advanced anyway.)
+ *
+ * <p>Two bounds make coverage self-healing instead:
+ * <ol>
+ *   <li>{@link #incrementalStart} floors the lookback, so ordinary run-cadence gaps
+ *       cannot open a hole.</li>
+ *   <li>{@link #fullSweepDue} caps how stale a uid's last full sweep may get, which
+ *       heals holes older than the floor and picks up articles that only became
+ *       attributable after an identity change.</li>
+ * </ol>
+ *
+ * Pure and side-effect free so the decisions are unit-testable without Spring or AWS.
+ */
+public final class RetrievalWindow {
+
+	private RetrievalWindow() {
+	}
+
+	/**
+	 * Start of the incremental {@code [EDAT]}/{@code [DP]} window: the earlier of the
+	 * previous run's watermark and the configured floor.
+	 *
+	 * @param lastRetrieval  ESearchResult.retrievalDate, or null if never run
+	 * @param today          current date (injected so this stays testable)
+	 * @param lookbackFloorDays minimum days to reach back; &lt;= 0 keeps the legacy
+	 *                          watermark-only behaviour
+	 */
+	public static LocalDate incrementalStart(Instant lastRetrieval, LocalDate today, int lookbackFloorDays) {
+		LocalDate watermark = lastRetrieval == null ? null : toUtcDate(lastRetrieval).minusDays(1);
+		if (lookbackFloorDays <= 0) {
+			// Floor disabled: fall back to the historical watermark-only window.
+			return watermark == null ? today.minusDays(1) : watermark;
+		}
+		LocalDate floor = today.minusDays(lookbackFloorDays);
+		if (watermark == null) {
+			return floor;
+		}
+		return watermark.isBefore(floor) ? watermark : floor;
+	}
+
+	/**
+	 * True when this uid's last full sweep is older than {@code maxAgeDays} (plus a
+	 * per-uid jitter, so cohorts that were swept on the same day do not all come due
+	 * together and stampede a single night's run).
+	 *
+	 * @param lastFullSweep most recent ALL_PUBLICATIONS retrieval, or null if never
+	 * @param maxAgeDays    &lt;= 0 disables periodic re-sweeping entirely
+	 * @param jitterDays    width of the per-uid spread; &lt;= 0 means no jitter
+	 */
+	public static boolean fullSweepDue(Instant lastFullSweep, LocalDate today, String uid, int maxAgeDays,
+			int jitterDays) {
+		if (maxAgeDays <= 0) {
+			return false;
+		}
+		if (lastFullSweep == null) {
+			return true;
+		}
+		int jitter = jitterDays <= 0 ? 0 : Math.floorMod(uid == null ? 0 : uid.hashCode(), jitterDays);
+		LocalDate due = toUtcDate(lastFullSweep).plusDays((long) maxAgeDays + jitter);
+		return !today.isBefore(due);
+	}
+
+	/**
+	 * Most recent ALL_PUBLICATIONS retrieval recorded on the item, or null if the uid
+	 * has no full sweep on record. Read from the per-strategy entries that are already
+	 * persisted, so this needs no schema change.
+	 *
+	 * <p>Entries are only written when a strategy returned at least one pmid, so this is
+	 * a lower bound on the true last-sweep date — erring toward re-sweeping sooner.
+	 */
+	public static Instant lastFullSweep(ESearchResult eSearchResult) {
+		if (eSearchResult == null || eSearchResult.getESearchPmids() == null) {
+			return null;
+		}
+		Instant latest = null;
+		for (ESearchPmid entry : eSearchResult.getESearchPmids()) {
+			if (entry == null || entry.getRetrievalDate() == null
+					|| entry.getLookupType() != ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS) {
+				continue;
+			}
+			if (latest == null || entry.getRetrievalDate().isAfter(latest)) {
+				latest = entry.getRetrievalDate();
+			}
+		}
+		return latest;
+	}
+
+	private static LocalDate toUtcDate(Instant instant) {
+		return instant.atZone(ZoneOffset.UTC).toLocalDate();
+	}
+}

--- a/src/main/java/reciter/xml/retriever/pubmed/RetrievalWindow.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/RetrievalWindow.java
@@ -22,31 +22,21 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 
-import reciter.database.dynamodb.model.ESearchPmid;
-import reciter.database.dynamodb.model.ESearchResult;
-
 /**
- * Decides how far back an ONLY_NEWLY_ADDED retrieval reaches, and when a uid is
- * overdue for a full ALL_PUBLICATIONS sweep.
+ * Decides how far back an ONLY_NEWLY_ADDED retrieval reaches.
  *
  * <p>Background: the incremental window used to be {@code retrievalDate - 1 day}, and
  * nothing ever revisits a window once it has been passed. So any single run that
- * failed to surface an article — a day the uid was not scheduled, an identity that
- * only later gained the alternate name / grant / email that makes an article findable,
- * or a PubMed record revised after the fact — dropped that article permanently, until
- * somebody noticed and triggered a manual full sweep. (#691 closed the narrower case
- * where a PubMed call errored and the watermark advanced anyway.)
+ * failed to surface an article — a swallowed PubMed failure, a client read timeout,
+ * a night the job did not run — dropped that article permanently, until somebody
+ * noticed and triggered a manual full sweep. (#691 closed the narrower case where a
+ * PubMed call errored and the watermark advanced anyway.)
  *
- * <p>Two bounds make coverage self-healing instead:
- * <ol>
- *   <li>{@link #incrementalStart} floors the lookback, so ordinary run-cadence gaps
- *       cannot open a hole.</li>
- *   <li>{@link #fullSweepDue} caps how stale a uid's last full sweep may get, which
- *       heals holes older than the floor and picks up articles that only became
- *       attributable after an identity change.</li>
- * </ol>
+ * <p>{@link #incrementalStart} floors the lookback so a missed window degrades from
+ * permanent loss to a bounded delay: the next run re-covers everything inside the
+ * floor no matter what happened to the runs before it.
  *
- * Pure and side-effect free so the decisions are unit-testable without Spring or AWS.
+ * <p>Pure and side-effect free so the decision is unit-testable without Spring or AWS.
  */
 public final class RetrievalWindow {
 
@@ -73,53 +63,6 @@ public final class RetrievalWindow {
 			return floor;
 		}
 		return watermark.isBefore(floor) ? watermark : floor;
-	}
-
-	/**
-	 * True when this uid's last full sweep is older than {@code maxAgeDays} (plus a
-	 * per-uid jitter, so cohorts that were swept on the same day do not all come due
-	 * together and stampede a single night's run).
-	 *
-	 * @param lastFullSweep most recent ALL_PUBLICATIONS retrieval, or null if never
-	 * @param maxAgeDays    &lt;= 0 disables periodic re-sweeping entirely
-	 * @param jitterDays    width of the per-uid spread; &lt;= 0 means no jitter
-	 */
-	public static boolean fullSweepDue(Instant lastFullSweep, LocalDate today, String uid, int maxAgeDays,
-			int jitterDays) {
-		if (maxAgeDays <= 0) {
-			return false;
-		}
-		if (lastFullSweep == null) {
-			return true;
-		}
-		int jitter = jitterDays <= 0 ? 0 : Math.floorMod(uid == null ? 0 : uid.hashCode(), jitterDays);
-		LocalDate due = toUtcDate(lastFullSweep).plusDays((long) maxAgeDays + jitter);
-		return !today.isBefore(due);
-	}
-
-	/**
-	 * Most recent ALL_PUBLICATIONS retrieval recorded on the item, or null if the uid
-	 * has no full sweep on record. Read from the per-strategy entries that are already
-	 * persisted, so this needs no schema change.
-	 *
-	 * <p>Entries are only written when a strategy returned at least one pmid, so this is
-	 * a lower bound on the true last-sweep date — erring toward re-sweeping sooner.
-	 */
-	public static Instant lastFullSweep(ESearchResult eSearchResult) {
-		if (eSearchResult == null || eSearchResult.getESearchPmids() == null) {
-			return null;
-		}
-		Instant latest = null;
-		for (ESearchPmid entry : eSearchResult.getESearchPmids()) {
-			if (entry == null || entry.getRetrievalDate() == null
-					|| entry.getLookupType() != ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS) {
-				continue;
-			}
-			if (latest == null || entry.getRetrievalDate().isAfter(latest)) {
-				latest = entry.getRetrievalDate();
-			}
-		}
-		return latest;
 	}
 
 	private static LocalDate toUtcDate(Instant instant) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -86,6 +86,25 @@ local.lambda.function.invocation.url=/2015-03-31/functions/function/invocations
 searchStrategy-lenient-threshold=3000
 searchStrategy-strict-threshold=1500
 
+# Coverage guards for ONLY_NEWLY_ADDED retrieval. A retrieval window is never
+# revisited once passed, so without these an article missed by a single run stays
+# missed. Set either *-days to 0 to disable that guard.
+
+# Minimum days an incremental run reaches back, regardless of how recently the uid
+# last ran. Absorbs gaps in run cadence. Costs larger efetch payloads, not more
+# eutils requests.
+retrieval.incremental.lookback-days=90
+
+# Maximum age of a uid's last ALL_PUBLICATIONS sweep before the next incremental run
+# is escalated to a full sweep. Heals holes older than the lookback floor, and picks
+# up articles that only became attributable after an identity change (new alternate
+# name, grant, email, ORCID).
+retrieval.full-sweep.max-age-days=180
+
+# Per-uid spread added to max-age-days. Cohorts swept on the same day would otherwise
+# all come due the same night; derived from the uid hash, so it is stable per person.
+retrieval.full-sweep.jitter-days=45
+
 
 
 #### INSTITUTION-SPECIFIC CONFIGURATION ####

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -86,24 +86,13 @@ local.lambda.function.invocation.url=/2015-03-31/functions/function/invocations
 searchStrategy-lenient-threshold=3000
 searchStrategy-strict-threshold=1500
 
-# Coverage guards for ONLY_NEWLY_ADDED retrieval. A retrieval window is never
-# revisited once passed, so without these an article missed by a single run stays
-# missed. Set either *-days to 0 to disable that guard.
-
-# Minimum days an incremental run reaches back, regardless of how recently the uid
-# last ran. Absorbs gaps in run cadence. Costs larger efetch payloads, not more
-# eutils requests.
+# Coverage floor for ONLY_NEWLY_ADDED retrieval (#695). A retrieval window is never
+# revisited once passed, so without this an article missed by a single run stays
+# missed. Minimum days an incremental run reaches back, regardless of how recently
+# the uid last ran. Costs larger efetch payloads, not more eutils requests; articles
+# whose pmids are already on the uid's ESearchResult are not re-persisted. Set to 0
+# to restore the watermark-only window.
 retrieval.incremental.lookback-days=90
-
-# Maximum age of a uid's last ALL_PUBLICATIONS sweep before the next incremental run
-# is escalated to a full sweep. Heals holes older than the lookback floor, and picks
-# up articles that only became attributable after an identity change (new alternate
-# name, grant, email, ORCID).
-retrieval.full-sweep.max-age-days=180
-
-# Per-uid spread added to max-age-days. Cohorts swept on the same day would otherwise
-# all come due the same night; derived from the uid hash, so it is stable per person.
-retrieval.full-sweep.jitter-days=45
 
 
 

--- a/src/test/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngineTest.java
@@ -1,0 +1,93 @@
+package reciter.xml.retriever.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import reciter.api.parameters.RetrievalRefreshFlag;
+import reciter.database.dynamodb.model.ESearchPmid;
+import reciter.database.dynamodb.model.ESearchResult;
+import reciter.model.pubmed.MedlineCitation;
+import reciter.model.pubmed.MedlineCitationPMID;
+import reciter.model.pubmed.PubMedArticle;
+
+/**
+ * Covers the known-pmid persistence skip (#695): with a floored lookback window the
+ * same span is re-retrieved nightly, so incremental runs must not re-write articles
+ * the uid's ESearchResult already records.
+ */
+public class AbstractReCiterRetrievalEngineTest {
+
+	private static PubMedArticle article(long pmid) {
+		MedlineCitationPMID id = new MedlineCitationPMID();
+		id.setPmid(pmid);
+		MedlineCitation citation = new MedlineCitation();
+		citation.setMedlinecitationpmid(id);
+		PubMedArticle article = new PubMedArticle();
+		article.setMedlinecitation(citation);
+		return article;
+	}
+
+	private static List<Long> pmidsOf(List<PubMedArticle> articles) {
+		return articles.stream()
+				.map(a -> a.getMedlinecitation().getMedlinecitationpmid().getPmid())
+				.collect(Collectors.toList());
+	}
+
+	private static ESearchResult resultWithKnownPmids() {
+		ESearchResult existing = new ESearchResult();
+		existing.setESearchPmids(Arrays.asList(
+				new ESearchPmid(Arrays.asList(1L, 2L), "EmailRetrievalStrategy", Instant.now(),
+						ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS),
+				new ESearchPmid(Collections.singletonList(3L), "FullNameRetrievalStrategy", Instant.now(),
+						ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
+		return existing;
+	}
+
+	@Test
+	public void incrementalRunSkipsPmidsAlreadyOnTheESearchResult() {
+		// 2 and 3 are already recorded (under different strategies); only 4 is new.
+		List<PubMedArticle> toPersist = AbstractReCiterRetrievalEngine.articlesToPersist(
+				Arrays.asList(article(2L), article(3L), article(4L)),
+				resultWithKnownPmids(), RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+		assertEquals(Collections.singletonList(4L), pmidsOf(toPersist));
+	}
+
+	@Test
+	public void fullSweepRePersistsEverything() {
+		// A full sweep refreshes stored article payloads, so nothing is skipped.
+		List<PubMedArticle> toPersist = AbstractReCiterRetrievalEngine.articlesToPersist(
+				Arrays.asList(article(2L), article(3L), article(4L)),
+				resultWithKnownPmids(), RetrievalRefreshFlag.ALL_PUBLICATIONS);
+		assertEquals(Arrays.asList(2L, 3L, 4L), pmidsOf(toPersist));
+	}
+
+	@Test
+	public void incrementalRunWithNoPriorResultPersistsEverything() {
+		List<PubMedArticle> retrieved = Arrays.asList(article(5L), article(6L));
+
+		assertEquals(Arrays.asList(5L, 6L), pmidsOf(AbstractReCiterRetrievalEngine.articlesToPersist(
+				retrieved, null, RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
+		assertEquals(Arrays.asList(5L, 6L), pmidsOf(AbstractReCiterRetrievalEngine.articlesToPersist(
+				retrieved, new ESearchResult(), RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
+	}
+
+	@Test
+	public void entriesWithoutPmidListsAreTolerated() {
+		ESearchResult existing = new ESearchResult();
+		existing.setESearchPmids(Arrays.asList(
+				null,
+				new ESearchPmid(null, "EmailRetrievalStrategy", Instant.now(),
+						ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS)));
+		List<PubMedArticle> toPersist = AbstractReCiterRetrievalEngine.articlesToPersist(
+				Collections.singletonList(article(7L)),
+				existing, RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+		assertEquals(Collections.singletonList(7L), pmidsOf(toPersist));
+	}
+}

--- a/src/test/java/reciter/xml/retriever/pubmed/RetrievalWindowTest.java
+++ b/src/test/java/reciter/xml/retriever/pubmed/RetrievalWindowTest.java
@@ -2,19 +2,13 @@ package reciter.xml.retriever.pubmed;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
-import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
-
-import reciter.database.dynamodb.model.ESearchPmid;
-import reciter.database.dynamodb.model.ESearchResult;
 
 public class RetrievalWindowTest {
 
@@ -23,8 +17,6 @@ public class RetrievalWindowTest {
 	private static Instant on(int y, int m, int d) {
 		return LocalDate.of(y, m, d).atStartOfDay(ZoneOffset.UTC).toInstant();
 	}
-
-	// --- incrementalStart -------------------------------------------------
 
 	@Test
 	public void floorAppliesWhenTheUidRanRecently() {
@@ -43,94 +35,38 @@ public class RetrievalWindowTest {
 	}
 
 	@Test
-	public void regressionCam4024ArticleFallsInsideTheFlooredWindow() {
-		// PMID 42242702: EDAT 2026-06-04, uid last ran 2026-07-30. The 1-day watermark
-		// window (start 2026-07-29) excluded it; the floored window must include it.
+	public void dateMissedByTheWatermarkWindowFallsInsideTheFlooredWindow() {
+		// A uid that last ran 2026-07-30 gets a watermark window starting 2026-07-29,
+		// which excludes an article indexed 2026-06-04 — one missed run and it is gone
+		// for good. The floored window must still cover that date.
 		LocalDate start = RetrievalWindow.incrementalStart(on(2026, 7, 30), TODAY, 90);
 		assertTrue(start.isBefore(LocalDate.of(2026, 6, 4)), "EDAT 2026-06-04 must fall inside the window");
 	}
 
 	@Test
+	public void windowIsNeverNarrowerThanTheFloor() {
+		LocalDate floorStart = TODAY.minusDays(90);
+		for (int age = 0; age <= 120; age++) {
+			Instant watermark = TODAY.minusDays(age).atStartOfDay(ZoneOffset.UTC).toInstant();
+			LocalDate start = RetrievalWindow.incrementalStart(watermark, TODAY, 90);
+			assertFalse(start.isAfter(floorStart),
+					"watermark " + age + "d old gave window start " + start + ", inside the floor");
+		}
+	}
+
+	@Test
 	public void floorOfZeroKeepsLegacyWatermarkBehaviour() {
+		// Legacy window: retrievalDate - 1 day, exactly.
 		assertEquals(LocalDate.of(2026, 7, 29),
 				RetrievalWindow.incrementalStart(on(2026, 7, 30), TODAY, 0));
+		assertEquals(LocalDate.of(2025, 10, 31),
+				RetrievalWindow.incrementalStart(on(2025, 11, 1), TODAY, 0));
+		// Legacy behaviour with no prior run: yesterday.
+		assertEquals(TODAY.minusDays(1), RetrievalWindow.incrementalStart(null, TODAY, 0));
 	}
 
 	@Test
 	public void nullWatermarkFallsBackToTheFloor() {
 		assertEquals(LocalDate.of(2026, 5, 5), RetrievalWindow.incrementalStart(null, TODAY, 90));
-	}
-
-	// --- fullSweepDue -----------------------------------------------------
-
-	@Test
-	public void freshSweepIsNotDue() {
-		assertFalse(RetrievalWindow.fullSweepDue(on(2026, 7, 1), TODAY, "cam4024", 180, 45));
-	}
-
-	@Test
-	public void staleSweepIsDueEvenWithMaximumJitter() {
-		// 180 + at most 44 days of jitter = 224; two years is past any jitter value.
-		assertTrue(RetrievalWindow.fullSweepDue(on(2024, 8, 3), TODAY, "cam4024", 180, 45));
-	}
-
-	@Test
-	public void neverSweptIsDue() {
-		assertTrue(RetrievalWindow.fullSweepDue(null, TODAY, "cam4024", 180, 45));
-	}
-
-	@Test
-	public void maxAgeOfZeroDisablesReSweeping() {
-		assertFalse(RetrievalWindow.fullSweepDue(null, TODAY, "cam4024", 0, 45));
-		assertFalse(RetrievalWindow.fullSweepDue(on(2000, 1, 1), TODAY, "cam4024", 0, 45));
-	}
-
-	@Test
-	public void jitterSpreadsACohortSweptOnTheSameDay() {
-		// 4,898 uids share a 2026-05-15 sweep date. They must not all come due at once.
-		Instant cohortSweep = on(2026, 5, 15);
-		int due = 0;
-		for (int i = 0; i < 400; i++) {
-			if (RetrievalWindow.fullSweepDue(cohortSweep, LocalDate.of(2026, 11, 20), "uid" + i, 180, 45)) {
-				due++;
-			}
-		}
-		assertTrue(due > 0 && due < 400, "jitter must delay part of the cohort, saw " + due + "/400");
-	}
-
-	@Test
-	public void jitterIsStablePerUid() {
-		for (int i = 0; i < 50; i++) {
-			LocalDate day = LocalDate.of(2026, 11, 1).plusDays(i);
-			assertEquals(RetrievalWindow.fullSweepDue(on(2026, 5, 15), day, "cam4024", 180, 45),
-					RetrievalWindow.fullSweepDue(on(2026, 5, 15), day, "cam4024", 180, 45));
-		}
-	}
-
-	// --- lastFullSweep ----------------------------------------------------
-
-	@Test
-	public void lastFullSweepIgnoresIncrementalEntries() {
-		ESearchResult r = new ESearchResult();
-		r.setESearchPmids(Arrays.asList(
-				new ESearchPmid(Collections.singletonList(1L), "AffiliationInDbRetrievalStrategy", on(2026, 5, 9),
-						ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS),
-				new ESearchPmid(Collections.singletonList(2L), "OrcidRetrievalStrategy", on(2026, 4, 1),
-						ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS),
-				// newer, but incremental - must not count as a full sweep
-				new ESearchPmid(Collections.singletonList(3L), "FullNameRetrievalStrategy", on(2026, 7, 30),
-						ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
-		assertEquals(on(2026, 5, 9), RetrievalWindow.lastFullSweep(r));
-	}
-
-	@Test
-	public void lastFullSweepIsNullWhenOnlyIncrementalEntriesExist() {
-		ESearchResult r = new ESearchResult();
-		r.setESearchPmids(Collections.singletonList(
-				new ESearchPmid(Collections.singletonList(3L), "FullNameRetrievalStrategy", on(2026, 7, 30),
-						ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
-		assertNull(RetrievalWindow.lastFullSweep(r));
-		assertNull(RetrievalWindow.lastFullSweep(null));
-		assertNull(RetrievalWindow.lastFullSweep(new ESearchResult()));
 	}
 }

--- a/src/test/java/reciter/xml/retriever/pubmed/RetrievalWindowTest.java
+++ b/src/test/java/reciter/xml/retriever/pubmed/RetrievalWindowTest.java
@@ -1,0 +1,136 @@
+package reciter.xml.retriever.pubmed;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import reciter.database.dynamodb.model.ESearchPmid;
+import reciter.database.dynamodb.model.ESearchResult;
+
+public class RetrievalWindowTest {
+
+	private static final LocalDate TODAY = LocalDate.of(2026, 8, 3);
+
+	private static Instant on(int y, int m, int d) {
+		return LocalDate.of(y, m, d).atStartOfDay(ZoneOffset.UTC).toInstant();
+	}
+
+	// --- incrementalStart -------------------------------------------------
+
+	@Test
+	public void floorAppliesWhenTheUidRanRecently() {
+		// Ran yesterday: the legacy watermark window would start 2026-07-30 and miss
+		// anything indexed earlier. The floor pulls it back to 90 days.
+		assertEquals(LocalDate.of(2026, 5, 5),
+				RetrievalWindow.incrementalStart(on(2026, 7, 31), TODAY, 90));
+	}
+
+	@Test
+	public void watermarkWinsWhenItIsOlderThanTheFloor() {
+		// Nine months since the last run: keep reaching back that far, do not shorten
+		// the window to the floor.
+		assertEquals(LocalDate.of(2025, 10, 31),
+				RetrievalWindow.incrementalStart(on(2025, 11, 1), TODAY, 90));
+	}
+
+	@Test
+	public void regressionCam4024ArticleFallsInsideTheFlooredWindow() {
+		// PMID 42242702: EDAT 2026-06-04, uid last ran 2026-07-30. The 1-day watermark
+		// window (start 2026-07-29) excluded it; the floored window must include it.
+		LocalDate start = RetrievalWindow.incrementalStart(on(2026, 7, 30), TODAY, 90);
+		assertTrue(start.isBefore(LocalDate.of(2026, 6, 4)), "EDAT 2026-06-04 must fall inside the window");
+	}
+
+	@Test
+	public void floorOfZeroKeepsLegacyWatermarkBehaviour() {
+		assertEquals(LocalDate.of(2026, 7, 29),
+				RetrievalWindow.incrementalStart(on(2026, 7, 30), TODAY, 0));
+	}
+
+	@Test
+	public void nullWatermarkFallsBackToTheFloor() {
+		assertEquals(LocalDate.of(2026, 5, 5), RetrievalWindow.incrementalStart(null, TODAY, 90));
+	}
+
+	// --- fullSweepDue -----------------------------------------------------
+
+	@Test
+	public void freshSweepIsNotDue() {
+		assertFalse(RetrievalWindow.fullSweepDue(on(2026, 7, 1), TODAY, "cam4024", 180, 45));
+	}
+
+	@Test
+	public void staleSweepIsDueEvenWithMaximumJitter() {
+		// 180 + at most 44 days of jitter = 224; two years is past any jitter value.
+		assertTrue(RetrievalWindow.fullSweepDue(on(2024, 8, 3), TODAY, "cam4024", 180, 45));
+	}
+
+	@Test
+	public void neverSweptIsDue() {
+		assertTrue(RetrievalWindow.fullSweepDue(null, TODAY, "cam4024", 180, 45));
+	}
+
+	@Test
+	public void maxAgeOfZeroDisablesReSweeping() {
+		assertFalse(RetrievalWindow.fullSweepDue(null, TODAY, "cam4024", 0, 45));
+		assertFalse(RetrievalWindow.fullSweepDue(on(2000, 1, 1), TODAY, "cam4024", 0, 45));
+	}
+
+	@Test
+	public void jitterSpreadsACohortSweptOnTheSameDay() {
+		// 4,898 uids share a 2026-05-15 sweep date. They must not all come due at once.
+		Instant cohortSweep = on(2026, 5, 15);
+		int due = 0;
+		for (int i = 0; i < 400; i++) {
+			if (RetrievalWindow.fullSweepDue(cohortSweep, LocalDate.of(2026, 11, 20), "uid" + i, 180, 45)) {
+				due++;
+			}
+		}
+		assertTrue(due > 0 && due < 400, "jitter must delay part of the cohort, saw " + due + "/400");
+	}
+
+	@Test
+	public void jitterIsStablePerUid() {
+		for (int i = 0; i < 50; i++) {
+			LocalDate day = LocalDate.of(2026, 11, 1).plusDays(i);
+			assertEquals(RetrievalWindow.fullSweepDue(on(2026, 5, 15), day, "cam4024", 180, 45),
+					RetrievalWindow.fullSweepDue(on(2026, 5, 15), day, "cam4024", 180, 45));
+		}
+	}
+
+	// --- lastFullSweep ----------------------------------------------------
+
+	@Test
+	public void lastFullSweepIgnoresIncrementalEntries() {
+		ESearchResult r = new ESearchResult();
+		r.setESearchPmids(Arrays.asList(
+				new ESearchPmid(Collections.singletonList(1L), "AffiliationInDbRetrievalStrategy", on(2026, 5, 9),
+						ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS),
+				new ESearchPmid(Collections.singletonList(2L), "OrcidRetrievalStrategy", on(2026, 4, 1),
+						ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS),
+				// newer, but incremental - must not count as a full sweep
+				new ESearchPmid(Collections.singletonList(3L), "FullNameRetrievalStrategy", on(2026, 7, 30),
+						ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
+		assertEquals(on(2026, 5, 9), RetrievalWindow.lastFullSweep(r));
+	}
+
+	@Test
+	public void lastFullSweepIsNullWhenOnlyIncrementalEntriesExist() {
+		ESearchResult r = new ESearchResult();
+		r.setESearchPmids(Collections.singletonList(
+				new ESearchPmid(Collections.singletonList(3L), "FullNameRetrievalStrategy", on(2026, 7, 30),
+						ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
+		assertNull(RetrievalWindow.lastFullSweep(r));
+		assertNull(RetrievalWindow.lastFullSweep(null));
+		assertNull(RetrievalWindow.lastFullSweep(new ESearchResult()));
+	}
+}


### PR DESCRIPTION
## Problem

`ONLY_NEWLY_ADDED_PUBLICATIONS` computes `startDate = ESearchResult.retrievalDate - 1 day`, giving a window about two days wide on `[EDAT]` that is never revisited once passed. Any failure inside that window permanently loses those articles until a full sweep that may never arrive:

- **Swallowed PubMed failures**: both retrieval swallow points return a benign value on error, indistinguishable from a legitimate zero result. Measured in prod (2026-08-03): ~2 swallowed `/pubmed/` 500s per 24h across both pods — roughly 700 silently-lost person-windows per year. #691 (merged, not yet deployed) stops the watermark advancing past those, but the already-lost windows stay lost.
- **Client read timeouts**: 21 distinct `SocketTimeoutException`s in 20h; the batch client logs and moves on with no retry.
- **Missed runs**: a night the job does not run for a person moves the window past whatever was indexed that day.

## What this does

**Floors the incremental lookback.** Window start becomes `min(watermark - 1 day, now - floorDays)`, so a missed window degrades from permanent loss to a bounded delay: the next successful run re-covers everything inside the floor. Pure window math lives in `RetrievalWindow`; the controller wires it into the `ONLY_NEWLY_ADDED_PUBLICATIONS` path.

**Config**: `retrieval.incremental.lookback-days`, default **90**. Setting it to `0` restores the legacy watermark-only window exactly (covered by a unit test).

**No escalation in this change.** An earlier draft escalated stale people to `ALL_PUBLICATIONS` using a last-full-sweep inferred from `ESearchPmid.lookupType`; incremental runs erase that marker, so the inference is unreliable and none of that code ships here. Escalation returns in #696 built on a persisted timestamp.

## Cost

Request *count* against PubMed is unchanged — the same strategies issue the same number of esearch/efetch calls, just with a wider date bound. What would otherwise grow is payload and DynamoDB/S3 writes, since the floored window re-retrieves the same span nightly. That is bounded by the second half of this change: on incremental runs, `savePubMedArticles` skips re-persisting articles whose pmids are already recorded on the person's `ESearchResult`. Full sweeps still re-persist everything, so revised PubMed records are refreshed at sweep cadence, and strategy entries still record every retrieved pmid.

## Tests

`mvn clean test`: 195 tests, 0 failures. New coverage: window never narrower than the floor; `floor=0` preserves today's behavior exactly; a date missed by the ~2-day window falls inside the floored window; known-pmid skip (incremental filters, full sweep does not, no-prior-result and malformed entries tolerated).

Refs #689, #695.
