### PR TITLE
Record external-article feedback in FeedbackLog (dev)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
 		<dependency>
 			<groupId>edu.cornell.weill.reciter</groupId>
 			<artifactId>reciter-dynamodb-model</artifactId>
-			<version>3.0.6</version>
+			<version>3.0.7</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->

--- a/src/main/java/reciter/controller/ExternalArticleController.java
+++ b/src/main/java/reciter/controller/ExternalArticleController.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -149,9 +150,11 @@ public class ExternalArticleController {
                     + "per call — who acted distinguishes reject-from-dispute, not the action name. REJECTED suppresses "
                     + "an existing ExternalArticle row; ACCEPTED un-suppresses it unless the supersede rule owns the "
                     + "suppression (supersededByPmid set); PENDING only logs. A candidate that was never added has no "
-                    + "row to flip — the feedback is still logged. actorPersonIdentifier is trusted as-is: the caller "
-                    + "(the PM proxy) derives it from the acting user's session, never the browser request — same "
-                    + "trust-boundary recipe as the goldstandard endpoint's curatedBy param.")
+                    + "row to flip — the feedback is still logged. REJECTED also takes ownership of the suppression "
+                    + "(clears supersededByPmid) so the supersede reconciler cannot resurrect an explicitly rejected "
+                    + "row. actorPersonIdentifier is trusted as-is: the caller (the PM proxy) derives it from the "
+                    + "acting user's session, never the browser request — same trust-boundary recipe as the "
+                    + "goldstandard endpoint's curatedBy param.")
     @PatchMapping(value = "/reciter/external-article/feedback", produces = "application/json")
     public ResponseEntity<Object> recordExternalArticleFeedback(@RequestBody FeedbackRequest request) {
         if (request == null || request.getUid() == null || request.getUid().trim().isEmpty()) {
@@ -168,7 +171,7 @@ public class ExternalArticleController {
         FeedbackLogService.Feedback feedback;
         try {
             feedback = FeedbackLogService.Feedback.valueOf(
-                    request.getAction() == null ? "" : request.getAction().trim().toUpperCase());
+                    request.getAction() == null ? "" : request.getAction().trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(errorBody("action is required and must be one of ACCEPTED, REJECTED, PENDING."));
@@ -181,9 +184,21 @@ public class ExternalArticleController {
         }
 
         ExternalArticle existing = externalArticleService.find(uid, articleId);
+        // The FeedbackLog row is the authoritative record here (suppressed is only a
+        // denormalized cache), so it is written first and its failure fails the request
+        // before any state changes — unlike the add/delete paths, where it is a side-log.
+        if (!logFeedback(uid, articleId, feedback, request.getActorPersonIdentifier().trim(), request.getNote())) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(errorBody("Failed to record the feedback; nothing was changed. Retry."));
+        }
         if (existing != null) {
             if (feedback == FeedbackLogService.Feedback.REJECTED) {
+                // A human rejection takes ownership of the suppression: clearing
+                // supersededByPmid keeps reconcileWithGoldStandard's auto-un-suppress
+                // (which fires when the superseding PMID leaves the gold standard)
+                // from resurrecting an explicitly rejected row.
                 existing.setSuppressed(Boolean.TRUE);
+                existing.setSupersededByPmid(null);
                 externalArticleService.save(existing);
             } else if (feedback == FeedbackLogService.Feedback.ACCEPTED
                     && existing.getSupersededByPmid() == null) {
@@ -192,7 +207,6 @@ public class ExternalArticleController {
                 externalArticleService.save(existing);
             }
         }
-        logFeedback(uid, articleId, feedback, request.getActorPersonIdentifier().trim(), request.getNote());
         log.info("External article {} for uid {} feedback {} by {}", articleId, uid, feedback,
                 request.getActorPersonIdentifier().trim());
 
@@ -216,9 +230,13 @@ public class ExternalArticleController {
         private String note;
     }
 
-    /** Best-effort append to FeedbackLog — recordAction never throws (matches the GoldStandard path). */
-    private void logFeedback(String uid, String articleId, FeedbackLogService.Feedback feedback,
-                             String actorPersonIdentifier, String note) {
+    /**
+     * Append to FeedbackLog. recordAction never throws; the boolean says whether the row
+     * was written — the add/delete paths ignore it (best-effort side-log, matching the
+     * GoldStandard path), the feedback endpoint fails the request on it.
+     */
+    private boolean logFeedback(String uid, String articleId, FeedbackLogService.Feedback feedback,
+                                String actorPersonIdentifier, String note) {
         FeedbackLog logEntry = new FeedbackLog();
         logEntry.setUid(uid);
         logEntry.setArticleId(articleId);
@@ -229,7 +247,7 @@ public class ExternalArticleController {
         long epoch = Instant.now().getEpochSecond();
         logEntry.setCreateTimestamp(epoch);
         logEntry.setModifyTimestamp(epoch);
-        feedbackLogService.recordAction(logEntry);
+        return feedbackLogService.recordAction(logEntry);
     }
 
     private String validate(ExternalArticle externalArticle) {

--- a/src/main/java/reciter/controller/ExternalArticleController.java
+++ b/src/main/java/reciter/controller/ExternalArticleController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,12 +25,15 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Data;
 import reciter.database.dynamodb.model.AnalysisOutput;
 import reciter.database.dynamodb.model.ExternalArticle;
+import reciter.database.dynamodb.model.FeedbackLog;
 import reciter.database.dynamodb.model.GoldStandard;
 import reciter.engine.analysis.ReCiterArticleFeature;
 import reciter.service.AnalysisService;
 import reciter.service.ExternalArticleService;
+import reciter.service.FeedbackLogService;
 import reciter.service.IdentityService;
 import reciter.service.dynamo.ExternalArticleDupCheck;
 import reciter.service.dynamo.IDynamoDbGoldStandardService;
@@ -58,6 +62,9 @@ public class ExternalArticleController {
 
     @Autowired
     private IdentityService identityService;
+
+    @Autowired
+    private FeedbackLogService feedbackLogService;
 
     @Operation(summary = "Add an external-source article for a person.",
             description = "Adds a publication from Scopus, Web of Science, or OpenAlex. Blocks on PMID/DOI duplicates "
@@ -101,6 +108,8 @@ public class ExternalArticleController {
         externalArticle.setSuppressed(Boolean.FALSE);
         externalArticle.setSupersededByPmid(null);
         externalArticleService.save(externalArticle);
+        logFeedback(externalArticle.getUid(), externalArticle.getArticleId(),
+                FeedbackLogService.Feedback.ACCEPTED, externalArticle.getAddedBy(), null);
         log.info("External article {} added for uid {} from {} (method={}, force={})",
                 externalArticle.getArticleId(), externalArticle.getUid(), externalArticle.getSourceType(),
                 externalArticle.getMethod(), force);
@@ -118,15 +127,109 @@ public class ExternalArticleController {
             description = "Deleting is the revoke path — there is deliberately no sameAs assert/revoke model.")
     @DeleteMapping(value = "/reciter/external-article/by/uid", produces = "application/json")
     public ResponseEntity<Object> deleteExternalArticle(@RequestParam(value = "uid") String uid,
-                                                        @RequestParam(value = "articleId") String articleId) {
+                                                        @RequestParam(value = "articleId") String articleId,
+                                                        @RequestParam(value = "actorPersonIdentifier", required = false) String actorPersonIdentifier) {
         ExternalArticle existing = externalArticleService.find(uid.trim(), articleId.trim());
         if (existing == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(errorBody("No external article '" + articleId + "' found for uid '" + uid + "'."));
         }
         externalArticleService.delete(uid.trim(), articleId.trim());
+        // Delete is the revoke of a prior accept — logged as PENDING (back to no assertion),
+        // matching the reopen/undo vocabulary. Actor is optional until PM starts sending it.
+        logFeedback(uid.trim(), articleId.trim(), FeedbackLogService.Feedback.PENDING,
+                actorPersonIdentifier, null);
         log.info("External article {} deleted for uid {}", articleId, uid);
         return new ResponseEntity<>(existing, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Record feedback on an external-source article.",
+            description = "One endpoint for curator actions (reject/dismiss/reopen a Scopus/OpenAlex candidate) and "
+                    + "faculty actions (dispute/retract/resolve an already-accepted row). Appends one FeedbackLog row "
+                    + "per call — who acted distinguishes reject-from-dispute, not the action name. REJECTED suppresses "
+                    + "an existing ExternalArticle row; ACCEPTED un-suppresses it unless the supersede rule owns the "
+                    + "suppression (supersededByPmid set); PENDING only logs. A candidate that was never added has no "
+                    + "row to flip — the feedback is still logged. actorPersonIdentifier is trusted as-is: the caller "
+                    + "(the PM proxy) derives it from the acting user's session, never the browser request — same "
+                    + "trust-boundary recipe as the goldstandard endpoint's curatedBy param.")
+    @PatchMapping(value = "/reciter/external-article/feedback", produces = "application/json")
+    public ResponseEntity<Object> recordExternalArticleFeedback(@RequestBody FeedbackRequest request) {
+        if (request == null || request.getUid() == null || request.getUid().trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorBody("uid is required."));
+        }
+        if (request.getArticleId() == null
+                || !ARTICLE_ID_PATTERN.matcher(request.getArticleId().trim()).matches()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(errorBody("articleId is required and must be a prefixed identifier: SCOPUS:<id>, WOS:<id>, OPENALEX:<id>, or WORLDCAT:<id>."));
+        }
+        if (request.getActorPersonIdentifier() == null || request.getActorPersonIdentifier().trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorBody("actorPersonIdentifier is required."));
+        }
+        FeedbackLogService.Feedback feedback;
+        try {
+            feedback = FeedbackLogService.Feedback.valueOf(
+                    request.getAction() == null ? "" : request.getAction().trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(errorBody("action is required and must be one of ACCEPTED, REJECTED, PENDING."));
+        }
+        String uid = request.getUid().trim();
+        String articleId = request.getArticleId().trim();
+        if (identityService.findByUid(uid) == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(errorBody("The uid provided '" + uid + "' was not found in the Identity table"));
+        }
+
+        ExternalArticle existing = externalArticleService.find(uid, articleId);
+        if (existing != null) {
+            if (feedback == FeedbackLogService.Feedback.REJECTED) {
+                existing.setSuppressed(Boolean.TRUE);
+                externalArticleService.save(existing);
+            } else if (feedback == FeedbackLogService.Feedback.ACCEPTED
+                    && existing.getSupersededByPmid() == null) {
+                // A supersede-owned suppression (#660) is not feedback's to clear.
+                existing.setSuppressed(Boolean.FALSE);
+                externalArticleService.save(existing);
+            }
+        }
+        logFeedback(uid, articleId, feedback, request.getActorPersonIdentifier().trim(), request.getNote());
+        log.info("External article {} for uid {} feedback {} by {}", articleId, uid, feedback,
+                request.getActorPersonIdentifier().trim());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", "LOGGED");
+        body.put("uid", uid);
+        body.put("articleId", articleId);
+        body.put("action", feedback.name());
+        body.put("rowExists", existing != null);
+        body.put("suppressed", existing == null ? null : existing.getSuppressed());
+        return new ResponseEntity<>(body, HttpStatus.OK);
+    }
+
+    /** PATCH body for {@link #recordExternalArticleFeedback}. */
+    @Data
+    public static class FeedbackRequest {
+        private String uid;
+        private String articleId;
+        private String action;
+        private String actorPersonIdentifier;
+        private String note;
+    }
+
+    /** Best-effort append to FeedbackLog — recordAction never throws (matches the GoldStandard path). */
+    private void logFeedback(String uid, String articleId, FeedbackLogService.Feedback feedback,
+                             String actorPersonIdentifier, String note) {
+        FeedbackLog logEntry = new FeedbackLog();
+        logEntry.setUid(uid);
+        logEntry.setArticleId(articleId);
+        logEntry.setFeedback(feedback.name());
+        logEntry.setCuratedBy(0); // no admin_users.userID on this path; actorPersonIdentifier carries identity
+        logEntry.setActorPersonIdentifier(actorPersonIdentifier);
+        logEntry.setNote(note);
+        long epoch = Instant.now().getEpochSecond();
+        logEntry.setCreateTimestamp(epoch);
+        logEntry.setModifyTimestamp(epoch);
+        feedbackLogService.recordAction(logEntry);
     }
 
     private String validate(ExternalArticle externalArticle) {

--- a/src/main/java/reciter/service/FeedbackLogService.java
+++ b/src/main/java/reciter/service/FeedbackLogService.java
@@ -30,15 +30,13 @@ public interface FeedbackLogService {
     }
 
     /**
-     * Record a single curator action.
+     * Record a single curator action. Never throws — all failures are logged and
+     * reported through the return value, so callers on best-effort paths can ignore
+     * it and callers for whom this row is the authoritative record can react.
      *
-     * @param uid                 person identifier
-     * @param pmid                PubMed ID
-     * @param feedback            ACCEPTED, REJECTED, or PENDING
-     * @param curatedBy           userID of the curator (or 0 if unknown — e.g., when the
-     *                            action is inferred from a GoldStandard list-replace API call
-     *                            that doesn't carry a userID)
-     * @param actionEpochSeconds  curator action time, epoch seconds (used in sk and timestamps)
+     * @param feedbackLog  row to write; uid, feedback, articleId, curatedBy and the
+     *                     timestamps are the caller's to set (sk and src are set here)
+     * @return true if the row was written, false if it was skipped or the write failed
      */
-    void recordAction(FeedbackLog feedbackLog);
+    boolean recordAction(FeedbackLog feedbackLog);
 }

--- a/src/main/java/reciter/service/dynamo/AuditHistoryEntry.java
+++ b/src/main/java/reciter/service/dynamo/AuditHistoryEntry.java
@@ -14,6 +14,10 @@ public class AuditHistoryEntry {
     public String feedback;
     /** Curator's admin_users.userID (0 = unknown; pre-Phase-34 rows are 0). */
     public int curatedBy;
+    /** CWID of the person who acted (curator or faculty; null on rows written before the field existed). */
+    public String actorPersonIdentifier;
+    /** Optional free-text note attached to the action (e.g. a dispute reason). */
+    public String note;
     /** Action time, epoch seconds (UTC). */
     public long createTimestamp;
     /** FeedbackLog sort key ({@code <epoch>#<hex>}); useful for stable ordering. */

--- a/src/main/java/reciter/service/dynamo/FeedbackLogQueryService.java
+++ b/src/main/java/reciter/service/dynamo/FeedbackLogQueryService.java
@@ -71,6 +71,8 @@ public class FeedbackLogQueryService {
         e.articleId       = feedbackLog.getArticleId();
         e.feedback        = feedbackLog.getFeedback();
         e.curatedBy       = feedbackLog.getCuratedBy();
+        e.actorPersonIdentifier = feedbackLog.getActorPersonIdentifier();
+        e.note            = feedbackLog.getNote();
         e.createTimestamp = feedbackLog.getCreateTimestamp();
         e.sk              = feedbackLog.getSk();
         e.src             = feedbackLog.getSrc();

--- a/src/main/java/reciter/service/dynamo/FeedbackLogServiceImpl.java
+++ b/src/main/java/reciter/service/dynamo/FeedbackLogServiceImpl.java
@@ -36,15 +36,16 @@ public class FeedbackLogServiceImpl implements FeedbackLogService {
     }
 
     @Override
-	public void recordAction(FeedbackLog feedbackLog) {
+	public boolean recordAction(FeedbackLog feedbackLog) {
 		if (feedbackLog == null || feedbackLog.getUid() == null || feedbackLog.getUid().isEmpty()) {
-			log.warn("recordAction called with null/empty uid; skipping (pmid={})", feedbackLog.getArticleId());
-			return;
+			log.warn("recordAction called with null/empty uid; skipping (pmid={})",
+					feedbackLog == null ? null : feedbackLog.getArticleId());
+			return false;
 		}
 		if (feedbackLog.getFeedback() == null) {
 			log.warn("recordAction called with null feedback; skipping (uid={} pmid={})", feedbackLog.getUid(),
 					feedbackLog.getArticleId());
-			return;
+			return false;
 		}
 
 		for (int attempt = 0; attempt < SK_RETRY_LIMIT; attempt++) {
@@ -55,7 +56,7 @@ public class FeedbackLogServiceImpl implements FeedbackLogService {
 			try {
 				// Pass the object directly just like ESearchResultRepository!
 				feedbackLogRepository.save(feedbackLog);
-				return;
+				return true;
 			} catch (ConditionalCheckFailedException race) {
 				// If a collision happens, log it and the loop will retry with a fresh SK
 				log.info("FeedbackLog sk collision for uid={} sk={}; retrying (attempt {})", feedbackLog.getUid(), sk,
@@ -63,10 +64,19 @@ public class FeedbackLogServiceImpl implements FeedbackLogService {
 			} catch (DynamoDbException e) {
 				log.warn("FeedbackLog write failed for uid={} articleId={}: {}", feedbackLog.getUid(),
 						feedbackLog.getArticleId(), e.getMessage());
-				return;
+				return false;
+			} catch (RuntimeException e) {
+				// SdkClientException (network/credentials) is not a DynamoDbException —
+				// without this, a logging failure would surface as a 500 after the
+				// caller's durable write already committed.
+				log.warn("FeedbackLog write failed for uid={} articleId={}: {}", feedbackLog.getUid(),
+						feedbackLog.getArticleId(), e.toString());
+				return false;
 			}
 		}
-
+		log.warn("FeedbackLog write gave up after {} sk collisions for uid={} articleId={}", SK_RETRY_LIMIT,
+				feedbackLog.getUid(), feedbackLog.getArticleId());
+		return false;
 	}
 
     /**

--- a/src/test/java/reciter/controller/ExternalArticleControllerFeedbackTest.java
+++ b/src/test/java/reciter/controller/ExternalArticleControllerFeedbackTest.java
@@ -1,0 +1,192 @@
+package reciter.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import reciter.controller.ExternalArticleController.FeedbackRequest;
+import reciter.database.dynamodb.model.ExternalArticle;
+import reciter.database.dynamodb.model.FeedbackLog;
+import reciter.model.identity.Identity;
+import reciter.service.AnalysisService;
+import reciter.service.ExternalArticleService;
+import reciter.service.FeedbackLogService;
+import reciter.service.IdentityService;
+import reciter.service.dynamo.IDynamoDbGoldStandardService;
+
+/** Covers PATCH /reciter/external-article/feedback (ACCEPTED/REJECTED/PENDING via FeedbackLog). */
+@ExtendWith(MockitoExtension.class)
+public class ExternalArticleControllerFeedbackTest {
+
+    @Mock
+    private ExternalArticleService externalArticleService;
+    @Mock
+    private IDynamoDbGoldStandardService dynamoDbGoldStandardService;
+    @Mock
+    private AnalysisService analysisService;
+    @Mock
+    private IdentityService identityService;
+    @Mock
+    private FeedbackLogService feedbackLogService;
+
+    @InjectMocks
+    private ExternalArticleController externalArticleController;
+
+    private ExternalArticle existing;
+
+    @BeforeEach
+    public void setUp() {
+        existing = new ExternalArticle();
+        existing.setUid("dnr4021");
+        existing.setArticleId("SCOPUS:85142207731");
+        existing.setSuppressed(Boolean.FALSE);
+    }
+
+    private FeedbackRequest request(String action, String actor) {
+        FeedbackRequest body = new FeedbackRequest();
+        body.setUid("dnr4021");
+        body.setArticleId("SCOPUS:85142207731");
+        body.setAction(action);
+        body.setActorPersonIdentifier(actor);
+        return body;
+    }
+
+    @Test
+    public void rejectedSuppressesRowAndLogs() {
+        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+
+        FeedbackRequest body = request("REJECTED", "dnr4021");
+        body.setNote("not mine");
+        ResponseEntity<Object> response = externalArticleController.recordExternalArticleFeedback(body);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Boolean.TRUE, existing.getSuppressed());
+        verify(externalArticleService).save(existing);
+
+        ArgumentCaptor<FeedbackLog> logged = ArgumentCaptor.forClass(FeedbackLog.class);
+        verify(feedbackLogService).recordAction(logged.capture());
+        assertEquals("REJECTED", logged.getValue().getFeedback());
+        assertEquals("dnr4021", logged.getValue().getActorPersonIdentifier());
+        assertEquals("not mine", logged.getValue().getNote());
+        assertEquals(0, logged.getValue().getCuratedBy());
+    }
+
+    @Test
+    public void acceptedUnsuppressesRow() {
+        existing.setSuppressed(Boolean.TRUE);
+        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+
+        // lower-case on the wire should still work
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("accepted", "curator99"));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Boolean.FALSE, existing.getSuppressed());
+        verify(externalArticleService).save(existing);
+        verify(feedbackLogService).recordAction(any(FeedbackLog.class));
+    }
+
+    @Test
+    public void acceptedLeavesSupersedeSuppressionAlone() {
+        existing.setSuppressed(Boolean.TRUE);
+        existing.setSupersededByPmid(12345L);
+        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("ACCEPTED", "curator99"));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Boolean.TRUE, existing.getSuppressed());
+        verify(externalArticleService, never()).save(any());
+        verify(feedbackLogService).recordAction(any(FeedbackLog.class));
+    }
+
+    @Test
+    public void pendingLogsWithoutTouchingRow() {
+        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("PENDING", "curator99"));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(externalArticleService, never()).save(any());
+        verify(feedbackLogService).recordAction(any(FeedbackLog.class));
+    }
+
+    @Test
+    public void feedbackOnNeverAddedCandidateStillLogs() {
+        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(null);
+
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("REJECTED", "curator99"));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(externalArticleService, never()).save(any());
+        verify(feedbackLogService).recordAction(any(FeedbackLog.class));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertEquals(Boolean.FALSE, body.get("rowExists"));
+    }
+
+    @Test
+    public void unknownUidIsNotFoundAndNothingLogged() {
+        when(identityService.findByUid("dnr4021")).thenReturn(null);
+
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("REJECTED", "curator99"));
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(feedbackLogService, never()).recordAction(any());
+    }
+
+    @Test
+    public void invalidActionIsBadRequest() {
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("DELETE_EVERYTHING", "curator99"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        verify(feedbackLogService, never()).recordAction(any());
+    }
+
+    @Test
+    public void missingActorIsBadRequest() {
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("REJECTED", "  "));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        verify(feedbackLogService, never()).recordAction(any());
+        verify(externalArticleService, never()).find(any(), any());
+    }
+
+    @Test
+    public void malformedArticleIdIsBadRequest() {
+        FeedbackRequest body = request("REJECTED", "curator99");
+        body.setArticleId("85142207731"); // no source prefix
+
+        ResponseEntity<Object> response = externalArticleController.recordExternalArticleFeedback(body);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        verify(feedbackLogService, never()).recordAction(any());
+    }
+}

--- a/src/test/java/reciter/controller/ExternalArticleControllerFeedbackTest.java
+++ b/src/test/java/reciter/controller/ExternalArticleControllerFeedbackTest.java
@@ -2,7 +2,9 @@ package reciter.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -66,10 +69,15 @@ public class ExternalArticleControllerFeedbackTest {
         return body;
     }
 
-    @Test
-    public void rejectedSuppressesRowAndLogs() {
+    private void happyPathStubs() {
         when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
         when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+        when(feedbackLogService.recordAction(any(FeedbackLog.class))).thenReturn(true);
+    }
+
+    @Test
+    public void rejectedSuppressesRowAndLogsFirst() {
+        happyPathStubs();
 
         FeedbackRequest body = request("REJECTED", "dnr4021");
         body.setNote("not mine");
@@ -77,10 +85,12 @@ public class ExternalArticleControllerFeedbackTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(Boolean.TRUE, existing.getSuppressed());
-        verify(externalArticleService).save(existing);
 
+        // The authoritative history row must land before the suppressed-cache flip.
+        InOrder order = inOrder(feedbackLogService, externalArticleService);
         ArgumentCaptor<FeedbackLog> logged = ArgumentCaptor.forClass(FeedbackLog.class);
-        verify(feedbackLogService).recordAction(logged.capture());
+        order.verify(feedbackLogService).recordAction(logged.capture());
+        order.verify(externalArticleService).save(existing);
         assertEquals("REJECTED", logged.getValue().getFeedback());
         assertEquals("dnr4021", logged.getValue().getActorPersonIdentifier());
         assertEquals("not mine", logged.getValue().getNote());
@@ -88,10 +98,26 @@ public class ExternalArticleControllerFeedbackTest {
     }
 
     @Test
+    public void rejectedTakesOwnershipOfSupersedeSuppression() {
+        existing.setSuppressed(Boolean.TRUE);
+        existing.setSupersededByPmid(12345L);
+        happyPathStubs();
+
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("REJECTED", "dnr4021"));
+
+        // supersededByPmid cleared so the reconciler's auto-un-suppress can't
+        // resurrect an explicitly rejected row once PMID 12345 leaves the gold standard.
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Boolean.TRUE, existing.getSuppressed());
+        assertNull(existing.getSupersededByPmid());
+        verify(externalArticleService).save(existing);
+    }
+
+    @Test
     public void acceptedUnsuppressesRow() {
         existing.setSuppressed(Boolean.TRUE);
-        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
-        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+        happyPathStubs();
 
         // lower-case on the wire should still work
         ResponseEntity<Object> response =
@@ -100,15 +126,13 @@ public class ExternalArticleControllerFeedbackTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(Boolean.FALSE, existing.getSuppressed());
         verify(externalArticleService).save(existing);
-        verify(feedbackLogService).recordAction(any(FeedbackLog.class));
     }
 
     @Test
     public void acceptedLeavesSupersedeSuppressionAlone() {
         existing.setSuppressed(Boolean.TRUE);
         existing.setSupersededByPmid(12345L);
-        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
-        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+        happyPathStubs();
 
         ResponseEntity<Object> response =
                 externalArticleController.recordExternalArticleFeedback(request("ACCEPTED", "curator99"));
@@ -121,8 +145,7 @@ public class ExternalArticleControllerFeedbackTest {
 
     @Test
     public void pendingLogsWithoutTouchingRow() {
-        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
-        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+        happyPathStubs();
 
         ResponseEntity<Object> response =
                 externalArticleController.recordExternalArticleFeedback(request("PENDING", "curator99"));
@@ -136,6 +159,7 @@ public class ExternalArticleControllerFeedbackTest {
     public void feedbackOnNeverAddedCandidateStillLogs() {
         when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
         when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(null);
+        when(feedbackLogService.recordAction(any(FeedbackLog.class))).thenReturn(true);
 
         ResponseEntity<Object> response =
                 externalArticleController.recordExternalArticleFeedback(request("REJECTED", "curator99"));
@@ -147,6 +171,20 @@ public class ExternalArticleControllerFeedbackTest {
         Map<String, Object> body = (Map<String, Object>) response.getBody();
         assertNotNull(body);
         assertEquals(Boolean.FALSE, body.get("rowExists"));
+    }
+
+    @Test
+    public void failedLogWriteFailsRequestBeforeAnyFlip() {
+        when(identityService.findByUid("dnr4021")).thenReturn(new Identity());
+        when(externalArticleService.find("dnr4021", "SCOPUS:85142207731")).thenReturn(existing);
+        when(feedbackLogService.recordAction(any(FeedbackLog.class))).thenReturn(false);
+
+        ResponseEntity<Object> response =
+                externalArticleController.recordExternalArticleFeedback(request("REJECTED", "dnr4021"));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(Boolean.FALSE, existing.getSuppressed());
+        verify(externalArticleService, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
Development-branch port of #707 (same two commits cherry-picked; see #707 for the full description and design record). One endpoint — `PATCH /reciter/external-article/feedback` — gives curator rejects of Scopus/OpenAlex candidates and faculty disputes of accepted external rows a durable record in the live `FeedbackLog` table; add/delete paths log too; the history read API exposes the new `actorPersonIdentifier`/`note` fields.

**⚠️ Build gate:** bumps `reciter-dynamodb-model` 3.0.6 → **3.0.7, which is not yet published** — the `ReCiter` pipeline's CodeBuild cannot resolve it until wcmc-its/ReCiter-Dynamodb-Model#15 merges and someone runs the Central release. Until then this branch of development builds only against a local install (full suite verified locally: 238 tests, 0 failures). Deploying to reciter-dev in the meantime via a locally built image for smoke-testing.