### PR TITLE
Guard feature generation against malformed author and keyword data

### DIFF
--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -205,7 +205,12 @@ public class ArticleTranslator {
                     }
 
                     String affiliation = author.getAffiliation();
-                    AuthorName authorName = new AuthorName(firstName, middleName, lastName);
+                    // AuthorName's constructor derives an initial by substring(0, 1) of any
+                    // non-null firstName/middleName, so a blank-or-whitespace value crashes
+                    // with StringIndexOutOfBoundsException (e.g. a PubMed author with an
+                    // empty <ForeName>). Normalize blanks to null, which the constructor
+                    // handles. lastName is null-guarded above and never substringed.
+                    AuthorName authorName = new AuthorName(blankToNull(firstName), blankToNull(middleName), lastName);
 
                     ReCiterAuthor reCiterAuthor = new ReCiterAuthor(authorName, affiliation);
                     reCiterAuthor.setRank(i++);
@@ -221,9 +226,13 @@ public class ArticleTranslator {
 
         // Translating Keywords.
         ReCiterArticleKeywords articleKeywords = new ReCiterArticleKeywords();
-        if (keywordList != null) {
+        if (keywordList != null && keywordList.getKeywordlist() != null) {
             for (MedlineCitationKeyword keyword : keywordList.getKeywordlist()) {
-                articleKeywords.addKeyword(keyword.getKeyword());
+                // A keyword list can contain null entries (observed in PubMed data) —
+                // skip them, and defensively skip entries whose keyword text is null.
+                if (keyword != null && keyword.getKeyword() != null) {
+                    articleKeywords.addKeyword(keyword.getKeyword());
+                }
             }
         }
 
@@ -533,6 +542,19 @@ public class ArticleTranslator {
         return reCiterArticle;
     }
     
+    /**
+     * Normalizes a blank-or-whitespace name part to null so that AuthorName's
+     * constructor (which substrings any non-null value to derive the initial)
+     * cannot throw StringIndexOutOfBoundsException on it.
+     * Package-private for testing.
+     */
+    static String blankToNull(String namePart) {
+        if (namePart == null || namePart.trim().isEmpty()) {
+            return null;
+        }
+        return namePart;
+    }
+
     /**
      * Phase 1: Determine canonical publication type from PubMed publication types.
      *

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -982,7 +982,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	 * @param identity
 	 * @return
 	 */
-	private void identityAuthorNames(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames) {
+	void identityAuthorNames(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames) {
 		Set<AuthorName> identityAuthorNames  = new HashSet<AuthorName>();
 		Set<AuthorName> identityDerivedNames = new HashSet<AuthorName>();
 		AuthorName identityPrimaryName = identity.getPrimaryName();
@@ -1009,6 +1009,12 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		
 		if(identity.getAlternateNames() != null) {
 			for(AuthorName authorName: identity.getAlternateNames()) {
+				// An alternate name deserialized from the Identity table can carry a null
+				// firstName or lastName, which every dereference below would NPE on — skip it.
+				if(authorName == null || authorName.getFirstName() == null || authorName.getLastName() == null) {
+					slf4jLogger.warn("uid: {} has a malformed alternate name (null firstName or lastName); skipping it", identity.getUid());
+					continue;
+				}
 				authorName.setFirstName(ReCiterStringUtil.deAccent(authorName.getFirstName().replaceAll("[\"()]", "")));
 				authorName.setLastName(ReCiterStringUtil.deAccent(authorName.getLastName().replaceAll("(,Jr|, Jr|, MD PhD|,MD PhD|, MD-PhD|,MD-PhD|, PhD|,PhD|, MD|,MD|, III|,III|, II|,II|, Sr|,Sr|Jr|MD PhD|MD-PhD|PhD|MD|III|II|Sr)$", "")));
 				if(authorName.getMiddleName() != null) {

--- a/src/test/java/reciter/algorithm/util/ArticleTranslatorTest.java
+++ b/src/test/java/reciter/algorithm/util/ArticleTranslatorTest.java
@@ -1,42 +1,52 @@
 package reciter.algorithm.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import reciter.engine.StrategyParameters;
 import reciter.model.article.ReCiterArticle;
+import reciter.model.article.ReCiterArticleKeywords;
+import reciter.model.pubmed.MedlineCitationArticleAuthor;
 import reciter.model.pubmed.MedlineCitationCommentsCorrections;
+import reciter.model.pubmed.MedlineCitationKeyword;
+import reciter.model.pubmed.MedlineCitationKeywordList;
 import reciter.model.pubmed.PubMedArticle;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ArticleTranslatorTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private PubMedArticle pubmedArticle;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        when(pubmedArticle.getPubmeddata()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getJournal()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getPublicationtypelist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getPublicationAbstract()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getAuthorlist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getKeywordlist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getMeshheadinglist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getArticledate()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getGrantlist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getPagination()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getElocationid()).thenReturn(null);
+        // lenient: not every test drives translate() through every branch, and some
+        // tests override individual stubs with real data.
+        lenient().when(pubmedArticle.getPubmeddata()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getJournal()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getPublicationtypelist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getPublicationAbstract()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getAuthorlist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getKeywordlist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getMeshheadinglist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getArticledate()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getGrantlist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getPagination()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getElocationid()).thenReturn(null);
     }
 
     @Test
@@ -60,5 +70,66 @@ public class ArticleTranslatorTest {
         assertEquals(1, result.getCommentsCorrectionsPmids().size());
         assertTrue(result.getCommentsCorrectionsPmids().contains(32648546L));
         assertEquals("ErratumFor", result.getCommentsCorrectionsRefTypes().get(32648546L));
+    }
+
+    @Test
+    public void translateToleratesBlankAuthorNamePartsAndKeepsAuthors() {
+        // AuthorName's constructor substrings any non-null firstName/middleName for its
+        // initial, so a blank one used to crash translate with
+        // StringIndexOutOfBoundsException (observed for pstuebge, kcm9013, xim9010).
+        MedlineCitationArticleAuthor blankForeName = new MedlineCitationArticleAuthor();
+        blankForeName.setLastname("Stuebgen");
+        blankForeName.setForename("");
+
+        MedlineCitationArticleAuthor whitespaceInitials = new MedlineCitationArticleAuthor();
+        whitespaceInitials.setLastname("Meyer");
+        whitespaceInitials.setInitials(" "); // no forename, so initials become the firstName
+
+        MedlineCitationArticleAuthor normal = new MedlineCitationArticleAuthor();
+        normal.setLastname("Bracken");
+        normal.setForename("Clay");
+
+        when(pubmedArticle.getMedlinecitation().getArticle().getAuthorlist())
+                .thenReturn(Arrays.asList(blankForeName, whitespaceInitials, normal));
+
+        StrategyParameters strategyParameters = new StrategyParameters();
+        strategyParameters.setNameExcludedSuffixes("Jr,MD PhD,MD-PhD,PhD,MD,III,II,Sr");
+
+        ReCiterArticle result = ArticleTranslator.translate(pubmedArticle, null, "Wang Y, Wang J", strategyParameters);
+
+        assertEquals(3, result.getArticleCoAuthors().getAuthors().size());
+        assertTrue(result.getArticleCoAuthors().getAuthors().stream()
+                .anyMatch(author -> "Clay".equals(author.getAuthorName().getFirstName())));
+    }
+
+    @Test
+    public void translateSkipsNullKeywordEntriesAndKeepsRealOnes() {
+        MedlineCitationKeyword realKeyword = new MedlineCitationKeyword();
+        realKeyword.setKeyword("neurology");
+
+        MedlineCitationKeyword nullTextKeyword = new MedlineCitationKeyword(); // getKeyword() == null
+
+        MedlineCitationKeywordList keywordList = new MedlineCitationKeywordList();
+        keywordList.setKeywordlist(Arrays.asList(null, realKeyword, nullTextKeyword));
+
+        when(pubmedArticle.getMedlinecitation().getKeywordlist()).thenReturn(keywordList);
+
+        ReCiterArticle result = ArticleTranslator.translate(pubmedArticle, null, "", null);
+
+        List<String> keywords = result.getArticleKeywords().getKeywords().stream()
+                .map(ReCiterArticleKeywords.Keyword::getKeyword)
+                .collect(Collectors.toList());
+        assertEquals(Arrays.asList("neurology"), keywords);
+    }
+
+    @Test
+    public void blankToNullNormalizesBlankAndWhitespaceNameParts() {
+        // Covers the middleName path of the AuthorName construction guard: translate
+        // itself cannot carry a non-null middleName today (the forename split is
+        // commented out), so the normalization is exercised directly.
+        assertNull(ArticleTranslator.blankToNull(null));
+        assertNull(ArticleTranslator.blankToNull(""));
+        assertNull(ArticleTranslator.blankToNull("   "));
+        assertEquals("Clay", ArticleTranslator.blankToNull("Clay"));
     }
 }

--- a/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import reciter.api.parameters.RetrievalRefreshFlag;
 import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
+import reciter.xml.retriever.engine.AliasReCiterRetrievalEngine.IdentityNameType;
 
 /**
  * Covers the blank-middleName hazard in deriveAdditionalName (an Identity primaryName
@@ -78,6 +82,32 @@ public class AliasReCiterRetrievalEngineTest {
 		// AuthorName(_, null, _) stores middleName as "".
 		Set<AuthorName> derived = engine.deriveAdditionalName(new AuthorName("W", "Clay", "Bracken"));
 		assertEquals(Set.of("Clay||Bracken"), flattened(derived));
+	}
+
+	@Test
+	public void malformedAlternateNamesAreSkippedWithoutThrowing() {
+		// The kns2002 shape: an alternate name deserialized from the Identity table with a
+		// null firstName. identityAuthorNames used to NPE on the first dereference; it must
+		// skip the malformed entries and still produce the rest.
+		Identity identity = new Identity();
+		identity.setUid("kns2002");
+		identity.setPrimaryName(new AuthorName("Katherine", null, "Smith"));
+
+		AuthorName nullFirstName = new AuthorName(); // constructor would turn null into ""
+		nullFirstName.setLastName("Smith");
+		AuthorName nullLastName = new AuthorName();
+		nullLastName.setFirstName("Kate");
+		AuthorName valid = new AuthorName("Kate", null, "Smith");
+		identity.setAlternateNames(Arrays.asList(nullFirstName, nullLastName, valid));
+
+		Map<IdentityNameType, Set<AuthorName>> identityNames = new HashMap<>();
+		engine.identityAuthorNames(identity, identityNames);
+
+		Set<AuthorName> original = identityNames.get(IdentityNameType.ORIGINAL);
+		assertEquals(2, original.size()); // primary + the valid alternate; malformed skipped
+		assertTrue(original.stream().anyMatch(n -> "Katherine".equals(n.getFirstName())));
+		assertTrue(original.stream().anyMatch(n -> "Kate".equals(n.getFirstName())));
+		assertTrue(original.stream().noneMatch(n -> n.getFirstName() == null || n.getLastName() == null));
 	}
 
 	@Test


### PR DESCRIPTION
Follow-up to #712. With retrieval crashes now surfaced instead of silently swallowed, the remaining backfill failures exposed three more data-robustness crashes, each reproduced on reciter-dev tonight (uids `pstuebge`, `kcm9013`, `xim9010`, `kns2002` — all currently 500 on the feature-generator):

1. **`ArticleTranslator.translate` (SIOOBE)** — a PubMed article author with an empty-string `<ForeName>` reaches `new AuthorName(firstName, middleName, lastName)`, whose constructor substrings any non-null first/middle name for the initial → `StringIndexOutOfBoundsException: begin 0, end 1, length 0` at `AuthorName.java:82`. Blank first/middle names are now normalized to null before construction (the constructor handles null). Root fix for the constructor itself is in ReCiter-Identity-Model #14 (v3.0.3); this guard means ReCiter doesn't wait on a model release.
2. **`ArticleTranslator` keyword loop (NPE)** — an article's keyword list can contain null entries; they're now skipped (plus a defensive null-check on the list itself).
3. **`AliasReCiterRetrievalEngine.identityAuthorNames` (NPE)** — an alternate name from the Identity table with a null firstName (uid `kns2002`) NPE'd the sanitization loop; malformed alternates are now skipped with a warn naming the uid.

## Testing

**254/254 pass** (baseline 249). Each guard was verified red-then-green: with the guard disabled, the new test reproduces the exact production exception; with it enabled, green.

**Worth knowing**: `ArticleTranslatorTest` had never actually executed — it was JUnit 4 (`MockitoJUnitRunner`) and the project is on Spring Boot 3.4 / JUnit 5 with no vintage engine, so surefire silently skips it. It's converted to JUnit 5 here so it (and the new tests) run. Several other JUnit 4 test classes are likewise silently skipped (`AuthorNameSanitizationUtilsTest`, `TfidfTest`, `GenderProbabilityTest`, `TargetAuthorSelectionTest`) — untouched here, suggest a separate issue.

Smoke test after deploy: re-run `pstuebge`, `kcm9013`, `xim9010`, `kns2002` — all four should go from 500 to real results.