### PR TITLE
Don't write zero-feature Analysis when retrieval crashes; guard blank middle names (prod port)

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -452,7 +452,13 @@ public class ReCiterController {
 
                 RetrievalEscalationTracker.setMode(RetrievalRefreshFlag.ALL_PUBLICATIONS);
                 try {
-                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), RetrievalRefreshFlag.ALL_PUBLICATIONS);
+                    // false = a retrieval worker crashed (a successful run that found nothing
+                    // still returns true), so the candidate set must not be treated as complete.
+                    if (!aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), RetrievalRefreshFlag.ALL_PUBLICATIONS)) {
+                        stopWatch.stop();
+                        log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+                        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("The uid supplied failed to retrieve articles");
+                    }
                 } catch (IOException e) {
                     log.error("Failed to retrieve articles."+ e);
                     stopWatch.stop();
@@ -521,7 +527,11 @@ public class ReCiterController {
 
             	RetrievalEscalationTracker.setMode(effectiveFlag);
             	try {
-                    aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), effectiveFlag);
+                    if (!aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), effectiveFlag)) {
+                        stopWatch.stop();
+                        log.error(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
+                        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("The uid supplied failed to retrieve articles");
+                    }
                 } catch (IOException e) {
                     log.error("Failed to retrieve articles."+e);
                     stopWatch.stop();
@@ -1285,15 +1295,28 @@ public class ReCiterController {
             if (eSearchResults == null) {
                 log.warn("No ESearchResult for uid={}; upgrading requested flag={} to ALL_PUBLICATIONS",
                          uid, retrievalRefreshFlag);
-                retrieveArticlesByUid(uid, RetrievalRefreshFlag.ALL_PUBLICATIONS);
+                ResponseEntity retrievalResponse = retrieveArticlesByUid(uid, RetrievalRefreshFlag.ALL_PUBLICATIONS);
                 // Marked AFTER the call: retrieveArticlesByUid resets the tracker on entry.
                 // Auto-upgrades are reported separately from escalations (#696) — they are
                 // unbudgeted full sweeps, and folding them into the escalation count would
                 // make the client's "budget is holding" signal a false one.
                 RetrievalEscalationTracker.markAutoUpgraded();
+                if (retrievalResponse.getStatusCode().isError()) {
+                    // The retrieval FAILED (a crashed worker, not a successful run that found
+                    // nothing): scoring the empty candidate set now would overwrite the prior
+                    // Analysis row with a zero-feature result. Bail out to the caller's 404.
+                    log.error("Retrieval failed for uid={} (status={}); skipping feature generation",
+                            uid, retrievalResponse.getStatusCode());
+                    return null;
+                }
                 eSearchResults = eSearchResultService.findByUid(uid);
             } else if(eSearchResults != null && (retrievalRefreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS || retrievalRefreshFlag == RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)) {
-            	retrieveArticlesByUid(uid, retrievalRefreshFlag, fullSweepMaxAgeDays);
+            	ResponseEntity retrievalResponse = retrieveArticlesByUid(uid, retrievalRefreshFlag, fullSweepMaxAgeDays);
+            	if (retrievalResponse.getStatusCode().isError()) {
+            		log.error("Retrieval failed for uid={} (status={}); skipping feature generation",
+            				uid, retrievalResponse.getStatusCode());
+            		return null;
+            	}
             	eSearchResults = eSearchResultService.findByUid(uid);
             }
         } catch (EmptyResultDataAccessException e) {

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -1301,7 +1301,7 @@ public class ReCiterController {
                 // unbudgeted full sweeps, and folding them into the escalation count would
                 // make the client's "budget is holding" signal a false one.
                 RetrievalEscalationTracker.markAutoUpgraded();
-                if (retrievalResponse.getStatusCode().isError()) {
+                if (retrievalResponse == null || retrievalResponse.getStatusCode().isError()) {
                     // The retrieval FAILED (a crashed worker, not a successful run that found
                     // nothing): scoring the empty candidate set now would overwrite the prior
                     // Analysis row with a zero-feature result. Bail out to the caller's 404.
@@ -1312,7 +1312,7 @@ public class ReCiterController {
                 eSearchResults = eSearchResultService.findByUid(uid);
             } else if(eSearchResults != null && (retrievalRefreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS || retrievalRefreshFlag == RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)) {
             	ResponseEntity retrievalResponse = retrieveArticlesByUid(uid, retrievalRefreshFlag, fullSweepMaxAgeDays);
-            	if (retrievalResponse.getStatusCode().isError()) {
+            	if (retrievalResponse == null || retrievalResponse.getStatusCode().isError()) {
             		log.error("Retrieval failed for uid={} (status={}); skipping feature generation",
             				uid, retrievalResponse.getStatusCode());
             		return null;

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -1043,7 +1043,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		// blank one (an Identity primaryName can carry middleName "") must behave exactly
 		// like null — both as a constructor argument and as a first-name substitute below.
 		String middleName = identityName.getMiddleName();
-		if(middleName != null && middleName.trim().isEmpty()) {
+		if(middleName != null && middleName.isBlank()) {
 			middleName = null;
 		}
 		// A malformed Identity can carry a null first or last name (see #715/#717), and an
@@ -1051,7 +1051,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		// this PR exists to stop. Read each once, guard each once.
 		String lastName = identityName.getLastName();
 		String firstName = identityName.getFirstName();
-		if(lastName != null && !lastName.trim().isEmpty()
+		if(lastName != null && !lastName.isBlank()
 				&& (lastName.contains(" ") || lastName.contains("."))) {
 			// The pattern splits on whitespace and hyphens, never on a period, so a
 			// period-without-space surname ("St.John") enters this branch but splits into a

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -99,14 +100,16 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		private final Date startDate;
 		private final Date endDate;
 		private final RetrievalRefreshFlag refreshFlag;
-		
-		public AsyncRetrievalEngine(Identity identity, Date startDate, Date endDate, RetrievalRefreshFlag refreshFlag) {
+		private final Set<String> failedUids;
+
+		public AsyncRetrievalEngine(Identity identity, Date startDate, Date endDate, RetrievalRefreshFlag refreshFlag, Set<String> failedUids) {
 			this.identity = identity;
 			this.startDate = startDate;
 			this.endDate = endDate;
 			this.refreshFlag = refreshFlag;
+			this.failedUids = failedUids;
 		}
-		
+
 		@Override
 		public void run() {
 			try {
@@ -122,8 +125,19 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 						+ startDate + "] endDate=[" + endDate + "].");
 					retrieveDataByDateRange(identity, startDate, endDate, this.refreshFlag);
 				}
-			} catch (IOException e) {
-				slf4jLogger.error("Unabled to retrieve. " + identity.getUid(), e);
+			} catch (Throwable t) {
+				// ForkJoinPool.execute() stores a task's throwable without ever rethrowing it to
+				// an uncaught-exception handler, so an unrecorded crash here is invisible and the
+				// caller would score an empty candidate set as if retrieval had succeeded. Catch
+				// Throwable, not Exception: an Error (OOM, StackOverflowError, NoClassDefFoundError)
+				// must also mark this uid as failed, or the false-return gate never fires. Record
+				// and log FIRST, then rethrow Errors to preserve JVM Error semantics — the pool
+				// swallows the rethrow, but the uid is already recorded.
+				slf4jLogger.error("Unabled to retrieve. " + identity.getUid(), t);
+				failedUids.add(identity.getUid());
+				if (t instanceof Error) {
+					throw (Error) t;
+				}
 			}
 		}
 	}
@@ -131,14 +145,19 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	@Override
 	public boolean retrieveArticlesByDateRange(List<Identity> identities, Date startDate, Date endDate, RetrievalRefreshFlag refreshFlag) throws IOException {
 		ExecutorService executorService = Executors.newWorkStealingPool(15);//Executors.newFixedThreadPool(10);
+		Set<String> failedUids = ConcurrentHashMap.newKeySet();
 		for (Identity identity : identities) {
-			executorService.execute(new AsyncRetrievalEngine(identity, startDate, endDate, refreshFlag));
+			executorService.execute(new AsyncRetrievalEngine(identity, startDate, endDate, refreshFlag, failedUids));
 		}
 		executorService.shutdown();
 		try {
 			executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
 		} catch (InterruptedException e) {
 			slf4jLogger.error("Thread interrupted while waiting for retrieval to finish.");
+			return false;
+		}
+		if (!failedUids.isEmpty()) {
+			slf4jLogger.error("Retrieval crashed for uids=" + failedUids + ".");
 			return false;
 		}
 		return true;
@@ -1016,19 +1035,22 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	 * @param identityName
 	 * @return
 	 */
-	private Set<AuthorName> deriveAdditionalName(AuthorName identityName) {
-		
+	Set<AuthorName> deriveAdditionalName(AuthorName identityName) {
+
 		Set<AuthorName> derivedAuthorNames = new HashSet<AuthorName>();
+		// AuthorName's constructor takes substring(0, 1) of any non-null middleName, so a
+		// blank one (an Identity primaryName can carry middleName "") must behave exactly
+		// like null — both as a constructor argument and as a first-name substitute below.
+		String middleName = identityName.getMiddleName();
+		if(middleName != null && middleName.trim().isEmpty()) {
+			middleName = null;
+		}
 		if(identityName.getLastName().contains(" ") || identityName.getLastName().contains(".")) {
 			String[] possibleLastName = identityName.getLastName().split("\\s+|-", 2);
-			if(possibleLastName[0].length() >=4 
+			if(possibleLastName[0].length() >=4
 					&&
 					possibleLastName[1].length() >=4) {
-				
-				String middleName = null;
-				if(identityName.getMiddleName() != null) {
-					middleName = identityName.getMiddleName();
-				}
+
 				AuthorName authorName1 = new AuthorName(identityName.getFirstName(), middleName, possibleLastName[0].trim());
 				AuthorName authorName2 = new AuthorName(identityName.getFirstName(), middleName, possibleLastName[1].trim());
 				derivedAuthorNames.add(authorName1);
@@ -1036,10 +1058,6 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 			}
 		}
 		if(identityName.getFirstName().contains(" ") || identityName.getFirstName().contains(".")) {
-			String middleName = null;
-			if(identityName.getMiddleName() != null) {
-				middleName = identityName.getMiddleName();
-			}
 			if(identityName.getFirstName().length() ==2 && identityName.getFirstName().trim().endsWith(".") && middleName != null) {
 				AuthorName authorName1 = new AuthorName(middleName, null, identityName.getLastName());//W.[firstName] Clay[middleName] Bracken[lastName]
 				derivedAuthorNames.add(authorName1);
@@ -1055,8 +1073,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				derivedAuthorNames.add(authorName1);
 			}
 		}
-		if(identityName.getFirstName().length() ==1 && identityName.getMiddleName() != null) {//Case for W[firstName] Clay[middleName] Bracken[lastName]
-			AuthorName authorName1 = new AuthorName(identityName.getMiddleName(), null, identityName.getLastName());
+		if(identityName.getFirstName().length() ==1 && middleName != null) {//Case for W[firstName] Clay[middleName] Bracken[lastName]
+			AuthorName authorName1 = new AuthorName(middleName, null, identityName.getLastName());
 			derivedAuthorNames.add(authorName1);
 		}
 		

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -163,7 +163,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		return true;
 	}
 	
-	private Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) throws IOException {
+	/** Package-private, not private, so a test can override it to simulate a worker Error. */
+	Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) throws IOException {
 		slf4jLogger.info("Coming into retrieveData section without date range****");
 		Set<Long> uniquePmids = new HashSet<>();
 
@@ -1045,36 +1046,51 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		if(middleName != null && middleName.trim().isEmpty()) {
 			middleName = null;
 		}
-		if(identityName.getLastName().contains(" ") || identityName.getLastName().contains(".")) {
-			String[] possibleLastName = identityName.getLastName().split("\\s+|-", 2);
-			if(possibleLastName[0].length() >=4
+		// A malformed Identity can carry a null first or last name (see #715/#717), and an
+		// unchecked throw here dies inside a retrieval worker — the swallowed-crash shape
+		// this PR exists to stop. Read each once, guard each once.
+		String lastName = identityName.getLastName();
+		String firstName = identityName.getFirstName();
+		if(lastName != null && !lastName.trim().isEmpty()
+				&& (lastName.contains(" ") || lastName.contains("."))) {
+			// The pattern splits on whitespace and hyphens, never on a period, so a
+			// period-without-space surname ("St.John") enters this branch but splits into a
+			// single element. Require both halves before indexing either one.
+			String[] possibleLastName = lastName.split("\\s+|-", 2);
+			if(possibleLastName.length > 1
+					&&
+					possibleLastName[0].length() >=4
 					&&
 					possibleLastName[1].length() >=4) {
 
-				AuthorName authorName1 = new AuthorName(identityName.getFirstName(), middleName, possibleLastName[0].trim());
-				AuthorName authorName2 = new AuthorName(identityName.getFirstName(), middleName, possibleLastName[1].trim());
+				AuthorName authorName1 = new AuthorName(firstName, middleName, possibleLastName[0].trim());
+				AuthorName authorName2 = new AuthorName(firstName, middleName, possibleLastName[1].trim());
 				derivedAuthorNames.add(authorName1);
 				derivedAuthorNames.add(authorName2);
 			}
 		}
-		if(identityName.getFirstName().contains(" ") || identityName.getFirstName().contains(".")) {
-			if(identityName.getFirstName().length() ==2 && identityName.getFirstName().trim().endsWith(".") && middleName != null) {
-				AuthorName authorName1 = new AuthorName(middleName, null, identityName.getLastName());//W.[firstName] Clay[middleName] Bracken[lastName]
+		if(firstName != null && (firstName.contains(" ") || firstName.contains("."))) {
+			// Measure the trimmed value: "W. " is the same initial as "W.", which an
+			// untrimmed length check silently skips. A genuine one-letter first name has
+			// neither a space nor a period, so it never reaches this branch at all.
+			String trimmedFirstName = firstName.trim();
+			if(trimmedFirstName.length() ==2 && trimmedFirstName.endsWith(".") && middleName != null) {
+				AuthorName authorName1 = new AuthorName(middleName, null, lastName);//W.[firstName] Clay[middleName] Bracken[lastName]
 				derivedAuthorNames.add(authorName1);
 			}
-			if(identityName.getFirstName().length() >=3 && Character.isWhitespace(identityName.getFirstName().charAt(1))) {
+			if(firstName.length() >=3 && Character.isWhitespace(firstName.charAt(1))) {
 				//String[] possibleFirstName = identityName.getFirstName().split("\\s+", 2);
-				AuthorName authorName1 = new AuthorName(Character.toString(identityName.getFirstName().charAt(2)), middleName, identityName.getLastName());//W Clay[firstName] Bracken[lastName]
+				AuthorName authorName1 = new AuthorName(Character.toString(firstName.charAt(2)), middleName, lastName);//W Clay[firstName] Bracken[lastName]
 				derivedAuthorNames.add(authorName1);
 			}	
-			if(identityName.getFirstName().length() >=4 && Character.isWhitespace(identityName.getFirstName().charAt(1)) && identityName.getFirstName().charAt(2) == '.') {
+			if(firstName.length() >=4 && Character.isWhitespace(firstName.charAt(1)) && firstName.charAt(2) == '.') {
 				//String[] possibleFirstName = identityName.getFirstName().split(".\\s+", 2);
-				AuthorName authorName1 = new AuthorName(Character.toString(identityName.getFirstName().charAt(3)), middleName, identityName.getLastName());//W. Clay[firstName] Bracken[lastName]
+				AuthorName authorName1 = new AuthorName(Character.toString(firstName.charAt(3)), middleName, lastName);//W. Clay[firstName] Bracken[lastName]
 				derivedAuthorNames.add(authorName1);
 			}
 		}
-		if(identityName.getFirstName().length() ==1 && middleName != null) {//Case for W[firstName] Clay[middleName] Bracken[lastName]
-			AuthorName authorName1 = new AuthorName(middleName, null, identityName.getLastName());
+		if(firstName != null && firstName.length() ==1 && middleName != null) {//Case for W[firstName] Clay[middleName] Bracken[lastName]
+			AuthorName authorName1 = new AuthorName(middleName, null, lastName);
 			derivedAuthorNames.add(authorName1);
 		}
 		

--- a/src/test/java/reciter/controller/ReCiterControllerTest.java
+++ b/src/test/java/reciter/controller/ReCiterControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -112,7 +113,13 @@ public class ReCiterControllerTest {
 	private Double defaultScoreThreshold = 0.7;
 
 	@BeforeEach
-	public void setUp() {
+	public void setUp() throws IOException {
+		// retrieveArticlesByDateRange returning false now means "a retrieval worker
+		// crashed"; default the mock to a clean run so only tests that stub a failure
+		// (or doThrow) exercise the error paths.
+		lenient().when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(), any(), any()))
+				.thenReturn(true);
+
 		// Set the necessary properties
 		ReflectionTestUtils.setField(reCiterController, "useScopusArticles", true);
 		ReflectionTestUtils.setField(reCiterController, "totalArticleScoreStandardizedDefault", 0.7);
@@ -687,6 +694,46 @@ public class ReCiterControllerTest {
 	}
 
 	@Test
+	public void testRetrieveArticlesByUidRetrievalCrashReturns500() throws IOException {
+		// A retrieval worker crashed: retrieveArticlesByDateRange reports false (a
+		// successful run that found nothing still returns true). The endpoint must
+		// answer with the 500 error shape, not a misleading success.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(null);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				eq(RetrievalRefreshFlag.ALL_PUBLICATIONS))).thenReturn(false);
+
+		// Act
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		// Assert
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		assertTrue(response.getBody().toString().contains("failed to retrieve articles"));
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ALL_PUBLICATIONS));
+	}
+
+	@Test
+	public void testRetrieveArticlesByUidRetrievalCrashOnIncrementalReturns500() throws IOException {
+		// Same crash gate on the ONLY_NEWLY_ADDED_PUBLICATIONS path.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(testESearchResult);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				eq(RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS))).thenReturn(false);
+
+		// Act
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		// Assert
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		assertTrue(response.getBody().toString().contains("failed to retrieve articles"));
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS));
+	}
+
+	@Test
 	public void testRetrieveArticlesByUidNullRefreshFlagNoExistingESearchResult() throws IOException {
 		// Arrange
 		when(identityService.findByUid(testUid)).thenReturn(identity);
@@ -936,6 +983,31 @@ public class ReCiterControllerTest {
 		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
 		assertEquals("The uid provided '" + uid + "' was not found in the Identity table", response.getBody());
 		verify(identityService, times(1)).findByUid(uid);
+	}
+
+	@Test
+	public void testRunFeatureGeneratorAutoUpgradeRetrievalCrashReturns404AndNeverSavesAnalysis() throws IOException {
+		// The uid has no ESearchResult, so initializeEngineParameters auto-upgrades to a
+		// full ALL_PUBLICATIONS retrieval — which crashes (retrieveArticlesByDateRange
+		// reports false → 500 from retrieveArticlesByUid). Feature generation must bail
+		// out to the 404, and the Analysis row must NOT be overwritten with a
+		// zero-feature result built from the empty candidate set.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(analysisService.findByUid(testUid.trim())).thenReturn(null);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(null);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				eq(RetrievalRefreshFlag.ALL_PUBLICATIONS))).thenReturn(false);
+
+		// Act
+		ResponseEntity<?> response = reCiterController.runFeatureGenerator(testUid, testScore,
+				UseGoldStandard.AS_EVIDENCE, FilterFeedbackType.ALL, false, null, null, false);
+
+		// Assert
+		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+		assertTrue(response.getBody().toString().contains("does not have any candidate records"));
+		verify(aliasReCiterRetrievalEngine, times(1)).retrieveArticlesByDateRange(anyList(), any(Date.class),
+				any(Date.class), eq(RetrievalRefreshFlag.ALL_PUBLICATIONS));
+		verify(analysisService, never()).save(any(AnalysisOutput.class));
 	}
 
 	@Test

--- a/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
@@ -1,0 +1,105 @@
+package reciter.xml.retriever.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import reciter.api.parameters.RetrievalRefreshFlag;
+import reciter.model.identity.AuthorName;
+import reciter.model.identity.Identity;
+
+/**
+ * Covers the blank-middleName hazard in deriveAdditionalName (an Identity primaryName
+ * can carry middleName "" — non-null — which AuthorName's constructor substrings, so it
+ * must behave exactly like null) and the crash-recording contract of
+ * retrieveArticlesByDateRange: false means a retrieval worker died, while a clean run
+ * that simply found nothing still returns true.
+ */
+public class AliasReCiterRetrievalEngineTest {
+
+	private final AliasReCiterRetrievalEngine engine = new AliasReCiterRetrievalEngine();
+
+	/** AuthorName("Manuel", "", ...) throws from the constructor, so set the blank after. */
+	private static AuthorName nameWithBlankMiddle(String firstName, String middleName, String lastName) {
+		AuthorName name = new AuthorName(firstName, null, lastName);
+		name.setMiddleName(middleName);
+		return name;
+	}
+
+	private static Set<String> flattened(Set<AuthorName> names) {
+		return names.stream()
+				.map(n -> n.getFirstName() + "|" + n.getMiddleName() + "|" + n.getLastName())
+				.collect(Collectors.toSet());
+	}
+
+	@Test
+	public void blankMiddleNameDerivesCompoundSurnameHalvesWithoutThrowing() {
+		// The mah4006 shape: compound surname, middleName "" (empty string, non-null).
+		Set<AuthorName> derived = engine.deriveAdditionalName(
+				nameWithBlankMiddle("Manuel", "", "Hidalgo Medina"));
+
+		assertEquals(2, derived.size());
+		assertEquals(Set.of("Hidalgo", "Medina"),
+				derived.stream().map(AuthorName::getLastName).collect(Collectors.toSet()));
+	}
+
+	@Test
+	public void blankMiddleNameDerivesExactlyWhatNullDoes() {
+		Set<AuthorName> fromBlank = engine.deriveAdditionalName(
+				nameWithBlankMiddle("Manuel", "", "Hidalgo Medina"));
+		Set<AuthorName> fromWhitespace = engine.deriveAdditionalName(
+				nameWithBlankMiddle("Manuel", " ", "Hidalgo Medina"));
+		Set<AuthorName> fromNull = engine.deriveAdditionalName(
+				new AuthorName("Manuel", null, "Hidalgo Medina"));
+
+		assertEquals(flattened(fromNull), flattened(fromBlank));
+		assertEquals(flattened(fromNull), flattened(fromWhitespace));
+	}
+
+	@Test
+	public void blankMiddleNameIsNotUsedAsAFirstNameSubstitute() {
+		// The single-initial branch promotes middleName to firstName; a blank one would
+		// hand AuthorName's constructor an empty firstName to substring. Like null, it
+		// must derive nothing.
+		assertTrue(engine.deriveAdditionalName(nameWithBlankMiddle("W", "", "Bracken")).isEmpty());
+		assertTrue(engine.deriveAdditionalName(new AuthorName("W", null, "Bracken")).isEmpty());
+	}
+
+	@Test
+	public void realMiddleNamesStillDeriveUnchanged() {
+		// AuthorName(_, null, _) stores middleName as "".
+		Set<AuthorName> derived = engine.deriveAdditionalName(new AuthorName("W", "Clay", "Bracken"));
+		assertEquals(Set.of("Clay||Bracken"), flattened(derived));
+	}
+
+	@Test
+	public void crashedRetrievalWorkerIsRecordedAndReportedAsFailure() throws IOException {
+		// A bare engine has no services wired, so the worker thread dies on an unchecked
+		// NPE at the top of retrieveData — the ForkJoinPool stores the throwable without
+		// rethrowing it, so the recorded uid is the only trace the caller can observe.
+		Identity identity = new Identity();
+		identity.setUid("mah4006");
+
+		assertFalse(engine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
+	}
+
+	@Test
+	public void runWithNoRetrievalWorkStillReportsSuccess() throws IOException {
+		// FALSE dispatches no retrieval, so no worker can fail: the gate is "a worker
+		// crashed", never "nothing was retrieved".
+		Identity identity = new Identity();
+		identity.setUid("mah4006");
+
+		assertTrue(engine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.FALSE));
+	}
+}

--- a/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
@@ -34,6 +34,22 @@ public class AliasReCiterRetrievalEngineTest {
 		return name;
 	}
 
+	/**
+	 * The no-arg constructor leaves firstName/lastName null, which is exactly the shape
+	 * DynamoDB deserialization produces for a malformed Identity (#715/#717). The setters
+	 * reject null, so this is the only way to build that state.
+	 */
+	private static AuthorName rawName(String firstName, String lastName) {
+		AuthorName name = new AuthorName();
+		if (firstName != null) {
+			name.setFirstName(firstName);
+		}
+		if (lastName != null) {
+			name.setLastName(lastName);
+		}
+		return name;
+	}
+
 	private static Set<String> flattened(Set<AuthorName> names) {
 		return names.stream()
 				.map(n -> n.getFirstName() + "|" + n.getMiddleName() + "|" + n.getLastName())
@@ -101,5 +117,75 @@ public class AliasReCiterRetrievalEngineTest {
 
 		assertTrue(engine.retrieveArticlesByDateRange(Collections.singletonList(identity),
 				new Date(), new Date(), RetrievalRefreshFlag.FALSE));
+	}
+
+	@Test
+	public void periodWithoutSpaceSurnameDerivesNothingInsteadOfThrowing() {
+		// "St.John" satisfies contains(".") but the split pattern matches whitespace and
+		// hyphens only, so it returns ONE element — indexing [1] threw
+		// ArrayIndexOutOfBoundsException inside the retrieval worker.
+		assertTrue(engine.deriveAdditionalName(new AuthorName("Manuel", null, "St.John")).isEmpty());
+		assertTrue(engine.deriveAdditionalName(new AuthorName("Manuel", null, "O.Brien")).isEmpty());
+	}
+
+	@Test
+	public void periodWithSpaceSurnameStillDerivesBothHalves() {
+		// The regression guard for the fix above: a period AND a space still splits.
+		Set<AuthorName> derived = engine.deriveAdditionalName(new AuthorName("Manuel", null, "Della. Robbia"));
+
+		assertEquals(Set.of("Della.", "Robbia"),
+				derived.stream().map(AuthorName::getLastName).collect(Collectors.toSet()));
+	}
+
+	@Test
+	public void blankAndNullLastNamesDeriveNothingInsteadOfThrowing() {
+		assertTrue(engine.deriveAdditionalName(rawName("Manuel", "")).isEmpty());
+		assertTrue(engine.deriveAdditionalName(rawName("Manuel", " ")).isEmpty());
+		assertTrue(engine.deriveAdditionalName(rawName("Manuel", null)).isEmpty());
+	}
+
+	@Test
+	public void nullFirstNameDerivesWithoutThrowing() {
+		// Null firstName must not NPE on contains(); the surname half still derives.
+		Set<AuthorName> derived = engine.deriveAdditionalName(
+				rawName(null, "Hidalgo Medina"));
+
+		assertEquals(Set.of("Hidalgo", "Medina"),
+				derived.stream().map(AuthorName::getLastName).collect(Collectors.toSet()));
+	}
+
+	@Test
+	public void trailingWhitespaceInitialIsTreatedAsAnInitial() {
+		// "W. " is the same initial as "W."; the untrimmed length()==2 check skipped it.
+		assertEquals(Set.of("Clay||Bracken"),
+				flattened(engine.deriveAdditionalName(new AuthorName("W. ", "Clay", "Bracken"))));
+		assertEquals(flattened(engine.deriveAdditionalName(new AuthorName("W.", "Clay", "Bracken"))),
+				flattened(engine.deriveAdditionalName(new AuthorName("W. ", "Clay", "Bracken"))));
+	}
+
+	@Test
+	public void genuineOneLetterFirstNameIsUnaffectedByTheTrimNormalization() {
+		// A real one-letter first name carries neither a space nor a period, so it never
+		// reaches the initial-detection branch: it derives only via the length()==1 case.
+		assertEquals(Set.of("Clay||Bracken"),
+				flattened(engine.deriveAdditionalName(new AuthorName("W", "Clay", "Bracken"))));
+		assertTrue(engine.deriveAdditionalName(new AuthorName("W", null, "Bracken")).isEmpty());
+	}
+
+	@Test
+	public void errorFromRetrievalWorkerIsRecordedBeforeItIsRethrown() throws IOException {
+		// An Error is recorded and rethrown; returning false proves the uid reached
+		// failedUids before the rethrow left the catch block.
+		AliasReCiterRetrievalEngine erroringEngine = new AliasReCiterRetrievalEngine() {
+			@Override
+			Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) {
+				throw new StackOverflowError("simulated worker Error");
+			}
+		};
+		Identity identity = new Identity();
+		identity.setUid("mah4006");
+
+		assertFalse(erroringEngine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
 	}
 }


### PR DESCRIPTION
Clean cherry-pick of #712 (merged to `development` as `f19db941`) onto the Corretto17 prod line — zero conflicts, same 4 files.

## Problem

Identities with an empty-string `middleName` and a compound surname (e.g. `mah4006`, Manuel Hidalgo Medina) crash the retrieval worker in `deriveAdditionalName` → `AuthorName.substring(0,1)`. `ForkJoinPool.execute` swallows the exception entirely (no log, no stderr), so the request thread resumes with a null `ESearchResult`, scores zero candidates, and **overwrites the Analysis row with zeros as an HTTP 200** — the May 3–4 corruption shape, repeating on every retry since `ESearchResult` is never populated.

## Fix (three layers)

1. `deriveAdditionalName` treats a blank middle name as null (the crash site).
2. Retrieval workers record any `Throwable` (per-call concurrent set; Errors rethrown after recording); `retrieveArticlesByDateRange` returns false when a worker failed — its boolean was write-only before, verified across all callers.
3. A failed retrieval returns 500 from `retrieveArticlesByUid` and 404 from the feature-generator **with the prior Analysis row untouched**. Gate is strictly "retrieval failed", never "ESearchResult still null", so genuinely zero-article people keep today's behavior exactly.

## ⚠️ Deliberate behavior change

A transient retrieval `IOException` (PubMed 429 pressure) now yields 500/404 with the prior Analysis preserved, instead of 200 re-scoring stale candidates — expect nightly inst-client failure counts to rise visibly during PubMed flakiness. By design, consistent with #691.

## Verification

- `mvn test` on this branch: **238/238 pass**.
- Dev-verified after #712 deployed to reciter-dev (image `634.…f19db941`): `mah4006` went from a 0.16s zero-feature 200 to a real 58s retrieval — **411 features, recall 1.0** (all 353 accepted PMIDs retrieved); a normal uid regression check was byte-identical before/after.
- Crash reproduced standalone against the released identity-model 3.0.2 jar; companion root fix ReCiter-Identity-Model #14 (v3.0.3) is open separately and is not a blocker.

Replaces #713 (dev→master promotion), closed in favor of this targeted port to the line prod actually runs.