### PR TITLE
feat(retrieval): budgeted ALL_PUBLICATIONS escalation with persisted lastFullSweep (stacked on #697)

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -20,6 +20,7 @@ package reciter.controller;
 
 import java.io.IOException;
 import java.sql.Date;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StopWatch;
@@ -101,6 +103,7 @@ import reciter.utils.AuthorNameSanitizationUtils;
 import reciter.utils.GenderProbability;
 import reciter.utils.InstitutionSanitizationUtil;
 import reciter.xml.retriever.engine.ReCiterRetrievalEngine;
+import reciter.xml.retriever.pubmed.RetrievalEscalationTracker;
 import reciter.xml.retriever.pubmed.RetrievalWindow;
 
 @Tag(name = "ReCiterController", description = "Operations on ReCiter API.")
@@ -160,6 +163,18 @@ public class ReCiterController {
 
     @Value("${retrieval.incremental.lookback-days:90}")
     private int incrementalLookbackDays;
+
+    // Server-side default for fullSweepMaxAgeDays when the request does not carry it.
+    // MUST stay 0: escalation only ever runs when a caller explicitly requests it and
+    // is counting the escalations against a budget (#696). Publication Manager and
+    // ad-hoc callers hit these endpoints too, and silently upgrading their seconds-long
+    // incremental into an unbounded re-disambiguation would be both a latency
+    // regression and an unbudgeted sweep.
+    @Value("${retrieval.full-sweep.max-age-days:0}")
+    private int fullSweepMaxAgeDaysDefault;
+
+    @Value("${retrieval.full-sweep.jitter-days:45}")
+    private int fullSweepJitterDays;
 
 
     @Operation(summary = "Update the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids)", description ="This api updates the goldstandard by passing GoldStandard model(uid, knownPmids, rejectedPmids).")
@@ -398,9 +413,12 @@ public class ReCiterController {
             @ApiResponse(responseCode = "404", description = "The resource you were trying to reach is not found")
     })
     @GetMapping(value = "/reciter/retrieve/articles/by/uid", produces = "application/json")
-    public ResponseEntity retrieveArticlesByUid(@RequestParam(required = false) String uid,@RequestParam(required = false) RetrievalRefreshFlag refreshFlag) {
+    public ResponseEntity retrieveArticlesByUid(@RequestParam(required = false) String uid,
+    		@RequestParam(required = false) RetrievalRefreshFlag refreshFlag,
+    		@RequestParam(required = false) Integer fullSweepMaxAgeDays) {
         StopWatch stopWatch = new StopWatch("Retrieve Articles for an UID");
         stopWatch.start("Retrieve Articles for an UID");
+        RetrievalEscalationTracker.reset();
         List<Identity> identities = new ArrayList<>();
         LocalDate initial = LocalDate.now();
         LocalDate startDate = initial.withDayOfMonth(1);
@@ -428,10 +446,11 @@ public class ReCiterController {
             		eSearchResult == null){
                 if (eSearchResult != null)
                     eSearchResultService.delete(uid.trim());
-                
+
                 if (identity != null)
                     identities.add(identity);
 
+                RetrievalEscalationTracker.setMode(RetrievalRefreshFlag.ALL_PUBLICATIONS);
                 try {
                     aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), RetrievalRefreshFlag.ALL_PUBLICATIONS);
                 } catch (IOException e) {
@@ -449,17 +468,60 @@ public class ReCiterController {
             		return ResponseEntity.status(HttpStatus.NOT_FOUND).body("The uid supplied failed to retrieve articles. Try running with ALL_PUBLICATIONS refreshFlag");
             	}
 
-            	// Coverage floor (#695): a passed retrieval window is never revisited, so an article
-            	// missed by one run — a swallowed PubMed failure, a client timeout, a night the job
-            	// did not run — stayed missed forever. Flooring how far back the window reaches turns
-            	// that permanent loss into a bounded delay. See RetrievalWindow for the reasoning;
-            	// set retrieval.incremental.lookback-days=0 to restore the watermark-only window.
-            	startDate = RetrievalWindow.incrementalStart(eSearchResult.getRetrievalDate(), initial, incrementalLookbackDays);
-            	log.info("Retrieval coverage: uid=[{}] incremental window start=[{}] (watermark=[{}], floor={}d)",
-            			uid, startDate, eSearchResult.getRetrievalDate(), incrementalLookbackDays);
+            	// Staleness escalation (#696): when the request carries a positive
+            	// fullSweepMaxAgeDays and this person's last full sweep is older than that
+            	// (plus a stable per-person jitter that spreads clustered sweep cohorts),
+            	// run the full ALL_PUBLICATIONS retrieval instead of the incremental one.
+            	// An absent or non-positive parameter means floor only, NEVER escalate —
+            	// the server default (retrieval.full-sweep.max-age-days) stays 0, so only
+            	// callers that opt in and budget the cost (the batch client) get sweeps.
+            	int maxAgeDays = fullSweepMaxAgeDays != null ? fullSweepMaxAgeDays : fullSweepMaxAgeDaysDefault;
+            	RetrievalRefreshFlag effectiveFlag = refreshFlag;
+            	if (maxAgeDays > 0) {
+            		// Persisted stamp first; while it is still null (stamps only appear as
+            		// clean sweeps complete post-deploy), fall back to the lookupType
+            		// inference from the item's own entries. The inference errs toward
+            		// looking staler than reality (incremental runs erase the marker), i.e.
+            		// toward an extra sweep — bounded by the client's budget and gone after
+            		// the person's first clean sweep stamps a real value. The inferred value
+            		// is never written back.
+            		Instant lastFullSweep = eSearchResultService.findLastFullSweep(uid.trim());
+            		boolean inferred = false;
+            		if (lastFullSweep == null) {
+            			lastFullSweep = RetrievalWindow.inferredLastFullSweep(eSearchResult);
+            			inferred = true;
+            		}
+            		if (RetrievalWindow.fullSweepDue(lastFullSweep, initial, uid.trim(), maxAgeDays, fullSweepJitterDays)) {
+            			effectiveFlag = RetrievalRefreshFlag.ALL_PUBLICATIONS;
+            			RetrievalEscalationTracker.markEscalated();
+            			log.info("Retrieval coverage: uid=[{}] last full sweep=[{}]{} exceeds maxAge={}d (+stable per-uid jitter over {}d) - escalating ONLY_NEWLY_ADDED to ALL_PUBLICATIONS",
+            					uid, lastFullSweep, inferred ? " (inferred)" : " (persisted)", maxAgeDays, fullSweepJitterDays);
+            		}
+            	}
 
+            	if (effectiveFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS) {
+            		// Escalated sweep. Deliberately NOT deleting the ESearchResult the way the
+            		// manual ALL_PUBLICATIONS path does: savePubMedArticles upserts per strategy,
+            		// so the sweep refreshes entries in place and the uid's candidate pmids
+            		// survive a sweep that dies midway. Note this path runs retrieveData, NOT
+            		// retrieveDataByDateRange — #691's watermark rollback does not apply here.
+            		// Failure handling is the lastFullSweep stamp instead: a sweep that hit the
+            		// error-swallow path is not stamped, so the person stays due and the sweep
+            		// is retried on a later run.
+            	} else {
+            		// Coverage floor (#695): a passed retrieval window is never revisited, so an article
+            		// missed by one run — a swallowed PubMed failure, a client timeout, a night the job
+            		// did not run — stayed missed forever. Flooring how far back the window reaches turns
+            		// that permanent loss into a bounded delay. See RetrievalWindow for the reasoning;
+            		// set retrieval.incremental.lookback-days=0 to restore the watermark-only window.
+            		startDate = RetrievalWindow.incrementalStart(eSearchResult.getRetrievalDate(), initial, incrementalLookbackDays);
+            		log.info("Retrieval coverage: uid=[{}] incremental window start=[{}] (watermark=[{}], floor={}d)",
+            				uid, startDate, eSearchResult.getRetrievalDate(), incrementalLookbackDays);
+            	}
+
+            	RetrievalEscalationTracker.setMode(effectiveFlag);
             	try {
-                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), refreshFlag);
+                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), effectiveFlag);
                 } catch (IOException e) {
                     log.error("Failed to retrieve articles."+e);
                     stopWatch.stop();
@@ -473,7 +535,32 @@ public class ReCiterController {
 
         stopWatch.stop();
         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
-        return ResponseEntity.ok().body("Successfully retrieved all candidate articles for " + uid + " and refreshed all search results");
+        return ResponseEntity.ok()
+                .headers(retrievalSignalHeaders())
+                .body("Successfully retrieved all candidate articles for " + uid + " and refreshed all search results");
+    }
+
+    /** Convenience overload for callers that do not opt into full-sweep escalation. */
+    public ResponseEntity retrieveArticlesByUid(String uid, RetrievalRefreshFlag refreshFlag) {
+        return retrieveArticlesByUid(uid, refreshFlag, null);
+    }
+
+    /**
+     * Response-signal headers for the retrieval endpoints (#696). The batch client
+     * budgets ALL_PUBLICATIONS escalations per night but cannot observe the server-side
+     * decision from the response body, so the controller reports it here:
+     * X-Reciter-Retrieval-Mode (retrieval actually executed, NONE when cached),
+     * X-Reciter-Escalated (staleness escalation — the value counted against the
+     * budget), and X-Reciter-Auto-Upgraded (forced full retrieval because the uid had
+     * no ESearchResult — counted separately, because those sweeps are unbudgeted).
+     */
+    private HttpHeaders retrievalSignalHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        RetrievalRefreshFlag mode = RetrievalEscalationTracker.getMode();
+        headers.set("X-Reciter-Retrieval-Mode", mode == null ? "NONE" : mode.name());
+        headers.set("X-Reciter-Escalated", Boolean.toString(RetrievalEscalationTracker.wasEscalated()));
+        headers.set("X-Reciter-Auto-Upgraded", Boolean.toString(RetrievalEscalationTracker.wasAutoUpgraded()));
+        return headers;
     }
     
     @Operation(summary = "Retrieve pending articles for a group of users.",  description = "Retrieve pending articles for a group of users.")
