### PR TITLE
feat(external-article): title/journal/pubYear on ExternalArticleDupCheck.Match

### DIFF
--- a/src/main/java/reciter/service/dynamo/ExternalArticleDupCheck.java
+++ b/src/main/java/reciter/service/dynamo/ExternalArticleDupCheck.java
@@ -28,11 +28,21 @@ public final class ExternalArticleDupCheck {
         private final String type;
         private final String matchedId;
         private final String detail;
+        private final String title;
+        private final String journal;
+        private final String pubYear;
 
         Match(String type, String matchedId, String detail) {
+            this(type, matchedId, detail, null, null, null);
+        }
+
+        Match(String type, String matchedId, String detail, String title, String journal, String pubYear) {
             this.type = type;
             this.matchedId = matchedId;
             this.detail = detail;
+            this.title = title;
+            this.journal = journal;
+            this.pubYear = pubYear;
         }
 
         public String getType() {
@@ -45,6 +55,23 @@ public final class ExternalArticleDupCheck {
 
         public String getDetail() {
             return detail;
+        }
+
+        /** Matched record's title, when known — null for the two gold-standard PMID
+         * matches (a GoldStandard entry carries no title, only the PMID). */
+        public String getTitle() {
+            return title;
+        }
+
+        /** Matched record's journal/venue, when known — null where the underlying
+         * record doesn't carry one (e.g. gold-standard PMID matches). */
+        public String getJournal() {
+            return journal;
+        }
+
+        /** Matched record's publication year, when known. */
+        public String getPubYear() {
+            return pubYear;
         }
     }
 
@@ -81,19 +108,24 @@ public final class ExternalArticleDupCheck {
         String candidateYear = year(candidate.getPubDate());
 
         for (ExternalArticle existing : safe(existingExternal)) {
+            String existingYear = year(existing.getPubDate());
             if (existing.getArticleId() != null && existing.getArticleId().equals(candidate.getArticleId())) {
                 blocked.add(new Match("ALREADY_ADDED", existing.getArticleId(),
-                        "This external article was already added for this person."));
+                        "This external article was already added for this person.",
+                        existing.getTitle(), existing.getJournalOrVenue(), existingYear));
             } else if (candidate.getPmid() != null && candidate.getPmid().equals(existing.getPmid())) {
                 blocked.add(new Match("PMID_MATCH_EXTERNAL", existing.getArticleId(),
-                        "An external article with the same PMID was already added from " + existing.getSourceType() + "."));
+                        "An external article with the same PMID was already added from " + existing.getSourceType() + ".",
+                        existing.getTitle(), existing.getJournalOrVenue(), existingYear));
             } else if (candidateDoi != null && candidateDoi.equals(normalizeDoi(existing.getDoi()))) {
                 blocked.add(new Match("DOI_MATCH_EXTERNAL", existing.getArticleId(),
-                        "An external article with the same DOI was already added from " + existing.getSourceType() + "."));
+                        "An external article with the same DOI was already added from " + existing.getSourceType() + ".",
+                        existing.getTitle(), existing.getJournalOrVenue(), existingYear));
             } else if (titleYearCollision(candidateTitle, candidateYear,
-                    normalizeTitle(existing.getTitle()), year(existing.getPubDate()))) {
+                    normalizeTitle(existing.getTitle()), existingYear)) {
                 warnings.add(new Match("TITLE_YEAR_MATCH_EXTERNAL", existing.getArticleId(),
-                        "An external article with a matching title and year was already added: " + existing.getTitle()));
+                        "An external article with a matching title and year was already added: " + existing.getTitle(),
+                        existing.getTitle(), existing.getJournalOrVenue(), existingYear));
             }
         }
 
