### PR TITLE
Fix FeedbackLog PENDING flood on single-pmid gold-standard accepts

### DIFF
--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -227,11 +227,13 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     				}
     				// Phase 33-02: FeedbackLog rows + ArticleProvenance D-11/D-13 transitions
     				// for the diff. Inside the same UPDATE branch where existingAccepted/Rejected
-    				// are in scope.
+    				// are in scope. goldStandard holds the MERGED lists at this point — the
+    				// final state the save below persists.
     				recordFeedbackLogAndArticleProvenance(
     						goldStandard.getUid(),
     						incomingAcceptedPmids, incomingRejectedPmids,
     						existingAccepted, existingRejected,
+    						goldStandard.getKnownPmids(), goldStandard.getRejectedPmids(),
     						entryPath,curatedBy);
     			}
     			dynamoDbGoldStandardRepository.save(goldStandard);
@@ -349,9 +351,12 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     					}
     					// Phase 33-02: per-uid FeedbackLog + ArticleProvenance writes for the diff.
     					// Bulk/list (PUT) path carries no interactive curator id -> curatedBy = 0.
+    					// goldStandardNew holds the MERGED lists at this point.
     					recordFeedbackLogAndArticleProvenance(uid,
     							batchIncomingAccepted, batchIncomingRejected,
-    							existingAccepted, existingRejected, entryPath,0);
+    							existingAccepted, existingRejected,
+    							goldStandardNew.getKnownPmids(), goldStandardNew.getRejectedPmids(),
+    							entryPath,0);
     				}
     			}
     			dynamoDbGoldStandardRepository.saveAll(goldStandard);
