### PR TITLE
Don't write zero-feature Analysis when retrieval crashes; guard blank middle names

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -452,7 +452,13 @@ public class ReCiterController {
 
                 RetrievalEscalationTracker.setMode(RetrievalRefreshFlag.ALL_PUBLICATIONS);
                 try {
-                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), RetrievalRefreshFlag.ALL_PUBLICATIONS);
+                    // false = a retrieval worker crashed (a successful run that found nothing
+                    // still returns true), so the candidate set must not be treated as complete.
+                    if (!aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), RetrievalRefreshFlag.ALL_PUBLICATIONS)) {
+                        stopWatch.stop();
+                        log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+                        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("The uid supplied failed to retrieve articles");
+                    }
                 } catch (IOException e) {
                     log.error("Failed to retrieve articles."+ e);
                     stopWatch.stop();
@@ -521,7 +527,11 @@ public class ReCiterController {
 
             	RetrievalEscalationTracker.setMode(effectiveFlag);
             	try {
-                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), effectiveFlag);
+                    if (!aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), effectiveFlag)) {
+                        stopWatch.stop();
+                        log.error(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+                        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("The uid supplied failed to retrieve articles");
+                    }
                 } catch (IOException e) {
                     log.error("Failed to retrieve articles."+e);
                     stopWatch.stop();
@@ -1285,15 +1295,28 @@ public class ReCiterController {
             if (eSearchResults == null) {
                 log.warn("No ESearchResult for uid={}; upgrading requested flag={} to ALL_PUBLICATIONS",
                          uid, retrievalRefreshFlag);
-                retrieveArticlesByUid(uid, RetrievalRefreshFlag.ALL_PUBLICATIONS);
+                ResponseEntity retrievalResponse = retrieveArticlesByUid(uid, RetrievalRefreshFlag.ALL_PUBLICATIONS);
                 // Marked AFTER the call: retrieveArticlesByUid resets the tracker on entry.
                 // Auto-upgrades are reported separately from escalations (#696) — they are
                 // unbudgeted full sweeps, and folding them into the escalation count would
                 // make the client's "budget is holding" signal a false one.
                 RetrievalEscalationTracker.markAutoUpgraded();
+                if (retrievalResponse.getStatusCode().isError()) {
+                    // The retrieval FAILED (a crashed worker, not a successful run that found
+                    // nothing): scoring the empty candidate set now would overwrite the prior
+                    // Analysis row with a zero-feature result. Bail out to the caller's 404.
+                    log.error("Retrieval failed for uid={} (status={}); skipping feature generation",
+                            uid, retrievalResponse.getStatusCode());
+                    return null;
+                }
                 eSearchResults = eSearchResultService.findByUid(uid);
             } else if(eSearchResults != null && (retrievalRefreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS || retrievalRefreshFlag == RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)) {
-            	retrieveArticlesByUid(uid, retrievalRefreshFlag, fullSweepMaxAgeDays);
+            	ResponseEntity retrievalResponse = retrieveArticlesByUid(uid, retrievalRefreshFlag, fullSweepMaxAgeDays);
+            	if (retrievalResponse.getStatusCode().isError()) {
+            		log.error("Retrieval failed for uid={} (status={}); skipping feature generation",
+            				uid, retrievalResponse.getStatusCode());
+            		return null;
+            	}
             	eSearchResults = eSearchResultService.findByUid(uid);
             }
         } catch (EmptyResultDataAccessException e) {

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -99,14 +100,16 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		private final Date startDate;
 		private final Date endDate;
 		private final RetrievalRefreshFlag refreshFlag;
-		
-		public AsyncRetrievalEngine(Identity identity, Date startDate, Date endDate, RetrievalRefreshFlag refreshFlag) {
+		private final Set<String> failedUids;
+
+		public AsyncRetrievalEngine(Identity identity, Date startDate, Date endDate, RetrievalRefreshFlag refreshFlag, Set<String> failedUids) {
 			this.identity = identity;
 			this.startDate = startDate;
 			this.endDate = endDate;
 			this.refreshFlag = refreshFlag;
+			this.failedUids = failedUids;
 		}
-		
+
 		@Override
 		public void run() {
 			try {
@@ -122,8 +125,19 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 						+ startDate + "] endDate=[" + endDate + "].");
 					retrieveDataByDateRange(identity, startDate, endDate, this.refreshFlag);
 				}
-			} catch (IOException e) {
-				slf4jLogger.error("Unabled to retrieve. " + identity.getUid(), e);
+			} catch (Throwable t) {
+				// ForkJoinPool.execute() stores a task's throwable without ever rethrowing it to
+				// an uncaught-exception handler, so an unrecorded crash here is invisible and the
+				// caller would score an empty candidate set as if retrieval had succeeded. Catch
+				// Throwable, not Exception: an Error (OOM, StackOverflowError, NoClassDefFoundError)
+				// must also mark this uid as failed, or the false-return gate never fires. Record
+				// and log FIRST, then rethrow Errors to preserve JVM Error semantics — the pool
+				// swallows the rethrow, but the uid is already recorded.
+				slf4jLogger.error("Unabled to retrieve. " + identity.getUid(), t);
+				failedUids.add(identity.getUid());
+				if (t instanceof Error) {
+					throw (Error) t;
+				}
 			}
 		}
 	}