@@ -610,15 +697,17 @@ public class ReCiterController {
     @GetMapping(value = "/reciter/feature-generator/by/uid", produces = "application/json")
     public ResponseEntity runFeatureGenerator(@RequestParam String uid,
     		@RequestParam(required = false)	Double authorshipLikelihoodScore ,
-    		@RequestParam(required = false) UseGoldStandard useGoldStandard, 
-    		@RequestParam(required = false) FilterFeedbackType filterByFeedback, 
+    		@RequestParam(required = false) UseGoldStandard useGoldStandard,
+    		@RequestParam(required = false) FilterFeedbackType filterByFeedback,
     		@RequestParam(required = false) boolean analysisRefreshFlag,
     		@RequestParam(required = false) RetrievalRefreshFlag retrievalRefreshFlag,
+    		@RequestParam(required = false) Integer fullSweepMaxAgeDays,
     		@RequestParam(value = "includeExternal", required = false, defaultValue = "false") boolean includeExternal) {
 
     	StopWatch stopWatch = new StopWatch("Feature generation for UID "+uid);
         stopWatch.start("Feature generation for UID");
-        
+        RetrievalEscalationTracker.reset();
+
         final double totalScore;
         if(authorshipLikelihoodScore == null) {
         	totalScore = totalArticleScoreStandardizedDefault; // Configuring the totalScore in multiple of 10's in application.properties file
@@ -783,7 +872,7 @@ public class ReCiterController {
             } else if (useGoldStandard == UseGoldStandard.AS_EVIDENCE) {
                 strategyParameters.setUseGoldStandardEvidence(true);
             }
-            parameters = initializeEngineParameters(uid, authorshipLikelihoodScore, retrievalRefreshFlag);
+            parameters = initializeEngineParameters(uid, authorshipLikelihoodScore, retrievalRefreshFlag, fullSweepMaxAgeDays);
             if (parameters == null) {
                 stopWatch.stop();
                 log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
@@ -943,8 +1032,11 @@ public class ReCiterController {
     }
 
     private ResponseEntity<Object> featureGeneratorResponse(ReCiterFeature reCiterFeature, String uid, boolean includeExternal) {
+        // Every 200 from the feature generator carries the retrieval-signal headers
+        // (#696) so the batch client can count escalations against its nightly budget.
+        HttpHeaders retrievalSignal = retrievalSignalHeaders();
         if (!includeExternal || reCiterFeature == null) {
-            return new ResponseEntity<>(reCiterFeature, HttpStatus.OK);
+            return new ResponseEntity<>(reCiterFeature, retrievalSignal, HttpStatus.OK);
         }
         try {
             List<ExternalArticle> externalArticles = externalArticleService.findByUid(uid.trim()).stream()
@@ -952,13 +1044,13 @@ public class ReCiterController {
                     .collect(Collectors.toList());
             ObjectNode responseBody = objectMapper.valueToTree(reCiterFeature);
             responseBody.set("externalArticles", objectMapper.valueToTree(externalArticles));
-            return new ResponseEntity<>(responseBody, HttpStatus.OK);
+            return new ResponseEntity<>(responseBody, retrievalSignal, HttpStatus.OK);
         } catch (Exception e) {
             // The scoring result must never fail on the optional external-article sidecar;
             // the absent externalArticles field (vs empty array) signals the degradation.
             log.warn("Could not append external articles for uid {}; returning scoring result without them: {}",
                     uid, e.getMessage());
-            return new ResponseEntity<>(reCiterFeature, HttpStatus.OK);
+            return new ResponseEntity<>(reCiterFeature, retrievalSignal, HttpStatus.OK);
         }
     }
     
@@ -1182,7 +1274,7 @@ public class ReCiterController {
     }
 
 
-    private EngineParameters initializeEngineParameters(String uid, Double totalStandardizedArticleScore, RetrievalRefreshFlag retrievalRefreshFlag) {
+    private EngineParameters initializeEngineParameters(String uid, Double totalStandardizedArticleScore, RetrievalRefreshFlag retrievalRefreshFlag, Integer fullSweepMaxAgeDays) {
         // find identity
         Identity identity = identityService.findByUid(uid);
         ESearchResult eSearchResults = null;
@@ -1194,9 +1286,14 @@ public class ReCiterController {
                 log.warn("No ESearchResult for uid={}; upgrading requested flag={} to ALL_PUBLICATIONS",
                          uid, retrievalRefreshFlag);
                 retrieveArticlesByUid(uid, RetrievalRefreshFlag.ALL_PUBLICATIONS);
+                // Marked AFTER the call: retrieveArticlesByUid resets the tracker on entry.
+                // Auto-upgrades are reported separately from escalations (#696) — they are
+                // unbudgeted full sweeps, and folding them into the escalation count would
+                // make the client's "budget is holding" signal a false one.
+                RetrievalEscalationTracker.markAutoUpgraded();
                 eSearchResults = eSearchResultService.findByUid(uid);
             } else if(eSearchResults != null && (retrievalRefreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS || retrievalRefreshFlag == RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)) {
-            	retrieveArticlesByUid(uid, retrievalRefreshFlag);
+            	retrieveArticlesByUid(uid, retrievalRefreshFlag, fullSweepMaxAgeDays);
             	eSearchResults = eSearchResultService.findByUid(uid);
             }
         } catch (EmptyResultDataAccessException e) {

--- a/src/main/java/reciter/database/dynamodb/repository/ESearchResultRepository.java
+++ b/src/main/java/reciter/database/dynamodb/repository/ESearchResultRepository.java
@@ -1,33 +1,146 @@
 package reciter.database.dynamodb.repository;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
 import reciter.database.dynamodb.model.ESearchResult;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
 @Repository
 public class ESearchResultRepository {
 
-	private final DynamoDbTable<ESearchResult> eSearchResultTable;
+	private static final Logger log = LoggerFactory.getLogger(ESearchResultRepository.class);
 
-	public ESearchResultRepository(DynamoDbEnhancedClient enhancedClient) {
+	/**
+	 * When the uid's last clean ALL_PUBLICATIONS sweep completed (#696). Lives on the
+	 * ESearchResult item but deliberately NOT on the bean schema: the model class comes
+	 * from the reciter-dynamodb-model artifact, so the attribute is managed here with
+	 * the low-level client instead — written only by {@link #stampLastFullSweepIfNewer}
+	 * and read only by {@link #findLastFullSweep}. For that to be safe, {@link #save}
+	 * must not use putItem (which replaces the whole item and would erase any attribute
+	 * the bean schema does not know about); it uses updateItem, which touches only the
+	 * schema's own attributes.
+	 */
+	static final String LAST_FULL_SWEEP = "lastFullSweep";
+
+	/**
+	 * Fixed-width UTC timestamp for the lastFullSweep attribute. The non-regression
+	 * condition compares timestamps inside DynamoDB, where string comparison is
+	 * lexicographic — {@code Instant.toString()} is unusable for that because it drops
+	 * trailing zeros ("...00Z" sorts after "...00.123Z"). A constant-width rendering
+	 * makes lexicographic order chronological order.
+	 */
+	private static final DateTimeFormatter SWEEP_TIMESTAMP =
+			DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+
+	private final DynamoDbTable<ESearchResult> eSearchResultTable;
+	private final DynamoDbClient dynamoDbClient;
+
+	public ESearchResultRepository(DynamoDbEnhancedClient enhancedClient, DynamoDbClient dynamoDbClient) {
 
 		this.eSearchResultTable = enhancedClient.table("ESearchResult", TableSchema.fromBean(ESearchResult.class));
+		this.dynamoDbClient = dynamoDbClient;
 
 	}
 
 	public void save(ESearchResult eSearchResult) {
-		eSearchResultTable.putItem(eSearchResult);
+		// updateItem, not putItem: putItem replaces the entire item, which would erase the
+		// lastFullSweep attribute (not on the bean schema — see LAST_FULL_SWEEP) on every
+		// strategy save. updateItem writes exactly the schema's attributes — including
+		// removing ones that are null on the bean, matching putItem's end state for them —
+		// and leaves everything else on the item alone. Like putItem, it creates the item
+		// when none exists.
+		eSearchResultTable.updateItem(eSearchResult);
 	}
 
 	public void saveAll(List<ESearchResult> eSearchResults) {
-		eSearchResults.forEach(eSearchResult -> eSearchResultTable.putItem(eSearchResult));
+		eSearchResults.forEach(eSearchResult -> eSearchResultTable.updateItem(eSearchResult));
+	}
+
+	/**
+	 * Record that a clean full sweep for this uid completed at {@code sweepTime} — but
+	 * never move an existing stamp backward. The condition runs inside DynamoDB, so a
+	 * Publication Manager request racing the batch cannot regress the stamp no matter
+	 * how the two writes interleave. Requires the item to exist: a sweep that persisted
+	 * nothing must not create a ghost item that consists only of a stamp.
+	 */
+	public void stampLastFullSweepIfNewer(String uid, Instant sweepTime) {
+		String value = toSortableTimestamp(sweepTime);
+		Map<String, AttributeValue> key = new HashMap<>();
+		key.put("uid", AttributeValue.builder().s(uid).build());
+		Map<String, AttributeValue> values = new HashMap<>();
+		values.put(":ts", AttributeValue.builder().s(value).build());
+		try {
+			dynamoDbClient.updateItem(UpdateItemRequest.builder()
+					.tableName(eSearchResultTable.tableName())
+					.key(key)
+					.updateExpression("SET " + LAST_FULL_SWEEP + " = :ts")
+					.conditionExpression("attribute_exists(uid) AND (attribute_not_exists(" + LAST_FULL_SWEEP
+							+ ") OR " + LAST_FULL_SWEEP + " < :ts)")
+					.expressionAttributeValues(values)
+					.build());
+			log.info("Stamped lastFullSweep=[{}] for uid=[{}]", value, uid);
+		} catch (ConditionalCheckFailedException e) {
+			// A newer stamp already exists (a concurrent sweep finished later) or the item
+			// is gone — either way, skipping is the non-regressing behavior we want.
+			log.info("Skipped lastFullSweep stamp for uid=[{}]: existing stamp is newer or item absent", uid);
+		}
+	}
+
+	/**
+	 * The uid's persisted lastFullSweep, or null when the item has never been stamped
+	 * (or does not exist). Read with a projection on the low-level client because the
+	 * attribute is not on the bean schema.
+	 */
+	public Instant findLastFullSweep(String uid) {
+		Map<String, AttributeValue> key = new HashMap<>();
+		key.put("uid", AttributeValue.builder().s(uid).build());
+		GetItemResponse response = dynamoDbClient.getItem(GetItemRequest.builder()
+				.tableName(eSearchResultTable.tableName())
+				.key(key)
+				.projectionExpression(LAST_FULL_SWEEP)
+				.build());
+		if (!response.hasItem() || !response.item().containsKey(LAST_FULL_SWEEP)) {
+			return null;
+		}
+		return parseSweepTimestamp(response.item().get(LAST_FULL_SWEEP).s(), uid);
+	}
+
+	static String toSortableTimestamp(Instant instant) {
+		return SWEEP_TIMESTAMP.format(instant);
+	}
+
+	static Instant parseSweepTimestamp(String value, String uid) {
+		if (value == null) {
+			return null;
+		}
+		try {
+			return Instant.parse(value);
+		} catch (DateTimeParseException e) {
+			// Unparseable is treated as never-stamped: the caller falls back to the
+			// lookupType inference, which errs toward an extra sweep, never a missed one.
+			log.warn("Unparseable lastFullSweep=[{}] for uid=[{}]; treating as never swept", value, uid);
+			return null;
+		}
 	}
 
 	public Optional<ESearchResult> findById(String id) {

--- a/src/main/java/reciter/service/ESearchResultService.java
+++ b/src/main/java/reciter/service/ESearchResultService.java
@@ -18,6 +18,8 @@
  *******************************************************************************/
 package reciter.service;
 
+import java.time.Instant;
+
 import reciter.database.dynamodb.model.ESearchResult;
 
 public interface ESearchResultService {
@@ -29,4 +31,17 @@ public interface ESearchResultService {
 	void deleteAll();
 
 	void delete(String uid);
+
+	/**
+	 * Record that a clean ALL_PUBLICATIONS sweep completed for this uid (#696). The
+	 * write is conditional and non-regressing: an existing newer stamp is never moved
+	 * backward, so a Publication Manager sweep racing the batch cannot regress it.
+	 */
+	void stampLastFullSweepIfNewer(String uid, Instant sweepTime);
+
+	/**
+	 * The uid's persisted lastFullSweep stamp, or null if the uid has never had a
+	 * clean full sweep recorded (callers then fall back to the lookupType inference).
+	 */
+	Instant findLastFullSweep(String uid);
 }

--- a/src/main/java/reciter/service/dynamo/ESearchResultServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ESearchResultServiceImpl.java
@@ -1,5 +1,7 @@
 package reciter.service.dynamo;
 
+import java.time.Instant;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +34,16 @@ public class ESearchResultServiceImpl implements ESearchResultService {
 	@Override
 	public void delete(String uid) {
 		eSearchResultRepository.deleteById(uid);
+	}
+
+	@Override
+	public void stampLastFullSweepIfNewer(String uid, Instant sweepTime) {
+		eSearchResultRepository.stampLastFullSweepIfNewer(uid, sweepTime);
+	}
+
+	@Override
+	public Instant findLastFullSweep(String uid) {
+		return eSearchResultRepository.findLastFullSweep(uid);
 	}
 
 }

--- a/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
@@ -20,6 +20,7 @@ package reciter.xml.retriever.engine;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -162,10 +163,15 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 				// appended a new ESearchPmid for the same strategy without removing the prior
 				// entry, growing the ESearchResult item unbounded toward the 400KB DynamoDB cap.
 				String newStrategyName = eSearchPmid.getRetrievalStrategyName();
+				ESearchPmid existingEntry = eSearchPmids.stream()
+						.filter(existing -> existing != null
+								&& existing.getRetrievalStrategyName() != null
+								&& existing.getRetrievalStrategyName().equalsIgnoreCase(newStrategyName))
+						.findFirst().orElse(null);
 				eSearchPmids.removeIf(existing -> existing != null
 						&& existing.getRetrievalStrategyName() != null
 						&& existing.getRetrievalStrategyName().equalsIgnoreCase(newStrategyName));
-				eSearchPmids.add(eSearchPmid);
+				eSearchPmids.add(upsertedStrategyEntry(existingEntry, eSearchPmid));
 			}
 			if(!eSearchPmids.isEmpty()) {
 				eSearchResultService.save(new ESearchResult(uid, Instant.now(), eSearchPmids, queryType));
@@ -175,6 +181,66 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 				eSearchResultService.save(eSearchResultDb);
 			}
 		}
+	}
+
+	/**
+	 * The strategy entry to store when a retrieval upserts over an existing one.
+	 * Normally the incoming entry replaces the old one wholesale — but an incremental
+	 * run must not downgrade an entry's {@code lookupType} from ALL_PUBLICATIONS
+	 * (#696/E13): {@code ArticleSizeStrategy} filters entries on that marker to compute
+	 * {@code articleCountScore}, so erasing it perturbs scoring, and the escalation
+	 * fallback infers last-full-sweep from the same marker's {@code retrievalDate}.
+	 *
+	 * <p>When the downgrade is refused, the stored entry keeps the ALL_PUBLICATIONS
+	 * marker AND the full sweep's retrievalDate — bumping the date on an incremental
+	 * run would make the person look freshly swept and suppress a due escalation —
+	 * while the pmid lists are merged, so the full-sweep article count is preserved and
+	 * newly discovered articles still register. Pure so the rule is unit-testable.
+	 */
+	static ESearchPmid upsertedStrategyEntry(ESearchPmid existing, ESearchPmid incoming) {
+		if (existing == null || incoming == null
+				|| existing.getLookupType() != ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS
+				|| incoming.getLookupType() == ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS) {
+			return incoming;
+		}
+		List<Long> mergedPmids = new ArrayList<>();
+		Set<Long> seen = new HashSet<>();
+		for (List<Long> pmidList : Arrays.asList(existing.getPmids(), incoming.getPmids())) {
+			if (pmidList == null) {
+				continue;
+			}
+			for (Long pmid : pmidList) {
+				if (pmid != null && seen.add(pmid)) {
+					mergedPmids.add(pmid);
+				}
+			}
+		}
+		log.info("Refusing lookupType downgrade for strategy {} : keeping ALL_PUBLICATIONS marker "
+				+ "(sweep date {}), merged pmids {} -> {}", incoming.getRetrievalStrategyName(),
+				existing.getRetrievalDate(),
+				incoming.getPmids() == null ? 0 : incoming.getPmids().size(), mergedPmids.size());
+		return new ESearchPmid(mergedPmids, incoming.getRetrievalStrategyName(),
+				existing.getRetrievalDate(), ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+	}
+
+	/**
+	 * Stamp {@code lastFullSweep} after an ALL_PUBLICATIONS retrieval — but only when
+	 * every strategy completed without entering the error-swallow path (#696). Stamping
+	 * after a swallowed failure would lock the loss in until the next scheduled sweep,
+	 * 30–365 days away, which is strictly worse than not stamping: an unstamped person
+	 * simply stays due and the sweep is retried. The write itself is conditional and
+	 * never regresses a newer stamp (see ESearchResultRepository).
+	 */
+	protected void stampLastFullSweepIfClean(String uid, RetrievalRefreshFlag refreshFlag) {
+		if (refreshFlag != RetrievalRefreshFlag.ALL_PUBLICATIONS) {
+			return;
+		}
+		if (reciter.xml.retriever.pubmed.RetrievalErrorTracker.hadError()) {
+			log.warn("Full sweep for uid=[{}] hit PubMed failures; NOT stamping lastFullSweep so the "
+					+ "sweep stays due and is retried.", uid);
+			return;
+		}
+		eSearchResultService.stampLastFullSweepIfNewer(uid, Instant.now());
 	}
 
 	/**

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -147,12 +147,19 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	private Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) throws IOException {
 		slf4jLogger.info("Coming into retrieveData section without date range****");
 		Set<Long> uniquePmids = new HashSet<>();
-		
+
 		QueryType queryType = null;
-		
+
 		//eSearchResultService.delete();
-		
+
 		String uid = identity.getUid();
+
+		// Clean-completion tracking (#696): clear the per-run PubMed-failure flag so the
+		// lastFullSweep stamp at the end of this method reflects THIS run only. This is the
+		// RetrievalErrorTracker discipline #691 established for retrieveDataByDateRange,
+		// extended to the full-sweep path — which is the path both manual and escalated
+		// ALL_PUBLICATIONS requests take.
+		RetrievalErrorTracker.reset();
 
 		// Phase 1 provenance tracking state
 		Set<Long> nonGsStrategyPmids = new HashSet<>();
@@ -477,9 +484,15 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			scopusService.save(scopusArticlesByDoi);
 		}
 		slf4jLogger.info("Finished retrieval for uid=[{}], uniquePmids={}", identity.getUid(), uniquePmids.size());
+
+		// Record the completed full sweep (#696) — only if no strategy entered the
+		// error-swallow path during this run. A strategy that threw outright never
+		// reaches this line, which is the same outcome: no stamp, person stays due.
+		stampLastFullSweepIfClean(uid, refreshFlag);
+
 		return uniquePmids;
 	}
-	
+
 	public void retrieveDataByDateRange(Identity identity, Date startDate, Date endDate, RetrievalRefreshFlag refreshFlag) throws IOException {
 		slf4jLogger.info("Coming in retrieveData section with date range****");
 		Set<Long> uniquePmids = new HashSet<>();
@@ -791,8 +804,11 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		} finally {
 			// Watermark guard (#689): ALWAYS runs — even if a strategy threw after savePubMedArticles
 			// already advanced retrievalDate — so a failed run never leaves the watermark skipped past
-			// a silently-dropped window. Only rolls back when a prior watermark existed; ALL_PUBLICATIONS
-			// deletes the ESearchResult first, so preRunRetrievalDate is null there and nothing rolls back.
+			// a silently-dropped window. This guard covers the ONLY_NEWLY_ADDED path only:
+			// ALL_PUBLICATIONS runs — manual, escalated (#696), or auto-upgraded — never route here
+			// (AsyncRetrievalEngine dispatches them to retrieveData), so this rollback does NOT protect
+			// them. Their failure handling lives in retrieveData instead: a sweep that hit the swallow
+			// path skips the lastFullSweep stamp, so the person stays due and the sweep is retried.
 			// The rollback is self-guarded so a DynamoDB hiccup here cannot mask the original exception.
 			if (RetrievalErrorTracker.hadError() && preRunRetrievalDate != null) {
 				try {

--- a/src/main/java/reciter/xml/retriever/pubmed/RetrievalEscalationTracker.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/RetrievalEscalationTracker.java
@@ -1,0 +1,80 @@
+package reciter.xml.retriever.pubmed;
+
+import reciter.api.parameters.RetrievalRefreshFlag;
+
+/**
+ * Thread-scoped record of what retrieval a request actually performed, so the
+ * controller can report it back to the caller (#696).
+ *
+ * The batch client budgets ALL_PUBLICATIONS escalations per night, but the escalation
+ * decision is made server-side, deep inside {@code retrieveArticlesByUid} — the client
+ * cannot observe it from the response body, which is the feature-generator's scoring
+ * payload. This tracker carries three facts from the decision points up to the HTTP
+ * response, where the controller emits them as headers:
+ *
+ * <ul>
+ *   <li>{@code X-Reciter-Retrieval-Mode} — the retrieval mode actually executed
+ *       ({@code ALL_PUBLICATIONS}, {@code ONLY_NEWLY_ADDED_PUBLICATIONS}, or
+ *       {@code NONE} when the request used cached results);</li>
+ *   <li>{@code X-Reciter-Escalated} — true iff an ONLY_NEWLY_ADDED request was
+ *       escalated to ALL_PUBLICATIONS by the {@code fullSweepMaxAgeDays} staleness
+ *       check. This is the value the client counts against its budget;</li>
+ *   <li>{@code X-Reciter-Auto-Upgraded} — true iff the request was forced to
+ *       ALL_PUBLICATIONS because the uid had no ESearchResult at all. Counted
+ *       separately because those sweeps are unbudgeted: during any recurrence of the
+ *       S3-offload null-read behavior they can number in the thousands, and folding
+ *       them into the escalation count would make "the budget is holding" a false
+ *       signal.</li>
+ * </ul>
+ *
+ * The decision points all run on the servlet thread handling the request (the engine
+ * fans retrieval out to a worker pool but the controller blocks on it), so a
+ * ThreadLocal scopes these flags to one request — same reasoning as
+ * {@link RetrievalErrorTracker}, which scopes the per-run PubMed-failure flag to one
+ * retrieval worker thread. {@link #reset()} runs at endpoint entry, which also guards
+ * against servlet-thread reuse.
+ */
+public final class RetrievalEscalationTracker {
+
+    private static final ThreadLocal<Boolean> ESCALATED = ThreadLocal.withInitial(() -> Boolean.FALSE);
+    private static final ThreadLocal<Boolean> AUTO_UPGRADED = ThreadLocal.withInitial(() -> Boolean.FALSE);
+    private static final ThreadLocal<RetrievalRefreshFlag> MODE = new ThreadLocal<>();
+
+    private RetrievalEscalationTracker() {
+    }
+
+    /** Clear all flags at the start of a request-handling endpoint. */
+    public static void reset() {
+        ESCALATED.set(Boolean.FALSE);
+        AUTO_UPGRADED.set(Boolean.FALSE);
+        MODE.remove();
+    }
+
+    /** An ONLY_NEWLY_ADDED request was escalated to ALL_PUBLICATIONS by the staleness check. */
+    public static void markEscalated() {
+        ESCALATED.set(Boolean.TRUE);
+    }
+
+    /** The request was forced to ALL_PUBLICATIONS because the uid had no ESearchResult. */
+    public static void markAutoUpgraded() {
+        AUTO_UPGRADED.set(Boolean.TRUE);
+    }
+
+    /** Record the retrieval mode actually dispatched to the engine. */
+    public static void setMode(RetrievalRefreshFlag mode) {
+        MODE.set(mode);
+    }
+
+    public static boolean wasEscalated() {
+        return ESCALATED.get();
+    }
+
+    public static boolean wasAutoUpgraded() {
+        return AUTO_UPGRADED.get();
+    }
+
+    /** Mode actually executed, or null when the request performed no retrieval. */
+    public static RetrievalRefreshFlag getMode() {
+        return MODE.get();
+    }
+}

--- a/src/main/java/reciter/xml/retriever/pubmed/RetrievalWindow.java
+++ b/src/main/java/reciter/xml/retriever/pubmed/RetrievalWindow.java
@@ -22,8 +22,12 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 
+import reciter.database.dynamodb.model.ESearchPmid;
+import reciter.database.dynamodb.model.ESearchResult;
+
 /**
- * Decides how far back an ONLY_NEWLY_ADDED retrieval reaches.
+ * Decides how far back an ONLY_NEWLY_ADDED retrieval reaches, and when a uid is
+ * overdue for a full ALL_PUBLICATIONS sweep.
  *
  * <p>Background: the incremental window used to be {@code retrievalDate - 1 day}, and
  * nothing ever revisits a window once it has been passed. So any single run that
@@ -32,11 +36,18 @@ import java.time.ZoneOffset;
  * noticed and triggered a manual full sweep. (#691 closed the narrower case where a
  * PubMed call errored and the watermark advanced anyway.)
  *
- * <p>{@link #incrementalStart} floors the lookback so a missed window degrades from
- * permanent loss to a bounded delay: the next run re-covers everything inside the
- * floor no matter what happened to the runs before it.
+ * <p>Two bounds make coverage self-healing instead:
+ * <ol>
+ *   <li>{@link #incrementalStart} floors the lookback, so a missed window degrades
+ *       from permanent loss to a bounded delay (#695).</li>
+ *   <li>{@link #fullSweepDue} caps how stale a uid's last full sweep may get (#696),
+ *       which heals holes older than the floor and picks up articles that only became
+ *       attributable after an identity change. It only ever fires when the caller
+ *       supplies a positive max age — the batch client sends it per cohort and counts
+ *       the escalations against its nightly budget; everyone else gets the floor only.</li>
+ * </ol>
  *
- * <p>Pure and side-effect free so the decision is unit-testable without Spring or AWS.
+ * Pure and side-effect free so the decisions are unit-testable without Spring or AWS.
  */
 public final class RetrievalWindow {
 
@@ -63,6 +74,78 @@ public final class RetrievalWindow {
 			return floor;
 		}
 		return watermark.isBefore(floor) ? watermark : floor;
+	}
+
+	/**
+	 * True when this uid's last full sweep is older than {@code maxAgeDays} plus the
+	 * uid's stable {@link #jitterOffset jitter offset}.
+	 *
+	 * @param lastFullSweep most recent completed ALL_PUBLICATIONS retrieval — the
+	 *                      persisted {@code lastFullSweep} stamp, or the
+	 *                      {@link #inferredLastFullSweep inferred} value while the
+	 *                      stamp is still null; null means no full sweep on record,
+	 *                      which counts as due
+	 * @param today         current date (injected so this stays testable)
+	 * @param maxAgeDays    &lt;= 0 disables escalation entirely — the parameterless
+	 *                      default, so Publication Manager and ad-hoc callers are
+	 *                      never silently upgraded to an unbounded re-disambiguation
+	 * @param jitterDays    width of the per-uid spread; &lt;= 0 means no jitter
+	 */
+	public static boolean fullSweepDue(Instant lastFullSweep, LocalDate today, String uid, int maxAgeDays,
+			int jitterDays) {
+		if (maxAgeDays <= 0) {
+			return false;
+		}
+		if (lastFullSweep == null) {
+			return true;
+		}
+		LocalDate due = toUtcDate(lastFullSweep).plusDays((long) maxAgeDays + jitterOffset(uid, jitterDays));
+		return !today.isBefore(due);
+	}
+
+	/**
+	 * Stable per-uid offset in {@code [0, jitterDays)}, added to the max age before the
+	 * dueness comparison. Sweep dates are heavily clustered (thousands of people share a
+	 * single sweep date), so a bare "older than N days" rule would bring a whole cohort
+	 * due on the same night; spreading the due date per person dissolves the clump. The
+	 * offset must be stable across runs — derived from the uid, not drawn at random —
+	 * or the spread would re-randomize nightly and people would flap in and out of
+	 * dueness instead of coming due once.
+	 */
+	public static int jitterOffset(String uid, int jitterDays) {
+		if (jitterDays <= 0) {
+			return 0;
+		}
+		return Math.floorMod(uid == null ? 0 : uid.hashCode(), jitterDays);
+	}
+
+	/**
+	 * Fallback for items whose persisted {@code lastFullSweep} is still null: the most
+	 * recent ALL_PUBLICATIONS retrieval recorded on the item's per-strategy entries, or
+	 * null if none. This lazily seeds the escalation decision without a table migration.
+	 *
+	 * <p>The inference errs in the safe direction only: incremental runs re-stamp these
+	 * entries (E13), so a person can look <em>less</em> recently swept than they are —
+	 * biasing toward an extra sweep, bounded by the client's budget and self-correcting
+	 * once the person's first clean sweep stamps a real timestamp. That is why the
+	 * inferred value is used for the decision but never written back: only a genuine
+	 * clean sweep may stamp.
+	 */
+	public static Instant inferredLastFullSweep(ESearchResult eSearchResult) {
+		if (eSearchResult == null || eSearchResult.getESearchPmids() == null) {
+			return null;
+		}
+		Instant latest = null;
+		for (ESearchPmid entry : eSearchResult.getESearchPmids()) {
+			if (entry == null || entry.getRetrievalDate() == null
+					|| entry.getLookupType() != ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS) {
+				continue;
+			}
+			if (latest == null || entry.getRetrievalDate().isAfter(latest)) {
+				latest = entry.getRetrievalDate();
+			}
+		}
+		return latest;
 	}
 
 	private static LocalDate toUtcDate(Instant instant) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -94,6 +94,22 @@ searchStrategy-strict-threshold=1500
 # to restore the watermark-only window.
 retrieval.incremental.lookback-days=90
 
+# Full-sweep escalation (#696). Server-side DEFAULT for the fullSweepMaxAgeDays
+# request parameter when a caller omits it — MUST stay 0 (escalation off, floor
+# only). Escalation upgrades an ONLY_NEWLY_ADDED request to a full ALL_PUBLICATIONS
+# re-disambiguation when the uid's last clean full sweep is older than the max age;
+# that is minutes of work instead of seconds, so it only ever runs when the caller
+# explicitly sends the parameter and counts the escalations (via the
+# X-Reciter-Escalated response header) against its own nightly budget. The batch
+# client sends per-cohort values from its scheduling ConfigMap; Publication Manager
+# and ad-hoc callers send nothing and are never upgraded.
+retrieval.full-sweep.max-age-days=0
+
+# Width in days of the stable per-uid spread added to the max age before the dueness
+# comparison. Sweep dates are heavily clustered (thousands of uids share a single
+# sweep date), so without jitter a whole cohort comes due the same night. 0 disables.
+retrieval.full-sweep.jitter-days=45
+
 
 
 #### INSTITUTION-SPECIFIC CONFIGURATION ####

--- a/src/test/java/reciter/controller/ReCiterControllerTest.java
+++ b/src/test/java/reciter/controller/ReCiterControllerTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.sql.Date;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,6 +46,7 @@ import reciter.api.parameters.GoldStandardUpdateFlag;
 import reciter.api.parameters.RetrievalRefreshFlag;
 import reciter.api.parameters.UseGoldStandard;
 import reciter.database.dynamodb.model.AnalysisOutput;
+import reciter.database.dynamodb.model.ESearchPmid;
 import reciter.database.dynamodb.model.ESearchResult;
 import reciter.database.dynamodb.model.GoldStandard;
 import reciter.engine.StrategyParameters;
@@ -701,6 +703,131 @@ public class ReCiterControllerTest {
 				any(Date.class), eq(RetrievalRefreshFlag.ALL_PUBLICATIONS));
 	}
 
+	// ---- #696: staleness escalation on ONLY_NEWLY_ADDED requests ----
+
+	private ESearchResult eSearchResultWithFullSweepDaysAgo(long daysAgo) {
+		ESearchResult result = new ESearchResult();
+		result.setUid(testUid);
+		result.setRetrievalDate(Instant.now());
+		List<ESearchPmid> entries = new ArrayList<>();
+		entries.add(new ESearchPmid(Arrays.asList(1L, 2L), "EmailRetrievalStrategy",
+				Instant.now().minus(daysAgo, ChronoUnit.DAYS),
+				ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS));
+		result.setESearchPmids(entries);
+		return result;
+	}
+
+	@Test
+	public void testEscalatesWhenInferredLastSweepExceedsMaxAge() throws IOException {
+		// No persisted stamp yet (pre-A2 record): the decision falls back to the
+		// lookupType inference, which shows a sweep 120 days ago against a 90-day max.
+		ReflectionTestUtils.setField(reCiterController, "fullSweepJitterDays", 0);
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(eSearchResultWithFullSweepDaysAgo(120));
+		when(eSearchResultService.findLastFullSweep(testUid.trim())).thenReturn(null);
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS, 90);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ALL_PUBLICATIONS));
+		// Escalation refreshes the item in place; only the manual ALL path deletes it.
+		verify(eSearchResultService, never()).delete(anyString());
+		assertEquals("true", response.getHeaders().getFirst("X-Reciter-Escalated"));
+		assertEquals("ALL_PUBLICATIONS", response.getHeaders().getFirst("X-Reciter-Retrieval-Mode"));
+		assertEquals("false", response.getHeaders().getFirst("X-Reciter-Auto-Upgraded"));
+	}
+
+	@Test
+	public void testDoesNotEscalateBelowMaxAge() throws IOException {
+		ReflectionTestUtils.setField(reCiterController, "fullSweepJitterDays", 0);
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(eSearchResultWithFullSweepDaysAgo(30));
+		when(eSearchResultService.findLastFullSweep(testUid.trim())).thenReturn(null);
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS, 90);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS));
+		assertEquals("false", response.getHeaders().getFirst("X-Reciter-Escalated"));
+		assertEquals("ONLY_NEWLY_ADDED_PUBLICATIONS", response.getHeaders().getFirst("X-Reciter-Retrieval-Mode"));
+	}
+
+	@Test
+	public void testPersistedStampIsPreferredOverStaleInference() throws IOException {
+		// Entries claim a 400-day-old sweep, but the persisted stamp (written by a
+		// clean sweep) says 10 days ago. The stamp wins: no escalation.
+		ReflectionTestUtils.setField(reCiterController, "fullSweepJitterDays", 0);
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(eSearchResultWithFullSweepDaysAgo(400));
+		when(eSearchResultService.findLastFullSweep(testUid.trim()))
+				.thenReturn(Instant.now().minus(10, ChronoUnit.DAYS));
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS, 90);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS));
+		assertEquals("false", response.getHeaders().getFirst("X-Reciter-Escalated"));
+	}
+
+	@Test
+	public void testStalePersistedStampEscalatesEvenWhenEntriesLookFresh() throws IOException {
+		// The inverse: incremental runs keep re-stamping entries (E13), so entries can
+		// look fresh while the real last full sweep is 200 days old. The stamp wins.
+		ReflectionTestUtils.setField(reCiterController, "fullSweepJitterDays", 0);
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(eSearchResultWithFullSweepDaysAgo(5));
+		when(eSearchResultService.findLastFullSweep(testUid.trim()))
+				.thenReturn(Instant.now().minus(200, ChronoUnit.DAYS));
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS, 90);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ALL_PUBLICATIONS));
+		assertEquals("true", response.getHeaders().getFirst("X-Reciter-Escalated"));
+	}
+
+	@Test
+	public void testParameterlessRequestNeverEscalates() throws IOException {
+		// A uid that has NEVER been fully swept, on a request without fullSweepMaxAgeDays
+		// (Publication Manager, ad-hoc callers): must stay incremental — and must not
+		// even read the stamp, since the decision is disabled.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		ESearchResult neverSwept = eSearchResultWithFullSweepDaysAgo(2000);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(neverSwept);
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS));
+		verify(eSearchResultService, never()).findLastFullSweep(anyString());
+		assertEquals("false", response.getHeaders().getFirst("X-Reciter-Escalated"));
+	}
+
+	@Test
+	public void testZeroMaxAgeNeverEscalates() throws IOException {
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(eSearchResultWithFullSweepDaysAgo(2000));
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS, 0);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS));
+		verify(eSearchResultService, never()).findLastFullSweep(anyString());
+		assertEquals("false", response.getHeaders().getFirst("X-Reciter-Escalated"));
+	}
+
 	@Test
 	public void testRetrieveBulkFeatureGeneratorWithUids() {
 		// Arrange
@@ -803,7 +930,7 @@ public class ReCiterControllerTest {
 		when(identityService.findByUid(uid)).thenReturn(null);
 
 		// Act
-		ResponseEntity<?> response = reCiterController.runFeatureGenerator(uid, null, null, null, false, null,false);
+		ResponseEntity<?> response = reCiterController.runFeatureGenerator(uid, null, null, null, false, null, null, false);
 
 		// Assert
 		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -820,7 +947,7 @@ public class ReCiterControllerTest {
 
 		// Act
 		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
-				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ALL, false, null,false);
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ALL, false, null, null, false);
 
 		// Assert
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -847,7 +974,7 @@ public class ReCiterControllerTest {
 
 		// Act
 		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
-				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ACCEPTED_ONLY, false, null,false);
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ACCEPTED_ONLY, false, null, null, false);
 
 		// Assert
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -868,7 +995,7 @@ public class ReCiterControllerTest {
 
 		// Act
 		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
-				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.REJECTED_ONLY, false, null,false);
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.REJECTED_ONLY, false, null, null, false);
 
 		// Assert
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -889,7 +1016,7 @@ public class ReCiterControllerTest {
 
 		// Act
 		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
-				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ACCEPTED_AND_NULL, false, null,false);
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ACCEPTED_AND_NULL, false, null, null, false);
 
 		// Assert
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -921,7 +1048,7 @@ public class ReCiterControllerTest {
 
 		// Act
 		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
-				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.REJECTED_AND_NULL, false, null,false);
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.REJECTED_AND_NULL, false, null, null, false);
 
 		// Assert
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -953,7 +1080,7 @@ public class ReCiterControllerTest {
 
 		// Act
 		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
-				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ACCEPTED_AND_REJECTED, false, null,false);
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ACCEPTED_AND_REJECTED, false, null, null, false);
 
 		// Assert
 		assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -982,7 +1109,7 @@ public class ReCiterControllerTest {
 
 		// Act
 		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
-				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.NULL, false, null,false);
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.NULL, false, null, null, false);
 
 		// Assert
 		assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/reciter/database/dynamodb/repository/ESearchResultLastFullSweepTest.java