@@ -107,16 +139,20 @@ public final class ExternalArticleDupCheck {
         }
 
         for (ReCiterArticleFeature feature : safe(candidateArticles)) {
+            String featureYear = year(feature.getPublicationDateStandardized());
             if (candidate.getPmid() != null && feature.getPmid() == candidate.getPmid()) {
                 blocked.add(new Match("PMID_IN_CANDIDATES", String.valueOf(feature.getPmid()),
-                        "This PMID exists in the person's PubMed candidate set; adjudicate it via normal feedback instead."));
+                        "This PMID exists in the person's PubMed candidate set; adjudicate it via normal feedback instead.",
+                        feature.getArticleTitle(), feature.getJournalTitleVerbose(), featureYear));
             } else if (candidateDoi != null && candidateDoi.equals(normalizeDoi(feature.getDoi()))) {
                 blocked.add(new Match("DOI_MATCH", String.valueOf(feature.getPmid()),
-                        "A PubMed article with the same DOI exists in the person's candidate set (PMID " + feature.getPmid() + ")."));
+                        "A PubMed article with the same DOI exists in the person's candidate set (PMID " + feature.getPmid() + ").",
+                        feature.getArticleTitle(), feature.getJournalTitleVerbose(), featureYear));
             } else if (titleYearCollision(candidateTitle, candidateYear,
-                    normalizeTitle(feature.getArticleTitle()), year(feature.getPublicationDateStandardized()))) {
+                    normalizeTitle(feature.getArticleTitle()), featureYear)) {
                 warnings.add(new Match("TITLE_YEAR_MATCH", String.valueOf(feature.getPmid()),
-                        "A PubMed article with a matching title and year exists (PMID " + feature.getPmid() + "): " + feature.getArticleTitle()));
+                        "A PubMed article with a matching title and year exists (PMID " + feature.getPmid() + "): " + feature.getArticleTitle(),
+                        feature.getArticleTitle(), feature.getJournalTitleVerbose(), featureYear));
             }
         }
 

--- a/src/main/java/reciter/service/dynamo/ExternalArticleDupCheck.java
+++ b/src/main/java/reciter/service/dynamo/ExternalArticleDupCheck.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import reciter.database.dynamodb.model.ExternalArticle;
 import reciter.engine.analysis.ReCiterArticleFeature;