@@ -131,14 +145,19 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	@Override
 	public boolean retrieveArticlesByDateRange(List<Identity> identities, Date startDate, Date endDate, RetrievalRefreshFlag refreshFlag) throws IOException {
 		ExecutorService executorService = Executors.newWorkStealingPool(15);//Executors.newFixedThreadPool(10);
+		Set<String> failedUids = ConcurrentHashMap.newKeySet();
 		for (Identity identity : identities) {
-			executorService.execute(new AsyncRetrievalEngine(identity, startDate, endDate, refreshFlag));
+			executorService.execute(new AsyncRetrievalEngine(identity, startDate, endDate, refreshFlag, failedUids));
 		}
 		executorService.shutdown();
 		try {
 			executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
 		} catch (InterruptedException e) {
 			slf4jLogger.error("Thread interrupted while waiting for retrieval to finish.");
+			return false;
+		}
+		if (!failedUids.isEmpty()) {
+			slf4jLogger.error("Retrieval crashed for uids=" + failedUids + ".");
 			return false;
 		}
 		return true;
@@ -1016,19 +1035,22 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	 * @param identityName
 	 * @return
 	 */
-	private Set<AuthorName> deriveAdditionalName(AuthorName identityName) {
-		
+	Set<AuthorName> deriveAdditionalName(AuthorName identityName) {
+
 		Set<AuthorName> derivedAuthorNames = new HashSet<AuthorName>();
+		// AuthorName's constructor takes substring(0, 1) of any non-null middleName, so a
+		// blank one (an Identity primaryName can carry middleName "") must behave exactly
+		// like null — both as a constructor argument and as a first-name substitute below.
+		String middleName = identityName.getMiddleName();
+		if(middleName != null && middleName.trim().isEmpty()) {
+			middleName = null;
+		}
 		if(identityName.getLastName().contains(" ") || identityName.getLastName().contains(".")) {
 			String[] possibleLastName = identityName.getLastName().split("\\s+|-", 2);
-			if(possibleLastName[0].length() >=4 
+			if(possibleLastName[0].length() >=4
 					&&
 					possibleLastName[1].length() >=4) {
-				
-				String middleName = null;
-				if(identityName.getMiddleName() != null) {
-					middleName = identityName.getMiddleName();
-				}
+
 				AuthorName authorName1 = new AuthorName(identityName.getFirstName(), middleName, possibleLastName[0].trim());
 				AuthorName authorName2 = new AuthorName(identityName.getFirstName(), middleName, possibleLastName[1].trim());
 				derivedAuthorNames.add(authorName1);
@@ -1036,10 +1058,6 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			}
 		}
 		if(identityName.getFirstName().contains(" ") || identityName.getFirstName().contains(".")) {
-			String middleName = null;
-			if(identityName.getMiddleName() != null) {
-				middleName = identityName.getMiddleName();
-			}
 			if(identityName.getFirstName().length() ==2 && identityName.getFirstName().trim().endsWith(".") && middleName != null) {
 				AuthorName authorName1 = new AuthorName(middleName, null, identityName.getLastName());//W.[firstName] Clay[middleName] Bracken[lastName]
 				derivedAuthorNames.add(authorName1);
@@ -1055,8 +1073,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				derivedAuthorNames.add(authorName1);
 			}
 		}
-		if(identityName.getFirstName().length() ==1 && identityName.getMiddleName() != null) {//Case for W[firstName] Clay[middleName] Bracken[lastName]
-			AuthorName authorName1 = new AuthorName(identityName.getMiddleName(), null, identityName.getLastName());
+		if(identityName.getFirstName().length() ==1 && middleName != null) {//Case for W[firstName] Clay[middleName] Bracken[lastName]
+			AuthorName authorName1 = new AuthorName(middleName, null, identityName.getLastName());
 			derivedAuthorNames.add(authorName1);
 		}
 		

--- a/src/test/java/reciter/controller/ReCiterControllerTest.java
+++ b/src/test/java/reciter/controller/ReCiterControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -112,7 +113,13 @@ public class ReCiterControllerTest {
 	private Double defaultScoreThreshold = 0.7;
 
 	@BeforeEach
-	public void setUp() {
+	public void setUp() throws IOException {
+		// retrieveArticlesByDateRange returning false now means "a retrieval worker
+		// crashed"; default the mock to a clean run so only tests that stub a failure
+		// (or doThrow) exercise the error paths.
+		lenient().when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(), any(), any()))
+				.thenReturn(true);
+
 		// Set the necessary properties
 		ReflectionTestUtils.setField(reCiterController, "useScopusArticles", true);
 		ReflectionTestUtils.setField(reCiterController, "totalArticleScoreStandardizedDefault", 0.7);
@@ -687,6 +694,46 @@ public class ReCiterControllerTest {
 	}
 
 	@Test
+	public void testRetrieveArticlesByUidRetrievalCrashReturns500() throws IOException {
+		// A retrieval worker crashed: retrieveArticlesByDateRange reports false (a
+		// successful run that found nothing still returns true). The endpoint must
+		// answer with the 500 error shape, not a misleading success.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(null);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				eq(RetrievalRefreshFlag.ALL_PUBLICATIONS))).thenReturn(false);
+
+		// Act
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		// Assert
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		assertTrue(response.getBody().toString().contains("failed to retrieve articles"));
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ALL_PUBLICATIONS));
+	}
+
+	@Test
+	public void testRetrieveArticlesByUidRetrievalCrashOnIncrementalReturns500() throws IOException {
+		// Same crash gate on the ONLY_NEWLY_ADDED_PUBLICATIONS path.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(testESearchResult);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				eq(RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS))).thenReturn(false);
+
+		// Act
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		// Assert
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		assertTrue(response.getBody().toString().contains("failed to retrieve articles"));
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS));
+	}
+
+	@Test
 	public void testRetrieveArticlesByUidNullRefreshFlagNoExistingESearchResult() throws IOException {
 		// Arrange
 		when(identityService.findByUid(testUid)).thenReturn(identity);
@@ -936,6 +983,31 @@ public class ReCiterControllerTest {
 		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
 		assertEquals("The uid provided '" + uid + "' was not found in the Identity table", response.getBody());
 		verify(identityService, times(1)).findByUid(uid);
+	}
+
+	@Test
+	public void testRunFeatureGeneratorAutoUpgradeRetrievalCrashReturns404AndNeverSavesAnalysis() throws IOException {
+		// The uid has no ESearchResult, so initializeEngineParameters auto-upgrades to a
+		// full ALL_PUBLICATIONS retrieval — which crashes (retrieveArticlesByDateRange
+		// reports false → 500 from retrieveArticlesByUid). Feature generation must bail
+		// out to the 404, and the Analysis row must NOT be overwritten with a
+		// zero-feature result built from the empty candidate set.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(analysisService.findByUid(testUid.trim())).thenReturn(null);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(null);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				eq(RetrievalRefreshFlag.ALL_PUBLICATIONS))).thenReturn(false);
+
+		// Act
+		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ALL, false, null, null, false);
+
+		// Assert
+		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+		assertTrue(response.getBody().toString().contains("does not have any candidate records"));
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ALL_PUBLICATIONS));
+		verify(analysisService, never()).save(any(AnalysisOutput.class));
 	}
 
 	@Test

