### PR TITLE
Fix FeedbackLog PENDING flood on partial-set gold-standard updates (prod line)

### DIFF
--- a/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
+++ b/src/main/java/reciter/service/dynamo/DynamoDbGoldStandardService.java
@@ -279,10 +279,13 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     	// existing-state snapshot from the attempt that actually committed so the diff
     	// reflects the true transition. Retries never reach here => no duplicate FeedbackLog.
     	if (goldStandardUpdateFlag == GoldStandardUpdateFlag.UPDATE) {
+    		// goldStandard holds the merged lists the committed save persisted — the
+    		// final state the PENDING diff must run against.
     		recordFeedbackLogAndArticleProvenance(
     				goldStandard.getUid(),
     				incomingAcceptedPmids, incomingRejectedPmids,
     				committedExistingAccepted, committedExistingRejected,
+    				goldStandard.getKnownPmids(), goldStandard.getRejectedPmids(),
     				entryPath, curatedBy);
     	}
 
@@ -392,9 +395,12 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
     					}
     					// Phase 33-02: per-uid FeedbackLog + ArticleProvenance writes for the diff.
     					// Bulk/list (PUT) path carries no interactive curator id -> curatedBy = 0.
+    					// goldStandardNew holds the MERGED lists at this point.
     					recordFeedbackLogAndArticleProvenance(uid,
     							batchIncomingAccepted, batchIncomingRejected,
-    							existingAccepted, existingRejected, entryPath,0);
+    							existingAccepted, existingRejected,
+    							goldStandardNew.getKnownPmids(), goldStandardNew.getRejectedPmids(),
+    							entryPath,0);
     				}
     			}
     			dynamoDbGoldStandardRepository.saveAll(goldStandard);