@@ -446,6 +451,7 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 	private void recordFeedbackLogAndArticleProvenance(String uid,
 			List<Long> incomingAccepted, List<Long> incomingRejected,
 			List<Long> existingAccepted, List<Long> existingRejected,
+			List<Long> finalAccepted, List<Long> finalRejected,
 			EntryPath entryPath,int curatedBy) {
 		long actionEpoch = System.currentTimeMillis() / 1000L;
 		Set<Long> incomingAccSet = new HashSet<>(incomingAccepted);
@@ -459,12 +465,23 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 		Set<Long> newlyRejected = new HashSet<>(incomingRejSet);
 		newlyRejected.removeAll(existingRejSet);
 
+		// PENDING = pmids that actually LEFT the gold standard, so the diff must run
+		// against the FINAL merged state, not the incoming request body. UPDATE has
+		// merge semantics: a caller sending a single pmid (e.g. the AAR queue) is not
+		// asserting the rest of the set left. Diffing against incoming marked every
+		// other known pmid PENDING on every such accept — flooding FeedbackLog with
+		// bogus rows (1,435 for one uid on 2026-08-14). Under a pure merge this set is
+		// empty; it only fires if a caller path genuinely removes pmids.
 		Set<Long> previouslyClassified = new HashSet<>();
 		previouslyClassified.addAll(existingAccSet);
 		previouslyClassified.addAll(existingRejSet);
 		Set<Long> stillClassified = new HashSet<>();
-		stillClassified.addAll(incomingAccSet);
-		stillClassified.addAll(incomingRejSet);
+		if (finalAccepted != null) {
+			stillClassified.addAll(finalAccepted);
+		}
+		if (finalRejected != null) {
+			stillClassified.addAll(finalRejected);
+		}
 		Set<Long> newlyPending = new HashSet<>(previouslyClassified);
 		newlyPending.removeAll(stillClassified);
 

--- a/src/test/java/reciter/service/dynamo/DynamoDbGoldStandardServiceFeedbackDiffTest.java
+++ b/src/test/java/reciter/service/dynamo/DynamoDbGoldStandardServiceFeedbackDiffTest.java
@@ -1,0 +1,98 @@
+package reciter.service.dynamo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import reciter.api.parameters.GoldStandardUpdateFlag;
+import reciter.database.dynamodb.model.FeedbackLog;
+import reciter.database.dynamodb.model.GoldStandard;
+import reciter.database.dynamodb.repository.DynamoDbGoldStandardRepository;
+import reciter.feedback.EntryPath;
+import reciter.service.ArticleProvenanceService;
+import reciter.service.ESearchResultService;
+import reciter.service.FeedbackLogService;
+import reciter.service.PmidProvenanceService;
+
+/**
+ * A single-pmid UPDATE (merge semantics — the AAR queue's shape) must log exactly
+ * the newly accepted pmid, never the rest of the existing set as PENDING. Diffing
+ * against the incoming request instead of the merged final state flooded FeedbackLog
+ * with a bogus PENDING row per already-known pmid on every accept.
+ */
+@ExtendWith(MockitoExtension.class)
+public class DynamoDbGoldStandardServiceFeedbackDiffTest {
+
+    @Mock
+    private DynamoDbGoldStandardRepository dynamoDbGoldStandardRepository;
+    @Mock
+    private ESearchResultService eSearchResultService;
+    @Mock
+    private PmidProvenanceService pmidProvenanceService;
+    @Mock
+    private FeedbackLogService feedbackLogService;
+    @Mock
+    private ArticleProvenanceService articleProvenanceService;
+
+    @InjectMocks
+    private DynamoDbGoldStandardService service;
+
+    private GoldStandard existing(String uid, List<Long> known) {
+        GoldStandard gs = new GoldStandard();
+        gs.setUid(uid);
+        gs.setKnownPmids(new ArrayList<>(known));
+        return gs;
+    }
+
+    @Test
+    public void singlePmidMergeAcceptLogsOnlyTheNewPmid() {
+        when(dynamoDbGoldStandardRepository.findById("brk2001"))
+                .thenReturn(Optional.of(existing("brk2001", Arrays.asList(111L, 222L, 333L))));
+
+        GoldStandard incoming = new GoldStandard();
+        incoming.setUid("brk2001");
+        incoming.setKnownPmids(new ArrayList<>(Arrays.asList(444L)));
+
+        service.save(incoming, GoldStandardUpdateFlag.UPDATE, "adversarial-attribution-review",
+                EntryPath.PM_AUTHOR, 40421);
+
+        ArgumentCaptor<FeedbackLog> logged = ArgumentCaptor.forClass(FeedbackLog.class);
+        verify(feedbackLogService).recordAction(logged.capture());
+        assertEquals(1, logged.getAllValues().size());
+        assertEquals("444", logged.getValue().getArticleId());
+        assertEquals(FeedbackLogService.Feedback.ACCEPTED.name(), logged.getValue().getFeedback());
+        assertEquals(40421, logged.getValue().getCuratedBy());
+        // the merge kept the full set
+        assertTrue(incoming.getKnownPmids().containsAll(Arrays.asList(111L, 222L, 333L, 444L)));
+    }
+
+    @Test
+    public void reAcceptOfKnownPmidLogsNothing() {
+        when(dynamoDbGoldStandardRepository.findById("brk2001"))
+                .thenReturn(Optional.of(existing("brk2001", Arrays.asList(111L, 222L))));
+
+        GoldStandard incoming = new GoldStandard();
+        incoming.setUid("brk2001");
+        incoming.setKnownPmids(new ArrayList<>(Arrays.asList(222L)));
+
+        service.save(incoming, GoldStandardUpdateFlag.UPDATE, "adversarial-attribution-review",
+                EntryPath.PM_AUTHOR, 40421);
+
+        verify(feedbackLogService, never()).recordAction(any());
+    }
+}


### PR DESCRIPTION
Every single-pmid `UPDATE` accept (the AAR queue's shape) flooded `FeedbackLog` with a bogus `PENDING` row for each *already-known* pmid in the person's set — 1,435 rows for one uid on 2026-08-14; ~25 more uids hit today. Root cause: the Phase 33-02 delta logger computed newly-pending as *existing − incoming*, which is only correct for full-set callers (PM's main curate UI). UPDATE has merge semantics, so a single-pmid request is not an assertion that the rest of the set left.

**Fix:** newly-pending now diffs previously-classified pmids against the **merged final lists** the save persists. Under a pure merge this set is empty; it only fires when a caller genuinely removes pmids. ACCEPTED/REJECTED buckets unchanged. Both call sites (single + bulk) updated.

**No data was damaged** — gold standards always merged correctly; the flood polluted the FeedbackLog-backed Curation History popover and wrote matching spurious ArticleProvenance transitions. Junk-row cleanup is being handled separately.

Also needs porting to the Corretto17 prod line eventually — the same code is there, currently dormant because prod callers all send full sets.

Verified: new regression test (single-pmid merge accept logs exactly the new pmid; re-accept of a known pmid logs nothing) + full suite 240 tests, 0 failures.