@@ -20,23 +22,47 @@ import reciter.engine.analysis.ReCiterArticleFeature;
  */
 public final class ExternalArticleDupCheck {
 
+    private static final Pattern YEAR = Pattern.compile("\\d{4}");
+    /** doi.org / dx.doi.org URL forms and the bare "doi:" prefix all denote the same DOI. */
+    private static final Pattern DOI_PREFIX = Pattern.compile("^(https?://(dx\\.)?doi\\.org/|doi:\\s*)");
+
     public enum Level {
         OK, WARNING, BLOCKED
     }
 
+    /**
+     * Why a match fired. Serializes to its own name, so the JSON contract PM reads is
+     * unchanged from when this was a String.
+     *
+     * Note that {@link Match#getMatchedId()} is polymorphic across these: the
+     * *_EXTERNAL and ALREADY_ADDED types carry an ExternalArticle articleId
+     * (e.g. "SCOPUS:2-s2.0-..."), every other type carries a PMID. See #735.
+     */
+    public enum MatchType {
+        ALREADY_ADDED,
+        PMID_MATCH_EXTERNAL,
+        DOI_MATCH_EXTERNAL,
+        TITLE_YEAR_MATCH_EXTERNAL,
+        PMID_IN_GOLD_STANDARD,
+        PMID_REJECTED_IN_GOLD_STANDARD,
+        PMID_IN_CANDIDATES,
+        DOI_MATCH,
+        TITLE_YEAR_MATCH
+    }
+
     public static final class Match {
-        private final String type;
+        private final MatchType type;
         private final String matchedId;
         private final String detail;
         private final String title;
         private final String journal;
         private final String pubYear;
 
-        Match(String type, String matchedId, String detail) {
+        Match(MatchType type, String matchedId, String detail) {
             this(type, matchedId, detail, null, null, null);
         }
 
-        Match(String type, String matchedId, String detail, String title, String journal, String pubYear) {
+        Match(MatchType type, String matchedId, String detail, String title, String journal, String pubYear) {
             this.type = type;
             this.matchedId = matchedId;
             this.detail = detail;
@@ -45,7 +71,7 @@ public final class ExternalArticleDupCheck {
             this.pubYear = pubYear;
         }
 
-        public String getType() {
+        public MatchType getType() {
             return type;
         }
 
@@ -81,7 +107,7 @@ public final class ExternalArticleDupCheck {
 
         Result(Level level, List<Match> matches) {
             this.level = level;
-            this.matches = matches;
+            this.matches = List.copyOf(matches);
         }
 
         public Level getLevel() {
@@ -110,47 +136,47 @@ public final class ExternalArticleDupCheck {
         for (ExternalArticle existing : safe(existingExternal)) {
             String existingYear = year(existing.getPubDate());
             if (existing.getArticleId() != null && existing.getArticleId().equals(candidate.getArticleId())) {
-                blocked.add(new Match("ALREADY_ADDED", existing.getArticleId(),
+                blocked.add(new Match(MatchType.ALREADY_ADDED, existing.getArticleId(),
                         "This external article was already added for this person.",
                         existing.getTitle(), existing.getJournalOrVenue(), existingYear));
             } else if (candidate.getPmid() != null && candidate.getPmid().equals(existing.getPmid())) {
-                blocked.add(new Match("PMID_MATCH_EXTERNAL", existing.getArticleId(),
+                blocked.add(new Match(MatchType.PMID_MATCH_EXTERNAL, existing.getArticleId(),
                         "An external article with the same PMID was already added from " + existing.getSourceType() + ".",
                         existing.getTitle(), existing.getJournalOrVenue(), existingYear));
             } else if (candidateDoi != null && candidateDoi.equals(normalizeDoi(existing.getDoi()))) {
-                blocked.add(new Match("DOI_MATCH_EXTERNAL", existing.getArticleId(),
+                blocked.add(new Match(MatchType.DOI_MATCH_EXTERNAL, existing.getArticleId(),
                         "An external article with the same DOI was already added from " + existing.getSourceType() + ".",
                         existing.getTitle(), existing.getJournalOrVenue(), existingYear));
             } else if (titleYearCollision(candidateTitle, candidateYear,
                     normalizeTitle(existing.getTitle()), existingYear)) {
-                warnings.add(new Match("TITLE_YEAR_MATCH_EXTERNAL", existing.getArticleId(),
+                warnings.add(new Match(MatchType.TITLE_YEAR_MATCH_EXTERNAL, existing.getArticleId(),
                         "An external article with a matching title and year was already added: " + existing.getTitle(),
                         existing.getTitle(), existing.getJournalOrVenue(), existingYear));
             }
         }
 
         if (candidate.getPmid() != null && knownPmids != null && knownPmids.contains(candidate.getPmid())) {
-            blocked.add(new Match("PMID_IN_GOLD_STANDARD", String.valueOf(candidate.getPmid()),
+            blocked.add(new Match(MatchType.PMID_IN_GOLD_STANDARD, String.valueOf(candidate.getPmid()),
                     "This PMID is already accepted in the person's gold standard."));
         }
         if (candidate.getPmid() != null && rejectedPmids != null && rejectedPmids.contains(candidate.getPmid())) {
-            blocked.add(new Match("PMID_REJECTED_IN_GOLD_STANDARD", String.valueOf(candidate.getPmid()),
+            blocked.add(new Match(MatchType.PMID_REJECTED_IN_GOLD_STANDARD, String.valueOf(candidate.getPmid()),
                     "This PMID was explicitly rejected by a curator; do not re-add it from an external source."));
         }
 
         for (ReCiterArticleFeature feature : safe(candidateArticles)) {
             String featureYear = year(feature.getPublicationDateStandardized());
-            if (candidate.getPmid() != null && feature.getPmid() == candidate.getPmid()) {
-                blocked.add(new Match("PMID_IN_CANDIDATES", String.valueOf(feature.getPmid()),
+            if (candidate.getPmid() != null && candidate.getPmid().longValue() == feature.getPmid()) {
+                blocked.add(new Match(MatchType.PMID_IN_CANDIDATES, String.valueOf(feature.getPmid()),
                         "This PMID exists in the person's PubMed candidate set; adjudicate it via normal feedback instead.",
                         feature.getArticleTitle(), feature.getJournalTitleVerbose(), featureYear));
             } else if (candidateDoi != null && candidateDoi.equals(normalizeDoi(feature.getDoi()))) {
-                blocked.add(new Match("DOI_MATCH", String.valueOf(feature.getPmid()),
+                blocked.add(new Match(MatchType.DOI_MATCH, String.valueOf(feature.getPmid()),
                         "A PubMed article with the same DOI exists in the person's candidate set (PMID " + feature.getPmid() + ").",
                         feature.getArticleTitle(), feature.getJournalTitleVerbose(), featureYear));
             } else if (titleYearCollision(candidateTitle, candidateYear,
                     normalizeTitle(feature.getArticleTitle()), featureYear)) {
-                warnings.add(new Match("TITLE_YEAR_MATCH", String.valueOf(feature.getPmid()),
+                warnings.add(new Match(MatchType.TITLE_YEAR_MATCH, String.valueOf(feature.getPmid()),
                         "A PubMed article with a matching title and year exists (PMID " + feature.getPmid() + "): " + feature.getArticleTitle(),
                         feature.getArticleTitle(), feature.getJournalTitleVerbose(), featureYear));
             }
@@ -194,13 +220,13 @@ public final class ExternalArticleDupCheck {
         return yearA == null || yearB == null || yearA.equals(yearB);
     }
 
-    /** Lowercase, trim, strip any doi.org URL prefix. Returns null for blank input. */
+    /** Lowercase, trim, strip any doi.org URL or "doi:" prefix. Returns null for blank input. */
     static String normalizeDoi(String doi) {
         if (doi == null) {
             return null;
         }
-        String normalized = doi.trim().toLowerCase(Locale.ROOT)
-                .replaceFirst("^https?://(dx\\.)?doi\\.org/", "");
+        String normalized = DOI_PREFIX.matcher(doi.trim().toLowerCase(Locale.ROOT))
+                .replaceFirst("").trim();
         return normalized.isEmpty() ? null : normalized;
     }
 
@@ -220,7 +246,7 @@ public final class ExternalArticleDupCheck {
         if (date == null) {
             return null;
         }
-        java.util.regex.Matcher m = java.util.regex.Pattern.compile("\\d{4}").matcher(date);
+        Matcher m = YEAR.matcher(date);
         return m.find() ? m.group() : null;
     }
 

--- a/src/test/java/reciter/service/dynamo/ExternalArticleDupCheckTest.java
+++ b/src/test/java/reciter/service/dynamo/ExternalArticleDupCheckTest.java
@@ -131,19 +131,28 @@ public class ExternalArticleDupCheckTest {
                 Collections.emptyList(),
                 Arrays.asList(existing));
         assertEquals(Level.BLOCKED, result.getLevel());
-        assertEquals("ALREADY_ADDED", result.getMatches().get(0).getType());
+        ExternalArticleDupCheck.Match match = result.getMatches().get(0);
+        assertEquals("ALREADY_ADDED", match.getType());
+        assertEquals("A Title", match.getTitle());
+        assertEquals("2020", match.getPubYear());
     }
 
     @Test
     public void titleAndYearCollisionWarns() {
+        ReCiterArticleFeature matched = pubmedArticle(44444L, null, "Deep learning for author disambiguation", "2023-09-15");
+        matched.setJournalTitleVerbose("Journal of Disambiguation");
         Result result = ExternalArticleDupCheck.check(
                 candidate("OPENALEX:W123", null, null, "Deep Learning for Author Disambiguation!", "2023"),
                 Collections.emptyList(),
                 Collections.emptyList(),
-                Arrays.asList(pubmedArticle(44444L, null, "Deep learning for author disambiguation", "2023-09-15")),
+                Arrays.asList(matched),
                 Collections.emptyList());
         assertEquals(Level.WARNING, result.getLevel());
-        assertEquals("TITLE_YEAR_MATCH", result.getMatches().get(0).getType());
+        ExternalArticleDupCheck.Match match = result.getMatches().get(0);
+        assertEquals("TITLE_YEAR_MATCH", match.getType());
+        assertEquals("Deep learning for author disambiguation", match.getTitle());
+        assertEquals("Journal of Disambiguation", match.getJournal());
+        assertEquals("2023", match.getPubYear());
     }
 
     @Test

--- a/src/test/java/reciter/service/dynamo/ExternalArticleDupCheckTest.java
+++ b/src/test/java/reciter/service/dynamo/ExternalArticleDupCheckTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import reciter.database.dynamodb.model.ExternalArticle;
 import reciter.engine.analysis.ReCiterArticleFeature;
 import reciter.service.dynamo.ExternalArticleDupCheck.Level;
+import reciter.service.dynamo.ExternalArticleDupCheck.MatchType;
 import reciter.service.dynamo.ExternalArticleDupCheck.Result;
 
 public class ExternalArticleDupCheckTest {
@@ -56,7 +57,7 @@ public class ExternalArticleDupCheckTest {
                 Collections.emptyList(),
                 Collections.emptyList());
         assertEquals(Level.BLOCKED, result.getLevel());
-        assertEquals("PMID_IN_GOLD_STANDARD", result.getMatches().get(0).getType());
+        assertEquals(MatchType.PMID_IN_GOLD_STANDARD, result.getMatches().get(0).getType());
     }
 
     @Test
@@ -68,7 +69,7 @@ public class ExternalArticleDupCheckTest {
                 Collections.emptyList(),
                 Collections.emptyList());
         assertEquals(Level.BLOCKED, result.getLevel());
-        assertEquals("PMID_REJECTED_IN_GOLD_STANDARD", result.getMatches().get(0).getType());
+        assertEquals(MatchType.PMID_REJECTED_IN_GOLD_STANDARD, result.getMatches().get(0).getType());
     }
 
     @Test
@@ -80,7 +81,7 @@ public class ExternalArticleDupCheckTest {
                 Arrays.asList(pubmedArticle(22222L, null, "Any Title", "2020-01-01")),
                 Collections.emptyList());
         assertEquals(Level.BLOCKED, result.getLevel());
-        assertEquals("PMID_IN_CANDIDATES", result.getMatches().get(0).getType());
+        assertEquals(MatchType.PMID_IN_CANDIDATES, result.getMatches().get(0).getType());
     }
 
     @Test
@@ -93,7 +94,7 @@ public class ExternalArticleDupCheckTest {
                 Collections.emptyList(),
                 Arrays.asList(existing));
         assertEquals(Level.BLOCKED, result.getLevel());
-        assertEquals("PMID_MATCH_EXTERNAL", result.getMatches().get(0).getType());
+        assertEquals(MatchType.PMID_MATCH_EXTERNAL, result.getMatches().get(0).getType());
     }
 
     @Test
@@ -105,7 +106,7 @@ public class ExternalArticleDupCheckTest {
                 Arrays.asList(pubmedArticle(33333L, "10.1000/abc", "Original Title", "2021-05-01")),
                 Collections.emptyList());
         assertEquals(Level.BLOCKED, result.getLevel());
-        assertEquals("DOI_MATCH", result.getMatches().get(0).getType());
+        assertEquals(MatchType.DOI_MATCH, result.getMatches().get(0).getType());
     }
 
     @Test
@@ -118,7 +119,7 @@ public class ExternalArticleDupCheckTest {
                 Collections.emptyList(),
                 Arrays.asList(existing));
         assertEquals(Level.BLOCKED, result.getLevel());
-        assertEquals("DOI_MATCH_EXTERNAL", result.getMatches().get(0).getType());
+        assertEquals(MatchType.DOI_MATCH_EXTERNAL, result.getMatches().get(0).getType());
     }
 
     @Test
@@ -132,7 +133,7 @@ public class ExternalArticleDupCheckTest {
                 Arrays.asList(existing));
         assertEquals(Level.BLOCKED, result.getLevel());
         ExternalArticleDupCheck.Match match = result.getMatches().get(0);
-        assertEquals("ALREADY_ADDED", match.getType());
+        assertEquals(MatchType.ALREADY_ADDED, match.getType());
         assertEquals("A Title", match.getTitle());
         assertEquals("2020", match.getPubYear());
     }
@@ -149,7 +150,7 @@ public class ExternalArticleDupCheckTest {
                 Collections.emptyList());
         assertEquals(Level.WARNING, result.getLevel());
         ExternalArticleDupCheck.Match match = result.getMatches().get(0);
-        assertEquals("TITLE_YEAR_MATCH", match.getType());
+        assertEquals(MatchType.TITLE_YEAR_MATCH, match.getType());
         assertEquals("Deep learning for author disambiguation", match.getTitle());
         assertEquals("Journal of Disambiguation", match.getJournal());
         assertEquals("2023", match.getPubYear());
@@ -164,7 +165,7 @@ public class ExternalArticleDupCheckTest {
                 Arrays.asList(pubmedArticle(44444L, null, "Deep learning for author disambiguation", null)),
                 Collections.emptyList());
         assertEquals(Level.WARNING, result.getLevel());
-        assertEquals("TITLE_YEAR_MATCH", result.getMatches().get(0).getType());
+        assertEquals(MatchType.TITLE_YEAR_MATCH, result.getMatches().get(0).getType());
     }
 
     @Test
@@ -226,6 +227,40 @@ public class ExternalArticleDupCheckTest {
     public void normalizers() {
         assertEquals("10.1000/abc", ExternalArticleDupCheck.normalizeDoi(" https://dx.doi.org/10.1000/ABC "));
         assertNull(ExternalArticleDupCheck.normalizeDoi("  "));
+    }
+
+    /** Every form a curator or an upstream source can hand us for the same DOI must
+     * normalize to one string, or the BLOCKED DOI paths silently miss real duplicates. */
+    @Test
+    public void normalizeDoiFoldsEveryCommonPrefixForm() {
+        String expected = "10.1000/abc";
+        for (String variant : Arrays.asList(
+                "10.1000/abc",
+                "10.1000/ABC",
+                "  10.1000/abc  ",
+                "doi:10.1000/abc",
+                "DOI: 10.1000/abc",
+                "http://doi.org/10.1000/abc",
+                "https://doi.org/10.1000/abc",
+                "http://dx.doi.org/10.1000/abc",
+                "https://dx.doi.org/10.1000/ABC")) {
+            assertEquals(variant, expected, ExternalArticleDupCheck.normalizeDoi(variant));
+        }
+        assertNull(ExternalArticleDupCheck.normalizeDoi(null));
+        assertNull(ExternalArticleDupCheck.normalizeDoi("https://doi.org/"));
+    }
+
+    /** A "doi:"-prefixed external DOI must still BLOCK against the bare form in the
+     * person's PubMed candidate set — the case the folding above exists for. */
+    @Test
+    public void doiPrefixVariantStillBlocksAgainstCandidateSet() {
+        Result result = ExternalArticleDupCheck.check(
+                candidate("SCOPUS:1", null, "doi: 10.1000/ABC", "Some title", "2024"),
+                null, null,
+                Collections.singletonList(pubmedArticle(111L, "10.1000/abc", "Other title", "2024-01-01")),
+                Collections.emptyList());
+        assertEquals(Level.BLOCKED, result.getLevel());
+        assertEquals(MatchType.DOI_MATCH, result.getMatches().get(0).getType());
         assertEquals("deep learning 2 0", ExternalArticleDupCheck.normalizeTitle("Deep-Learning: 2.0?"));
         assertEquals("2023", ExternalArticleDupCheck.year("2023-09-15"));
         assertNull(ExternalArticleDupCheck.year("n.d."));


### PR DESCRIPTION
The client-facing 409 body for a duplicate warning/block only ever carried a bare `matchedId` (PMID or articleId) plus a hand-built message sentence — no structured way for a curator-facing UI to show what it's actually conflicting with. The matched record (`ExternalArticle` or `ReCiterArticleFeature`) is already fully loaded in memory at every call site in `ExternalArticleDupCheck.check()`; this reads three more getters off objects already in scope and adds them as fields on `Match`, serialized automatically via the existing Jackson getters — no controller/response-shape change needed elsewhere.

- `Match` gains `title`/`journal`/`pubYear` (all nullable — the two gold-standard PMID matches have none, `GoldStandard` entries carry no title).
- Populated at all 6 `Match` construction sites (both BLOCKED and WARNING), not just the two title-collision WARNING sites, for consistency and because a BLOCKED "already exists" conflict benefits from the same context.
- Existing 4-arg `Match` constructor kept (delegates to the new one with nulls) so no other call site needs touching.

Prompted by `docs/HANDOFF_2026-08-14_authorships_live_session.md` thread #1 (ReCiter Research repo) — the Publication Manager "possible duplicate" toast shows a bare ID today; this is the ReCiter-side half of making that richer. The PM-side change (parsing/displaying these fields, anchoring the toast to its card) is a separate PR against `ReCiter-Publication-Manager`.

Extended the two most relevant existing tests with assertions on the new fields rather than adding a new test class.

**Test note:** `mvn test` compiles clean. The test class itself doesn't execute under plain `mvn test` in my local environment even on unmodified `origin/development` (confirmed via `git stash` before touching anything) — a pre-existing surefire JUnit4/vintage-engine provider gap, not a regression from this change. Flagging in case CI hits the same thing.