+++ b/src/test/java/reciter/database/dynamodb/repository/ESearchResultLastFullSweepTest.java
@@ -1,0 +1,172 @@
+package reciter.database.dynamodb.repository;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import reciter.database.dynamodb.model.ESearchResult;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+/**
+ * Covers the persisted lastFullSweep attribute (#696): the conditional, non-regressing
+ * stamp; the projection read; the sortable timestamp encoding the DynamoDB-side
+ * comparison depends on; and the putItem→updateItem switch that keeps the attribute
+ * alive across ordinary strategy saves.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ESearchResultLastFullSweepTest {
+
+	@Mock
+	private DynamoDbEnhancedClient enhancedClient;
+
+	@Mock
+	private DynamoDbTable<ESearchResult> table;
+
+	@Mock
+	private DynamoDbClient dynamoDbClient;
+
+	private ESearchResultRepository repository;
+
+	@BeforeEach
+	public void setUp() {
+		when(enhancedClient.table(eq("ESearchResult"), any(TableSchema.class))).thenReturn(table);
+		when(table.tableName()).thenReturn("ESearchResult");
+		repository = new ESearchResultRepository(enhancedClient, dynamoDbClient);
+	}
+
+	@Test
+	public void stampIsConditionalAndNonRegressing() {
+		repository.stampLastFullSweepIfNewer("cam4024", Instant.parse("2026-08-03T12:00:00Z"));
+
+		ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+		verify(dynamoDbClient).updateItem(captor.capture());
+		UpdateItemRequest request = captor.getValue();
+
+		assertEquals("ESearchResult", request.tableName());
+		assertEquals("cam4024", request.key().get("uid").s());
+		assertEquals("SET lastFullSweep = :ts", request.updateExpression());
+		// The non-regression guard evaluates inside DynamoDB, so a racing writer can
+		// never move the stamp backward regardless of interleaving; and a sweep must
+		// never create a ghost item that consists only of a stamp.
+		assertEquals("attribute_exists(uid) AND (attribute_not_exists(lastFullSweep) OR lastFullSweep < :ts)",
+				request.conditionExpression());
+		assertEquals("2026-08-03T12:00:00.000Z", request.expressionAttributeValues().get(":ts").s());
+	}
+
+	@Test
+	public void refusingToRegressIsNotAnError() {
+		when(dynamoDbClient.updateItem(any(UpdateItemRequest.class)))
+				.thenThrow(ConditionalCheckFailedException.builder().message("existing stamp is newer").build());
+
+		// A rejected write means a newer stamp already exists — the desired outcome,
+		// and it must not disrupt the sweep that just completed.
+		assertDoesNotThrow(() -> repository.stampLastFullSweepIfNewer("cam4024",
+				Instant.parse("2026-08-03T12:00:00Z")));
+	}
+
+	@Test
+	public void findLastFullSweepReadsTheProjectedAttribute() {
+		Map<String, AttributeValue> item = new HashMap<>();
+		item.put("lastFullSweep", AttributeValue.builder().s("2026-05-15T04:30:00.250Z").build());
+		when(dynamoDbClient.getItem(any(GetItemRequest.class)))
+				.thenReturn(GetItemResponse.builder().item(item).build());
+
+		assertEquals(Instant.parse("2026-05-15T04:30:00.250Z"), repository.findLastFullSweep("cam4024"));
+
+		ArgumentCaptor<GetItemRequest> captor = ArgumentCaptor.forClass(GetItemRequest.class);
+		verify(dynamoDbClient).getItem(captor.capture());
+		assertEquals("lastFullSweep", captor.getValue().projectionExpression());
+		assertEquals("cam4024", captor.getValue().key().get("uid").s());
+	}
+
+	@Test
+	public void neverStampedOrMissingItemReadsAsNull() {
+		when(dynamoDbClient.getItem(any(GetItemRequest.class)))
+				.thenReturn(GetItemResponse.builder().build());
+		assertNull(repository.findLastFullSweep("cam4024"));
+
+		Map<String, AttributeValue> itemWithoutStamp = new HashMap<>();
+		itemWithoutStamp.put("uid", AttributeValue.builder().s("cam4024").build());
+		when(dynamoDbClient.getItem(any(GetItemRequest.class)))
+				.thenReturn(GetItemResponse.builder().item(itemWithoutStamp).build());
+		assertNull(repository.findLastFullSweep("cam4024"));
+	}
+
+	@Test
+	public void unparseableStampReadsAsNeverSwept() {
+		// Null errs toward an extra sweep (the caller falls back to inference), never
+		// toward suppressing a due one.
+		Map<String, AttributeValue> item = new HashMap<>();
+		item.put("lastFullSweep", AttributeValue.builder().s("not-a-timestamp").build());
+		when(dynamoDbClient.getItem(any(GetItemRequest.class)))
+				.thenReturn(GetItemResponse.builder().item(item).build());
+		assertNull(repository.findLastFullSweep("cam4024"));
+	}
+
+	@Test
+	public void sortableTimestampOrderMatchesChronologicalOrder() {
+		// The condition expression compares the strings lexicographically inside
+		// DynamoDB. Instant.toString() would get the sub-second case wrong:
+		// "…00Z" sorts AFTER "…00.123Z" despite being earlier. The fixed-width
+		// rendering must keep lexicographic order chronological, including that case.
+		Instant[] ascending = {
+				Instant.parse("2026-08-03T11:59:59.999Z"),
+				Instant.parse("2026-08-03T12:00:00Z"),
+				Instant.parse("2026-08-03T12:00:00.123Z"),
+				Instant.parse("2026-08-03T12:00:01Z"),
+				Instant.parse("2027-01-01T00:00:00Z"),
+		};
+		for (int i = 0; i < ascending.length; i++) {
+			for (int j = i + 1; j < ascending.length; j++) {
+				String earlier = ESearchResultRepository.toSortableTimestamp(ascending[i]);
+				String later = ESearchResultRepository.toSortableTimestamp(ascending[j]);
+				assertTrue(earlier.compareTo(later) < 0,
+						earlier + " must sort before " + later);
+			}
+		}
+		// Round-trips through the parser used on read.
+		assertEquals(Instant.parse("2026-08-03T12:00:00Z"),
+				ESearchResultRepository.parseSweepTimestamp(
+						ESearchResultRepository.toSortableTimestamp(Instant.parse("2026-08-03T12:00:00Z")), "cam4024"));
+	}
+
+	@Test
+	public void saveUsesUpdateItemSoTheStampSurvivesStrategySaves() {
+		// putItem would replace the whole item and erase lastFullSweep (which is not on
+		// the bean schema) on every strategy save; updateItem touches only the schema's
+		// own attributes.
+		ESearchResult result = new ESearchResult();
+		result.setUid("cam4024");
+
+		repository.save(result);
+
+		verify(table).updateItem(result);
+	}
+}

--- a/src/test/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngineTest.java
@@ -1,6 +1,13 @@
 package reciter.xml.retriever.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -8,19 +15,25 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import reciter.api.parameters.RetrievalRefreshFlag;
 import reciter.database.dynamodb.model.ESearchPmid;
 import reciter.database.dynamodb.model.ESearchResult;
+import reciter.model.identity.Identity;
 import reciter.model.pubmed.MedlineCitation;
 import reciter.model.pubmed.MedlineCitationPMID;
 import reciter.model.pubmed.PubMedArticle;
+import reciter.service.ESearchResultService;
+import reciter.xml.retriever.pubmed.RetrievalErrorTracker;
 
 /**
  * Covers the known-pmid persistence skip (#695): with a floored lookback window the
  * same span is re-retrieved nightly, so incremental runs must not re-write articles
- * the uid's ESearchResult already records.
+ * the uid's ESearchResult already records. Also covers the two #696 engine rules:
+ * the lookupType downgrade guard on strategy-entry upserts and the clean-completion
+ * gate on the lastFullSweep stamp.
  */
 public class AbstractReCiterRetrievalEngineTest {
 
@@ -89,5 +102,125 @@ public class AbstractReCiterRetrievalEngineTest {
 				Collections.singletonList(article(7L)),
 				existing, RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
 		assertEquals(Collections.singletonList(7L), pmidsOf(toPersist));
+	}
+
+	// ---- lookupType downgrade guard (#696 / E13) ----
+
+	private static final Instant SWEEP_DATE = Instant.parse("2026-05-15T00:00:00Z");
+	private static final Instant TONIGHT = Instant.parse("2026-08-03T00:00:00Z");
+
+	@Test
+	public void incrementalUpsertMustNotDowngradeAnAllPublicationsEntry() {
+		// ArticleSizeStrategy counts pmids on entries whose lookupType is
+		// ALL_PUBLICATIONS, and the escalation fallback infers last-full-sweep from
+		// the same entries. The stored entry must therefore keep the marker AND the
+		// sweep's retrievalDate (a bumped date would fake a fresh sweep and suppress
+		// a due escalation), while merging in the incremental run's new pmids.
+		ESearchPmid existing = new ESearchPmid(Arrays.asList(1L, 2L, 3L), "EmailRetrievalStrategy",
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(3L, 4L), "EmailRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming);
+
+		assertEquals(ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS, stored.getLookupType());
+		assertEquals(SWEEP_DATE, stored.getRetrievalDate());
+		assertEquals(Arrays.asList(1L, 2L, 3L, 4L), stored.getPmids());
+	}
+
+	@Test
+	public void fullSweepUpsertReplacesTheEntryWholesale() {
+		ESearchPmid existing = new ESearchPmid(Arrays.asList(1L, 2L), "EmailRetrievalStrategy",
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(2L, 5L), "EmailRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming));
+	}
+
+	@Test
+	public void incrementalOverIncrementalReplacesTheEntry() {
+		ESearchPmid existing = new ESearchPmid(Arrays.asList(1L), "EmailRetrievalStrategy",
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(2L), "EmailRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming));
+	}
+
+	@Test
+	public void firstEntryForAStrategyIsStoredAsIs() {
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(2L), "EmailRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(null, incoming));
+	}
+
+	@Test
+	public void downgradeGuardToleratesNullPmidLists() {
+		ESearchPmid existing = new ESearchPmid(null, "EmailRetrievalStrategy",
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(4L), "EmailRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming);
+		assertEquals(ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS, stored.getLookupType());
+		assertEquals(Arrays.asList(4L), stored.getPmids());
+	}
+
+	// ---- Clean-completion gate on the lastFullSweep stamp (#696) ----
+
+	@AfterEach
+	public void clearErrorFlag() {
+		RetrievalErrorTracker.reset();
+	}
+
+	private static AbstractReCiterRetrievalEngine engineWith(ESearchResultService service) {
+		AbstractReCiterRetrievalEngine engine = new AbstractReCiterRetrievalEngine() {
+			@Override
+			public boolean retrieveArticlesByDateRange(List<Identity> identities, java.util.Date startDate,
+					java.util.Date endDate, RetrievalRefreshFlag refreshFlag) {
+				return true;
+			}
+
+			@Override
+			public void retrieveByPmids(String uid, List<Long> pmids) {
+			}
+		};
+		engine.eSearchResultService = service;
+		return engine;
+	}
+
+	@Test
+	public void cleanFullSweepStampsLastFullSweep() {
+		ESearchResultService service = mock(ESearchResultService.class);
+		RetrievalErrorTracker.reset();
+
+		engineWith(service).stampLastFullSweepIfClean("cam4024", RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		verify(service).stampLastFullSweepIfNewer(eq("cam4024"), any(Instant.class));
+	}
+
+	@Test
+	public void sweepThatHitTheSwallowPathIsNotStamped() {
+		// Stamping after a swallowed PubMed failure would lock the loss in for a full
+		// interval; an unstamped person simply stays due and the sweep is retried.
+		ESearchResultService service = mock(ESearchResultService.class);
+		RetrievalErrorTracker.reset();
+		RetrievalErrorTracker.markError();
+
+		engineWith(service).stampLastFullSweepIfClean("cam4024", RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		verify(service, never()).stampLastFullSweepIfNewer(anyString(), any(Instant.class));
+	}
+
+	@Test
+	public void incrementalRunsNeverStamp() {
+		ESearchResultService service = mock(ESearchResultService.class);
+		RetrievalErrorTracker.reset();
+
+		engineWith(service).stampLastFullSweepIfClean("cam4024", RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+		engineWith(service).stampLastFullSweepIfClean("cam4024", null);
+
+		verify(service, never()).stampLastFullSweepIfNewer(anyString(), any(Instant.class));
 	}
 }

--- a/src/test/java/reciter/xml/retriever/pubmed/RetrievalWindowTest.java
+++ b/src/test/java/reciter/xml/retriever/pubmed/RetrievalWindowTest.java
@@ -2,13 +2,22 @@ package reciter.xml.retriever.pubmed;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+
+import reciter.database.dynamodb.model.ESearchPmid;
+import reciter.database.dynamodb.model.ESearchResult;
 
 public class RetrievalWindowTest {
 
@@ -16,6 +25,10 @@ public class RetrievalWindowTest {
 
 	private static Instant on(int y, int m, int d) {
 		return LocalDate.of(y, m, d).atStartOfDay(ZoneOffset.UTC).toInstant();
+	}
+
+	private static Instant daysAgo(long days) {
+		return TODAY.minusDays(days).atStartOfDay(ZoneOffset.UTC).toInstant();
 	}
 
 	@Test
@@ -68,5 +81,130 @@ public class RetrievalWindowTest {
 	@Test
 	public void nullWatermarkFallsBackToTheFloor() {
 		assertEquals(LocalDate.of(2026, 5, 5), RetrievalWindow.incrementalStart(null, TODAY, 90));
+	}
+
+	// ---- Full-sweep escalation (#696) ----
+
+	@Test
+	public void fullSweepDueWhenLastSweepOlderThanMaxAge() {
+		// Jitter 0 keeps the boundary crisp: due exactly at lastFullSweep + maxAge.
+		assertTrue(RetrievalWindow.fullSweepDue(daysAgo(91), TODAY, "cam4024", 90, 0));
+		assertTrue(RetrievalWindow.fullSweepDue(daysAgo(90), TODAY, "cam4024", 90, 0));
+	}
+
+	@Test
+	public void fullSweepNotDueBelowMaxAge() {
+		assertFalse(RetrievalWindow.fullSweepDue(daysAgo(89), TODAY, "cam4024", 90, 0));
+		assertFalse(RetrievalWindow.fullSweepDue(daysAgo(1), TODAY, "cam4024", 90, 0));
+	}
+
+	@Test
+	public void zeroOrNegativeMaxAgeNeverEscalates() {
+		// The parameterless default: even a uid with no sweep on record must not be
+		// upgraded — non-batch callers are not budgeting these.
+		assertFalse(RetrievalWindow.fullSweepDue(null, TODAY, "cam4024", 0, 45));
+		assertFalse(RetrievalWindow.fullSweepDue(daysAgo(10_000), TODAY, "cam4024", 0, 45));
+		assertFalse(RetrievalWindow.fullSweepDue(daysAgo(10_000), TODAY, "cam4024", -1, 45));
+	}
+
+	@Test
+	public void noSweepOnRecordIsDueWhenEscalationEnabled() {
+		assertTrue(RetrievalWindow.fullSweepDue(null, TODAY, "cam4024", 90, 45));
+	}
+
+	// ---- Jitter ----
+
+	@Test
+	public void jitterOffsetsSpreadAcrossUids() {
+		// The point of the jitter is that uids swept on the same date do NOT all come
+		// due together. A constant (e.g. always-zero) offset satisfies stability but
+		// defeats the spread; this asserts genuine dispersion across a cohort.
+		Set<Integer> offsets = new HashSet<>();
+		for (int i = 0; i < 200; i++) {
+			int offset = RetrievalWindow.jitterOffset("uid" + i, 45);
+			assertTrue(offset >= 0 && offset < 45, "offset " + offset + " outside [0,45)");
+			offsets.add(offset);
+		}
+		assertTrue(offsets.size() > 10, "expected a spread of offsets, got " + offsets.size() + " distinct value(s)");
+	}
+
+	@Test
+	public void jitterOffsetIsStableAcrossDistinctStringInstances() {
+		// Stability must come from the uid's value, not object identity or a RNG —
+		// otherwise the spread re-randomizes nightly and people flap in and out of
+		// dueness. Distinct String instances rule out identity-hash implementations.
+		String literal = "cam4024";
+		String constructed = new StringBuilder("cam").append("4024").toString();
+		assertNotSame(literal, constructed);
+		assertEquals(RetrievalWindow.jitterOffset(literal, 45), RetrievalWindow.jitterOffset(constructed, 45));
+	}
+
+	@Test
+	public void jitterShiftsTheDueBoundaryPerUid() {
+		// Find two uids with different offsets, then show each uid's due boundary sits
+		// exactly at maxAge + its own offset: due on the boundary day, not due one day
+		// fresher. This fails for any implementation that ignores the uid.
+		String uidA = "uid0";
+		String uidB = null;
+		for (int i = 1; i < 1000 && uidB == null; i++) {
+			if (RetrievalWindow.jitterOffset("uid" + i, 45) != RetrievalWindow.jitterOffset(uidA, 45)) {
+				uidB = "uid" + i;
+			}
+		}
+		assertNotNull(uidB, "expected two uids with different jitter offsets");
+		for (String uid : Arrays.asList(uidA, uidB)) {
+			int offset = RetrievalWindow.jitterOffset(uid, 45);
+			assertTrue(RetrievalWindow.fullSweepDue(daysAgo(90 + offset), TODAY, uid, 90, 45),
+					uid + " (offset " + offset + ") must be due at its jittered boundary");
+			assertFalse(RetrievalWindow.fullSweepDue(daysAgo(90 + offset - 1), TODAY, uid, 90, 45),
+					uid + " (offset " + offset + ") must not be due one day before its jittered boundary");
+		}
+	}
+
+	@Test
+	public void zeroJitterMeansUnshiftedBoundary() {
+		assertEquals(0, RetrievalWindow.jitterOffset("cam4024", 0));
+		assertEquals(0, RetrievalWindow.jitterOffset(null, 45));
+	}
+
+	// ---- Lazy seeding: inference fallback for un-stamped items ----
+
+	@Test
+	public void inferredLastFullSweepPicksTheLatestAllPublicationsEntry() {
+		ESearchResult result = new ESearchResult();
+		result.setESearchPmids(Arrays.asList(
+				entry("EmailRetrievalStrategy", on(2026, 3, 1), ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS),
+				entry("FullNameRetrievalStrategy", on(2026, 5, 15), ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS),
+				// A fresher incremental entry must NOT count as a full sweep.
+				entry("GoldStandardRetrievalStrategy", on(2026, 8, 1),
+						ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
+		assertEquals(on(2026, 5, 15), RetrievalWindow.inferredLastFullSweep(result));
+	}
+
+	@Test
+	public void inferredLastFullSweepIsNullWithoutAnyAllPublicationsEntry() {
+		ESearchResult result = new ESearchResult();
+		result.setESearchPmids(Arrays.asList(
+				entry("EmailRetrievalStrategy", on(2026, 8, 1),
+						ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)));
+		assertNull(RetrievalWindow.inferredLastFullSweep(result));
+	}
+
+	@Test
+	public void inferredLastFullSweepToleratesSparseItems() {
+		assertNull(RetrievalWindow.inferredLastFullSweep(null));
+		assertNull(RetrievalWindow.inferredLastFullSweep(new ESearchResult()));
+
+		ESearchResult sparse = new ESearchResult();
+		sparse.setESearchPmids(Arrays.asList(
+				null,
+				entry("EmailRetrievalStrategy", null, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS),
+				entry("FullNameRetrievalStrategy", on(2026, 5, 15), null)));
+		assertNull(RetrievalWindow.inferredLastFullSweep(sparse));
+	}
+
+	private static ESearchPmid entry(String strategy, Instant retrievalDate,
+			ESearchPmid.RetrievalRefreshFlag lookupType) {
+		return new ESearchPmid(Arrays.asList(1L), strategy, retrievalDate, lookupType);
 	}
 }


### PR DESCRIPTION
Layer A2 of continuous full retrieval: on an incremental request that opts in, escalate to `ALL_PUBLICATIONS` when the person's last full sweep is too old. Stacked on #697 (the A1 lookback floor) — this diff shows only the A2 delta.

## Protocol

- **Opt-in per request.** `fullSweepMaxAgeDays` rides on `GET /reciter/feature-generator/by/uid` (and on `/reciter/retrieve/articles/by/uid`). A positive value enables the staleness check for that request; absent or `0` means floor only, **never** escalate. The server default `retrieval.full-sweep.max-age-days` is `0` and must stay `0` — Publication Manager and ad-hoc callers hit the same endpoints and must not have a seconds-long incremental silently upgraded to an unbounded re-disambiguation. Policy (per-cohort intervals) stays in the client's ConfigMap; state (who was swept when) stays server-side.
- **Dueness** = last full sweep older than `maxAgeDays` + a stable per-uid jitter offset (`Math.floorMod(uid.hashCode(), jitter-days)`, default spread 45d, `retrieval.full-sweep.jitter-days`). Sweep dates are heavily clustered (4,898 people share one date); the jitter spreads a cohort's due dates so an "older than N" rule cannot bring thousands due the same night. The offset is derived from the uid, not drawn at random, so people come due once instead of flapping.
- **Escalated sweeps do not delete the `ESearchResult`** (unlike the manual `ALL_PUBLICATIONS` path): strategy entries refresh in place, so candidate pmids survive a sweep that dies midway.

## Persisted `lastFullSweep` + stamping rule

- New `lastFullSweep` attribute on the `ESearchResult` item. The model class is in the `reciter-dynamodb-model` artifact, so the attribute is managed with the low-level client: a conditional `UpdateItem` to write, a projected `GetItem` to read. `ESearchResultRepository.save` switches `putItem` → `updateItem` so ordinary strategy saves (which rebuild the bean) no longer erase attributes the bean schema doesn't know about.
- **Stamp only on clean completion.** `RetrievalErrorTracker` is reset at the start of `retrieveData` and checked at the end; the stamp is skipped if any strategy entered the error-swallow path. This extends #691's discipline to the path full sweeps actually take — #691's watermark rollback lives in `retrieveDataByDateRange`, which `ALL_PUBLICATIONS` runs never reach (an in-code comment implying otherwise is corrected). An unstamped person simply stays due and the sweep is retried; stamping a bad sweep would lock the loss in for 30–365 days.
- **Non-regressing write.** Condition: `attribute_exists(uid) AND (attribute_not_exists(lastFullSweep) OR lastFullSweep < :ts)` — evaluated inside DynamoDB, so a Publication Manager sweep racing the batch cannot move the stamp backward under any interleaving. The timestamp is a fixed-width UTC string (`uuuu-MM-dd'T'HH:mm:ss.SSS'Z'`) because the condition compares lexicographically and `Instant.toString()`'s variable-length fractions would mis-order sub-second cases.

## Response-signal contract (for the client budget, ReCiter-Institutional-Client#135)

Every **200** from `/reciter/feature-generator/by/uid` (all branches, including cached-analysis) and from `/reciter/retrieve/articles/by/uid` carries three headers:

| Header | Values | Meaning |
|---|---|---|
| `X-Reciter-Escalated` | `true` / `false` | This request's `ONLY_NEWLY_ADDED` retrieval was escalated to `ALL_PUBLICATIONS` by the `fullSweepMaxAgeDays` check. **This is the value the client counts against its nightly budget.** Counted at dispatch, so a sweep that later failed still counts (it consumed sweep time). |
| `X-Reciter-Auto-Upgraded` | `true` / `false` | The request was forced to `ALL_PUBLICATIONS` because the uid had no `ESearchResult`. Reported separately because these sweeps are unbudgeted — during any E10 recurrence they number in the thousands, and folding them into the escalation count would make "the budget is holding" a false signal. |
| `X-Reciter-Retrieval-Mode` | `ALL_PUBLICATIONS` / `ONLY_NEWLY_ADDED_PUBLICATIONS` / `NONE` | Retrieval actually executed (`NONE` = cached results, no retrieval). |

Non-200 responses (404/500) carry no signal headers; the client should treat an absent header as not-escalated. Jersey side: `response.getHeaderString("X-Reciter-Escalated")`.

## Day-one seeding, without a migration

`lastFullSweep` is null for every existing record. While it is null, the escalation decision falls back to the `lookupType` inference computed from the item's own `esearchpmids` (max `retrievalDate` where `lookupType == ALL_PUBLICATIONS`). That is lazy seeding from exactly the distribution the spec's Part 4 sizing tables were computed against, with the same safe error direction: incremental runs erase the marker (E13), so a person can only look *less* recently swept than they are — biasing toward an extra sweep, bounded by the client budget, and self-correcting once the person's first clean sweep stamps a real value. The inferred value is **never written back** — only genuine clean sweeps stamp — and no 32k-item write migration is needed.

## Independent scoring fix (E13)

`savePubMedArticles` now refuses to downgrade a strategy entry's `lookupType` from `ALL_PUBLICATIONS` to an incremental flag. The stored entry keeps the marker **and the sweep's `retrievalDate`** (bumping the date on an incremental run would fake a fresh sweep and suppress a due escalation) and merges the pmid lists (replacing them would collapse `ArticleSizeStrategy`'s `articleCountScore` input to one night's articles). This protects scoring regardless of whether escalation is ever enabled.

## Deployment gates

1. **#691 must be in prod before stamping goes live.** `RetrievalErrorTracker.markError()` is what makes "clean completion" observable; without #691's image the tracker never fires and a swallowed failure would be stamped as clean.
2. **Client budget (ReCiter-Institutional-Client#135) before escalation is enabled.** Escalation stays inert until the client sends `fullSweepMaxAgeDays > 0`, and it must not do that until the nightly budget/ordering from spec step 5 is in place — an unbudgeted first night is the ~99-hour backlog E14 warns about. Deploying this PR alone changes no behavior beyond the stamping and the downgrade guard.

## Tests

`mvn clean test`: 227 tests, 0 failures (195 on the #697 base). New coverage: escalation above/below threshold; parameterless and zero never escalate (and never read the stamp); persisted stamp preferred over inference in both directions; jitter genuinely exercised (dispersion across 200 uids, stability across distinct String instances, per-uid due boundary shifts with the offset); stamp skipped when a strategy failed; conditional write refuses to regress without erroring; sortable-timestamp ordering incl. the sub-second case; inference fallback and null-tolerance; downgrade guard incl. pmid-merge and date preservation.

Refs #696.