--- a/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
@@ -1,0 +1,105 @@
+package reciter.xml.retriever.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import reciter.api.parameters.RetrievalRefreshFlag;
+import reciter.model.identity.AuthorName;
+import reciter.model.identity.Identity;
+
+/**
+ * Covers the blank-middleName hazard in deriveAdditionalName (an Identity primaryName
+ * can carry middleName "" — non-null — which AuthorName's constructor substrings, so it
+ * must behave exactly like null) and the crash-recording contract of
+ * retrieveArticlesByDateRange: false means a retrieval worker died, while a clean run
+ * that simply found nothing still returns true.
+ */
+public class AliasReCiterRetrievalEngineTest {
+
+	private final AliasReCiterRetrievalEngine engine = new AliasReCiterRetrievalEngine();
+
+	/** AuthorName("Manuel", "", ...) throws from the constructor, so set the blank after. */
+	private static AuthorName nameWithBlankMiddle(String firstName, String middleName, String lastName) {
+		AuthorName name = new AuthorName(firstName, null, lastName);
+		name.setMiddleName(middleName);
+		return name;
+	}
+
+	private static Set<String> flattened(Set<AuthorName> names) {
+		return names.stream()
+				.map(n -> n.getFirstName() + "|" + n.getMiddleName() + "|" + n.getLastName())
+				.collect(Collectors.toSet());
+	}
+
+	@Test
+	public void blankMiddleNameDerivesCompoundSurnameHalvesWithoutThrowing() {
+		// The mah4006 shape: compound surname, middleName "" (empty string, non-null).
+		Set<AuthorName> derived = engine.deriveAdditionalName(
+				nameWithBlankMiddle("Manuel", "", "Hidalgo Medina"));
+
+		assertEquals(2, derived.size());
+		assertEquals(Set.of("Hidalgo", "Medina"),
+				derived.stream().map(AuthorName::getLastName).collect(Collectors.toSet()));
+	}
+
+	@Test
+	public void blankMiddleNameDerivesExactlyWhatNullDoes() {
+		Set<AuthorName> fromBlank = engine.deriveAdditionalName(
+				nameWithBlankMiddle("Manuel", "", "Hidalgo Medina"));
+		Set<AuthorName> fromWhitespace = engine.deriveAdditionalName(
+				nameWithBlankMiddle("Manuel", " ", "Hidalgo Medina"));
+		Set<AuthorName> fromNull = engine.deriveAdditionalName(
+				new AuthorName("Manuel", null, "Hidalgo Medina"));
+
+		assertEquals(flattened(fromNull), flattened(fromBlank));
+		assertEquals(flattened(fromNull), flattened(fromWhitespace));
+	}
+
+	@Test
+	public void blankMiddleNameIsNotUsedAsAFirstNameSubstitute() {
+		// The single-initial branch promotes middleName to firstName; a blank one would
+		// hand AuthorName's constructor an empty firstName to substring. Like null, it
+		// must derive nothing.
+		assertTrue(engine.deriveAdditionalName(nameWithBlankMiddle("W", "", "Bracken")).isEmpty());
+		assertTrue(engine.deriveAdditionalName(new AuthorName("W", null, "Bracken")).isEmpty());
+	}
+
+	@Test
+	public void realMiddleNamesStillDeriveUnchanged() {
+		// AuthorName(_, null, _) stores middleName as "".
+		Set<AuthorName> derived = engine.deriveAdditionalName(new AuthorName("W", "Clay", "Bracken"));
+		assertEquals(Set.of("Clay||Bracken"), flattened(derived));
+	}
+
+	@Test
+	public void crashedRetrievalWorkerIsRecordedAndReportedAsFailure() throws IOException {
+		// A bare engine has no services wired, so the worker thread dies on an unchecked
+		// NPE at the top of retrieveData — the ForkJoinPool stores the throwable without
+		// rethrowing it, so the recorded uid is the only trace the caller can observe.
+		Identity identity = new Identity();
+		identity.setUid("mah4006");
+
+		assertFalse(engine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
+	}
+
+	@Test
+	public void runWithNoRetrievalWorkStillReportsSuccess() throws IOException {
+		// FALSE dispatches no retrieval, so no worker can fail: the gate is "a worker
+		// crashed", never "nothing was retrieved".
+		Identity identity = new Identity();
+		identity.setUid("mah4006");
+
+		assertTrue(engine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.FALSE));
+	}
+}