@@ -489,6 +495,7 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 	private void recordFeedbackLogAndArticleProvenance(String uid,
 			List<Long> incomingAccepted, List<Long> incomingRejected,
 			List<Long> existingAccepted, List<Long> existingRejected,
+			List<Long> finalAccepted, List<Long> finalRejected,
 			EntryPath entryPath,int curatedBy) {
 		long actionEpoch = System.currentTimeMillis() / 1000L;
 		Set<Long> incomingAccSet = new HashSet<>(incomingAccepted);
@@ -502,12 +509,24 @@ public class DynamoDbGoldStandardService implements IDynamoDbGoldStandardService
 		Set<Long> newlyRejected = new HashSet<>(incomingRejSet);
 		newlyRejected.removeAll(existingRejSet);
 
+		// PENDING = pmids that actually LEFT the gold standard, so the diff must run
+		// against the FINAL merged state, not the incoming request body. UPDATE has
+		// merge semantics: a caller sending a partial set (single-pmid accepts, the
+		// daily batch writer) is not asserting the rest of the set left. Diffing
+		// against incoming marked every other known pmid PENDING on every such call —
+		// flooding FeedbackLog with bogus rows (~1.17M rows, 85% of the table, between
+		// 2026-05-05 and 2026-08-20). Under a pure merge this set is empty; it only
+		// fires if a caller path genuinely removes pmids.
 		Set<Long> previouslyClassified = new HashSet<>();
 		previouslyClassified.addAll(existingAccSet);
 		previouslyClassified.addAll(existingRejSet);
 		Set<Long> stillClassified = new HashSet<>();
-		stillClassified.addAll(incomingAccSet);
-		stillClassified.addAll(incomingRejSet);
+		if (finalAccepted != null) {
+			stillClassified.addAll(finalAccepted);
+		}
+		if (finalRejected != null) {
+			stillClassified.addAll(finalRejected);
+		}
 		Set<Long> newlyPending = new HashSet<>(previouslyClassified);
 		newlyPending.removeAll(stillClassified);
 

--- a/src/test/java/reciter/service/dynamo/DynamoDbGoldStandardServiceFeedbackDiffTest.java
+++ b/src/test/java/reciter/service/dynamo/DynamoDbGoldStandardServiceFeedbackDiffTest.java
@@ -1,0 +1,100 @@
+package reciter.service.dynamo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import reciter.api.parameters.GoldStandardUpdateFlag;
+import reciter.database.dynamodb.model.FeedbackLog;
+import reciter.database.dynamodb.model.GoldStandard;
+import reciter.database.dynamodb.repository.DynamoDbGoldStandardRepository;
+import reciter.feedback.EntryPath;
+import reciter.service.ArticleProvenanceService;
+import reciter.service.ESearchResultService;
+import reciter.service.FeedbackLogService;
+import reciter.service.PmidProvenanceService;
+
+/**
+ * A single-pmid UPDATE (merge semantics — the AAR queue's shape) must log exactly
+ * the newly accepted pmid, never the rest of the existing set as PENDING. Diffing
+ * against the incoming request instead of the merged final state flooded FeedbackLog
+ * with a bogus PENDING row per already-known pmid on every accept.
+ */
+@ExtendWith(MockitoExtension.class)
+public class DynamoDbGoldStandardServiceFeedbackDiffTest {
+
+    @Mock
+    private DynamoDbGoldStandardRepository dynamoDbGoldStandardRepository;
+    @Mock
+    private ESearchResultService eSearchResultService;
+    @Mock
+    private PmidProvenanceService pmidProvenanceService;
+    @Mock
+    private FeedbackLogService feedbackLogService;
+    @Mock
+    private ArticleProvenanceService articleProvenanceService;
+
+    @InjectMocks
+    private DynamoDbGoldStandardService service;
+
+    private GoldStandard existing(String uid, List<Long> known) {
+        GoldStandard gs = new GoldStandard();
+        gs.setUid(uid);
+        gs.setKnownPmids(new ArrayList<>(known));
+        return gs;
+    }
+
+    @Test
+    public void singlePmidMergeAcceptLogsOnlyTheNewPmid() {
+        when(dynamoDbGoldStandardRepository.saveIfUnchanged(any(), any(), any())).thenReturn(true);
+        when(dynamoDbGoldStandardRepository.findById("brk2001"))
+                .thenReturn(Optional.of(existing("brk2001", Arrays.asList(111L, 222L, 333L))));
+
+        GoldStandard incoming = new GoldStandard();
+        incoming.setUid("brk2001");
+        incoming.setKnownPmids(new ArrayList<>(Arrays.asList(444L)));
+
+        service.save(incoming, GoldStandardUpdateFlag.UPDATE, "adversarial-attribution-review",
+                EntryPath.PM_AUTHOR, 40421);
+
+        ArgumentCaptor<FeedbackLog> logged = ArgumentCaptor.forClass(FeedbackLog.class);
+        verify(feedbackLogService).recordAction(logged.capture());
+        assertEquals(1, logged.getAllValues().size());
+        assertEquals("444", logged.getValue().getArticleId());
+        assertEquals(FeedbackLogService.Feedback.ACCEPTED.name(), logged.getValue().getFeedback());
+        assertEquals(40421, logged.getValue().getCuratedBy());
+        // the merge kept the full set
+        assertTrue(incoming.getKnownPmids().containsAll(Arrays.asList(111L, 222L, 333L, 444L)));
+    }
+
+    @Test
+    public void reAcceptOfKnownPmidLogsNothing() {
+        when(dynamoDbGoldStandardRepository.saveIfUnchanged(any(), any(), any())).thenReturn(true);
+        when(dynamoDbGoldStandardRepository.findById("brk2001"))
+                .thenReturn(Optional.of(existing("brk2001", Arrays.asList(111L, 222L))));
+
+        GoldStandard incoming = new GoldStandard();
+        incoming.setUid("brk2001");
+        incoming.setKnownPmids(new ArrayList<>(Arrays.asList(222L)));
+
+        service.save(incoming, GoldStandardUpdateFlag.UPDATE, "adversarial-attribution-review",
+                EntryPath.PM_AUTHOR, 40421);
+
+        verify(feedbackLogService, never()).recordAction(any());
+    }
+}


### PR DESCRIPTION
Prod-line port of #709 — **this one is urgent for prod**: the flood is not dormant there. A daily batch writer has been sending partial-set `UPDATE` gold-standard calls through this code since 2026-05-05, and the delta logger diffs 'newly pending' against the incoming request instead of the merged final state — marking every *already-known* pmid PENDING on every call. Result measured today: **~1.17M bogus PENDING rows = 85% of the entire FeedbackLog table**, across 2,505 uids, growing 5k–70k rows/day. These pollute the Curation History popover in PM and write matching spurious ArticleProvenance transitions.

**No gold-standard data was ever damaged** — UPDATE's merge semantics always kept the full set; only the derived logs are wrong.

**Fix** (same as #709, adapted to this branch's post-commit logging structure): newly-pending diffs previously-classified pmids against the **merged final lists** the committed save persisted. Under a pure merge the set is empty; it only fires when a caller genuinely removes pmids. ACCEPTED/REJECTED buckets unchanged. Both call sites (single post-commit + bulk) updated.

Junk-row cleanup of the existing ~1.17M rows is scripted separately (`scripts/cleanup_feedbacklog_pending_flood.py` in the ReCiter Research folder — backup-then-delete, spares pre-2026-05-05 backfill-era history).

Verified: regression test (single-pmid merge accept logs exactly the new pmid, +0 pending; re-accept logs nothing) + full suite 242 tests, 0 failures on this branch.