### PR TITLE
Add PATCH /reciter/external-article/by/uid for the dispute lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
 		<dependency>
 			<groupId>edu.cornell.weill.reciter</groupId>
 			<artifactId>reciter-dynamodb-model</artifactId>
-			<version>3.0.5</version>
+			<version>3.0.7</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->

--- a/src/main/java/reciter/controller/ExternalArticleController.java
+++ b/src/main/java/reciter/controller/ExternalArticleController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Data;
 import reciter.database.dynamodb.model.AnalysisOutput;
 import reciter.database.dynamodb.model.ExternalArticle;
 import reciter.database.dynamodb.model.GoldStandard;
@@ -127,6 +129,54 @@ public class ExternalArticleController {
         externalArticleService.delete(uid.trim(), articleId.trim());
         log.info("External article {} deleted for uid {}", articleId, uid);
         return new ResponseEntity<>(existing, HttpStatus.OK);
+    }
+
+    @Operation(summary = "File, retract, or resolve a dispute on an external-source article.",
+            description = "action=DISPUTE immediately suppresses the row and records disputedBy/disputedAt/disputeNote, "
+                    + "permanently. action=RETRACT (the disputing faculty member undoing their own dispute) or "
+                    + "action=RESOLVE (a curator clearing it) both un-suppress the row and record "
+                    + "disputeResolvedBy/disputeResolvedAt/disputeResolution — the original dispute fields are never "
+                    + "cleared, only appended to. actingUid is trusted as-is: the caller (the PM proxy) is responsible "
+                    + "for deriving it from the acting user's session, never the request body — same recipe as the "
+                    + "goldstandard endpoint's curatedBy param, except actingUid is a real uid string here, not that "
+                    + "param's long-standing always-0 int placeholder.")
+    @PatchMapping(value = "/reciter/external-article/by/uid", produces = "application/json")
+    public ResponseEntity<Object> updateExternalArticleDispute(@RequestParam(value = "uid") String uid,
+                                                                @RequestParam(value = "articleId") String articleId,
+                                                                @RequestParam(value = "actingUid") String actingUid,
+                                                                @RequestBody(required = false) DisputeRequest disputeRequest) {
+        if (actingUid == null || actingUid.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorBody("actingUid is required."));
+        }
+        String action = disputeRequest == null || disputeRequest.getAction() == null
+                ? null : disputeRequest.getAction().trim().toUpperCase();
+        if (!"DISPUTE".equals(action) && !"RETRACT".equals(action) && !"RESOLVE".equals(action)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(errorBody("action is required and must be one of DISPUTE, RETRACT, RESOLVE."));
+        }
+        ExternalArticle existing = externalArticleService.find(uid.trim(), articleId.trim());
+        if (existing == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(errorBody("No external article '" + articleId + "' found for uid '" + uid + "'."));
+        }
+
+        ExternalArticle updated;
+        String trimmedActingUid = actingUid.trim();
+        if ("DISPUTE".equals(action)) {
+            updated = externalArticleService.dispute(existing, trimmedActingUid, disputeRequest.getDisputeNote());
+        } else {
+            String resolution = "RETRACT".equals(action) ? "RETRACTED" : "CLEARED";
+            updated = externalArticleService.resolveDispute(existing, trimmedActingUid, resolution);
+        }
+        log.info("External article {} for uid {} dispute action {} by {}", articleId, uid, action, trimmedActingUid);
+        return new ResponseEntity<>(updated, HttpStatus.OK);
+    }
+
+    /** PATCH body for {@link #updateExternalArticleDispute}. */
+    @Data
+    public static class DisputeRequest {
+        private String action;
+        private String disputeNote;
     }
 
     private String validate(ExternalArticle externalArticle) {

--- a/src/main/java/reciter/service/ExternalArticleService.java
+++ b/src/main/java/reciter/service/ExternalArticleService.java
@@ -22,4 +22,20 @@ public interface ExternalArticleService {
      * longer accepted. Never throws; returns the number of rows changed.
      */
     int reconcileWithGoldStandard(String uid);
+
+    /**
+     * Files a dispute: sets disputedBy/disputedAt/disputeNote (permanent, first-write-only
+     * in practice) and immediately suppresses the row. Does not touch supersededByPmid, so
+     * the row stays immune to reconcileWithGoldStandard's auto-un-suppress path. Saves and
+     * returns the mutated row.
+     */
+    ExternalArticle dispute(ExternalArticle externalArticle, String actingUid, String disputeNote);
+
+    /**
+     * Resolves a filed dispute — either the disputing faculty member retracting it
+     * ({@code resolution="RETRACTED"}) or a curator clearing it ({@code resolution="CLEARED"}).
+     * Un-suppresses the row and records disputeResolvedBy/disputeResolvedAt/disputeResolution;
+     * never clears the original dispute fields. Saves and returns the mutated row.
+     */
+    ExternalArticle resolveDispute(ExternalArticle externalArticle, String actingUid, String resolution);
 }

--- a/src/main/java/reciter/service/dynamo/ExternalArticleServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/ExternalArticleServiceImpl.java
@@ -1,5 +1,6 @@
 package reciter.service.dynamo;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -55,6 +56,26 @@ public class ExternalArticleServiceImpl implements ExternalArticleService {
     @Override
     public void delete(String uid, String articleId) {
     	externalArticleRepository.delete(uid, articleId);
+    }
+
+    @Override
+    public ExternalArticle dispute(ExternalArticle externalArticle, String actingUid, String disputeNote) {
+        externalArticle.setDisputedBy(actingUid);
+        externalArticle.setDisputedAt(Instant.now().toString());
+        externalArticle.setDisputeNote(disputeNote);
+        externalArticle.setSuppressed(Boolean.TRUE);
+        save(externalArticle);
+        return externalArticle;
+    }
+
+    @Override
+    public ExternalArticle resolveDispute(ExternalArticle externalArticle, String actingUid, String resolution) {
+        externalArticle.setDisputeResolvedBy(actingUid);
+        externalArticle.setDisputeResolvedAt(Instant.now().toString());
+        externalArticle.setDisputeResolution(resolution);
+        externalArticle.setSuppressed(Boolean.FALSE);
+        save(externalArticle);
+        return externalArticle;
     }
 
     @Override

--- a/src/test/java/reciter/controller/ExternalArticleControllerDisputeTest.java
+++ b/src/test/java/reciter/controller/ExternalArticleControllerDisputeTest.java
@@ -1,0 +1,143 @@
+package reciter.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import reciter.controller.ExternalArticleController.DisputeRequest;
+import reciter.database.dynamodb.model.ExternalArticle;
+import reciter.service.AnalysisService;
+import reciter.service.ExternalArticleService;
+import reciter.service.IdentityService;
+import reciter.service.dynamo.IDynamoDbGoldStandardService;
+
+/** Covers the PATCH /reciter/external-article/by/uid dispute lifecycle (DISPUTE/RETRACT/RESOLVE). */
+@ExtendWith(MockitoExtension.class)
+public class ExternalArticleControllerDisputeTest {
+
+    @Mock
+    private ExternalArticleService externalArticleService;
+    @Mock
+    private IDynamoDbGoldStandardService dynamoDbGoldStandardService;
+    @Mock
+    private AnalysisService analysisService;
+    @Mock
+    private IdentityService identityService;
+
+    @InjectMocks
+    private ExternalArticleController externalArticleController;
+
+    private ExternalArticle existing;
+
+    @BeforeEach
+    public void setUp() {
+        existing = new ExternalArticle();
+        existing.setUid("dnr4021");
+        existing.setArticleId("SCOPUS:85142207731");
+        existing.setSuppressed(Boolean.FALSE);
+    }
+
+    @Test
+    public void disputeSetsFieldsAndSuppresses() {
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+        ExternalArticle disputed = new ExternalArticle();
+        disputed.setDisputedBy("dnr4021");
+        disputed.setSuppressed(Boolean.TRUE);
+        when(externalArticleService.dispute(eq(existing), eq("dnr4021"), eq("not mine")))
+                .thenReturn(disputed);
+
+        DisputeRequest body = new DisputeRequest();
+        body.setAction("DISPUTE");
+        body.setDisputeNote("not mine");
+
+        ResponseEntity<Object> response = externalArticleController.updateExternalArticleDispute(
+                "dnr4021", "SCOPUS:85142207731", "dnr4021", body);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(disputed, response.getBody());
+        verify(externalArticleService).dispute(existing, "dnr4021", "not mine");
+        verify(externalArticleService, never()).resolveDispute(any(), any(), any());
+    }
+
+    @Test
+    public void retractResolvesAsRetracted() {
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+        when(externalArticleService.resolveDispute(existing, "dnr4021", "RETRACTED")).thenReturn(existing);
+
+        DisputeRequest body = new DisputeRequest();
+        body.setAction("RETRACT");
+
+        ResponseEntity<Object> response = externalArticleController.updateExternalArticleDispute(
+                "dnr4021", "SCOPUS:85142207731", "dnr4021", body);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(externalArticleService).resolveDispute(existing, "dnr4021", "RETRACTED");
+    }
+
+    @Test
+    public void resolveByCuratorMarksCleared() {
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+        when(externalArticleService.resolveDispute(existing, "curator99", "CLEARED")).thenReturn(existing);
+
+        DisputeRequest body = new DisputeRequest();
+        body.setAction("resolve"); // lower-case on the wire should still work
+
+        ResponseEntity<Object> response = externalArticleController.updateExternalArticleDispute(
+                "dnr4021", "SCOPUS:85142207731", "curator99", body);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(externalArticleService).resolveDispute(existing, "curator99", "CLEARED");
+    }
+
+    @Test
+    public void notFoundWhenRowMissing() {
+        when(externalArticleService.find("dnr4021", "SCOPUS:nope")).thenReturn(null);
+
+        DisputeRequest body = new DisputeRequest();
+        body.setAction("DISPUTE");
+
+        ResponseEntity<Object> response = externalArticleController.updateExternalArticleDispute(
+                "dnr4021", "SCOPUS:nope", "dnr4021", body);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNotNull(response.getBody());
+        verify(externalArticleService, never()).dispute(any(), any(), any());
+    }
+
+    @Test
+    public void missingActingUidIsBadRequest() {
+        DisputeRequest body = new DisputeRequest();
+        body.setAction("DISPUTE");
+
+        ResponseEntity<Object> response = externalArticleController.updateExternalArticleDispute(
+                "dnr4021", "SCOPUS:85142207731", "  ", body);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        verify(externalArticleService, never()).find(any(), any());
+    }
+
+    @Test
+    public void invalidActionIsBadRequest() {
+        DisputeRequest body = new DisputeRequest();
+        body.setAction("DELETE_EVERYTHING");
+
+        ResponseEntity<Object> response = externalArticleController.updateExternalArticleDispute(
+                "dnr4021", "SCOPUS:85142207731", "dnr4021", body);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        verify(externalArticleService, never()).find(any(), any());
+    }
+}

--- a/src/test/java/reciter/database/dynamodb/repository/DynamoDbGoldStandardRepositoryTest.java
+++ b/src/test/java/reciter/database/dynamodb/repository/DynamoDbGoldStandardRepositoryTest.java
@@ -29,8 +29,8 @@ public class DynamoDbGoldStandardRepositoryTest {
 
 	@BeforeEach
 	public void setUp() {
-		goldStandard1 = new GoldStandard("uid1", Arrays.asList(123L, 456L), Arrays.asList(779L), null);
-		goldStandard2 = new GoldStandard("uid2", Arrays.asList(5678L, 8760L), Arrays.asList(799L), null);
+		goldStandard1 = new GoldStandard("uid1", Arrays.asList(123L, 456L), Arrays.asList(779L), null, null);
+		goldStandard2 = new GoldStandard("uid2", Arrays.asList(5678L, 8760L), Arrays.asList(799L), null, null);
 	}
 
 	@Test

--- a/src/test/java/reciter/service/dynamo/DynamoDbGoldStandardServiceRaceTest.java
+++ b/src/test/java/reciter/service/dynamo/DynamoDbGoldStandardServiceRaceTest.java
@@ -66,7 +66,7 @@ public class DynamoDbGoldStandardServiceRaceTest {
 
 	/** Fresh baseline on every read: a concurrent writer already committed pmid 100. */
 	private GoldStandard baselineWith100() {
-		return new GoldStandard(UID, new ArrayList<>(Collections.singletonList(100L)), new ArrayList<>(), null);
+		return new GoldStandard(UID, new ArrayList<>(Collections.singletonList(100L)), new ArrayList<>(), null, null);
 	}
 
 	/**
@@ -83,7 +83,7 @@ public class DynamoDbGoldStandardServiceRaceTest {
 				.thenReturn(false)
 				.thenReturn(true);
 
-		GoldStandard request = new GoldStandard(UID, new ArrayList<>(Collections.singletonList(200L)), null, null);
+		GoldStandard request = new GoldStandard(UID, new ArrayList<>(Collections.singletonList(200L)), null, null, null);
 		service.save(request, GoldStandardUpdateFlag.UPDATE, "TestSource", EntryPath.CANDIDATE_LIST, 7);
 
 		// Persisted twice (one conflict, one success); the committed item carries BOTH pmids.
@@ -102,10 +102,10 @@ public class DynamoDbGoldStandardServiceRaceTest {
 	@Test
 	public void noConflictCommitsInOneAttempt() {
 		when(goldStandardRepository.findById(UID))
-				.thenReturn(Optional.of(new GoldStandard(UID, new ArrayList<>(Arrays.asList(100L)), new ArrayList<>(), null)));
+				.thenReturn(Optional.of(new GoldStandard(UID, new ArrayList<>(Arrays.asList(100L)), new ArrayList<>(), null, null)));
 		when(goldStandardRepository.saveIfUnchanged(any(GoldStandard.class), any(), any())).thenReturn(true);
 
-		GoldStandard request = new GoldStandard(UID, new ArrayList<>(Collections.singletonList(200L)), null, null);
+		GoldStandard request = new GoldStandard(UID, new ArrayList<>(Collections.singletonList(200L)), null, null, null);
 		service.save(request, GoldStandardUpdateFlag.UPDATE, "TestSource", EntryPath.CANDIDATE_LIST, 7);
 
 		ArgumentCaptor<GoldStandard> persisted = ArgumentCaptor.forClass(GoldStandard.class);


### PR DESCRIPTION
## What

Step 2 of the "Other Publications" dispute feature (see `docs/README-other-publications-tab.md` in the ReCiter Research repo for the full design): a `PATCH /reciter/external-article/by/uid?uid=<uid>&articleId=<id>&actingUid=<uid>` endpoint with three actions:

- `DISPUTE` — faculty flags a curator-added row as not theirs. Sets `disputedBy`/`disputedAt`/`disputeNote`, immediately suppresses the row. `supersededByPmid` is left untouched so the row stays immune to `reconcileWithGoldStandard`'s auto-un-suppress path.
- `RETRACT` — the disputing faculty member undoes their own dispute.
- `RESOLVE` — a curator clears it.

Both resolutions un-suppress the row and set `disputeResolvedBy`/`disputeResolvedAt`/`disputeResolution` (`RETRACTED` vs `CLEARED`) — the original dispute fields are never nulled, append-only per Decision 6 in the design doc.

`actingUid` is a required query param, never read from the request body. The PM proxy (step 3, not in this PR) is responsible for deriving it from the session — same shape as the goldstandard endpoint's `curatedBy` param, except `actingUid` is a real uid string that's actually threaded through (`curatedBy` is a long-standing always-0 int in practice; not copying that).

## Blocked on wcmc-its/ReCiter-Dynamodb-Model#15

The six new `ExternalArticle` fields this PATCH writes live on that PR, which is **open, not merged, not published**. This PR bumps `pom.xml`'s `reciter-dynamodb-model` dependency `3.0.5 -> 3.0.7` to get them — **CI will not build clean until #15 merges and publishes 3.0.7.** Verified locally only, against a matching 3.0.7 jar built from that PR's branch and `mvn install`ed to a local repo.

## Also included: pre-existing test fix, unrelated to the feature

Two existing test files (`DynamoDbGoldStandardRepositoryTest`, `DynamoDbGoldStandardServiceRaceTest`) called `GoldStandard`'s all-args constructor with 4 args. That constructor gained a 5th param (`auditLog`) back on `3.0.6` — never caught because this repo never bumped past `3.0.5` until now. Fixed with a trailing `null`, separate commit, no behavior change intended.

## Verified locally

- `mvn clean compile` — clean.
- `mvn test` — **235 tests, 0 failures** (includes the new `ExternalArticleControllerDisputeTest`, 6 cases: dispute/retract/resolve/not-found/missing-actingUid/invalid-action).
- Both against JDK 17 (Temurin) — note for whoever picks this up locally: `mvn` on this machine defaults to JDK 25 unless `JAVA_HOME` is set per this repo's documented local-dev setup, and Lombok 1.18.32 silently no-ops its annotation processing under JDK 25 (no error, just missing generated accessors) — cost real time to track down, flagging so it doesn't happen again.

## Not in this PR

Step 3 (PM proxy + faculty/curator UI) is separate, tracked alongside this one.