### PR DESCRIPTION
## Problem

`mah4006` (Manuel Hidalgo Medina — 353 accepted PMIDs) returns a zero-feature HTTP 200 from the feature-generator in ~0.16s on every attempt, never populates `ESearchResult`, and overwrites his Analysis row with zeros — the same silent-zero-write shape as the May 3–4 Analysis corruption.

Root cause (reproduced against the released identity-model 3.0.2 jar): his Identity has `middleName: ""` (empty string, not null) and a compound surname. The compound-surname path in `deriveAdditionalName` guards only `middleName != null`, so `new AuthorName("Manuel", "", "Hidalgo")` reaches `middleName.trim().substring(0, 1)` → `StringIndexOutOfBoundsException`. The retrieval worker runs on a `ForkJoinPool` via `execute()`, which **stores the exception in the task and never rethrows it** — not even to stderr — while `run()` catches `IOException` only. The request thread resumes from `awaitTermination` with `ESearchResult` still null, scores zero candidates, and writes a zero-feature Analysis row as a 200. Since the crash precedes `savePubMedArticles`, `ESearchResult` is never created and the auto-upgrade → crash loop repeats forever.

## Fix (three layers)

1. **Crash site**: `deriveAdditionalName` normalizes a blank middle name to null at the top, covering the constructor calls and the middle-name-as-first-name branches. (Companion root fix in the identity-model: ReCiter-Identity-Model #14, v3.0.3 — defense-in-depth, not required for this PR.)
2. **Silent swallow**: `AsyncRetrievalEngine.run()` now records any `Throwable` (uid into a per-call concurrent set — the engine bean is a singleton serving concurrent requests, so no shared state) and logs it; `Error`s are rethrown after recording. `retrieveArticlesByDateRange` returns false when any worker failed — its boolean was previously written but never read, verified across all callers.
3. **Garbage write**: `retrieveArticlesByUid` returns a 500 when retrieval reports failure, and the feature-generator's `initializeEngineParameters` returns null (→ the existing 404 shape) when the retrieval it triggered (auto-upgrade or explicit refresh) failed — **leaving the prior Analysis row untouched**. The gate is strictly "retrieval failed", never "ESearchResult still null", so a genuinely zero-article person keeps today's behavior exactly. The batch retrieval endpoint's aggregate-200 contract is deliberately unchanged.

## ⚠️ Deliberate behavior change

A transient retrieval `IOException` (PubMed/Scopus network failure, 429 pressure) previously logged-and-200'd, re-scoring stale candidates; it now yields 500/404 with the prior Analysis preserved and a retry on the next nightly. Expect nightly inst-client failure counts to rise visibly during PubMed flakiness — that's the fix working, not a regression. Consistent with the error-aware direction of #691.

## Testing

`mvn test`: **249/249 pass** (246 pre-existing + new coverage): blank/whitespace middle names derive compound-surname halves identically to null without throwing; real middle names unchanged; crashed worker recorded and reported; endpoint-level tests assert the 500 on both retrieval-flag paths and that a failed auto-upgrade returns 404 with `analysisService.save` **never** invoked. Post-merge smoke test on reciter-dev: re-run `mah4006` — expect a real retrieval (Identity has ~350 accepted PMIDs) instead of a 0.16s zero-feature 200.

Also fixed in passing: a uid absent from the Identity table now gets a clean 404 from the feature-generator instead of an NPE-driven 500.