### PR TITLE
Guard feature generation against malformed author and keyword data (prod port)

### DIFF
--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -549,7 +549,7 @@ public class ArticleTranslator {
      * Package-private for testing.
      */
     static String blankToNull(String namePart) {
-        if (namePart == null || namePart.trim().isEmpty()) {
+        if (namePart == null || namePart.isBlank()) {
             return null;
         }
         return namePart;

--- a/src/main/java/reciter/algorithm/util/ArticleTranslator.java
+++ b/src/main/java/reciter/algorithm/util/ArticleTranslator.java
@@ -205,7 +205,12 @@ public class ArticleTranslator {
                     }
 
                     String affiliation = author.getAffiliation();
-                    AuthorName authorName = new AuthorName(firstName, middleName, lastName);
+                    // AuthorName's constructor derives an initial by substring(0, 1) of any
+                    // non-null firstName/middleName, so a blank-or-whitespace value crashes
+                    // with StringIndexOutOfBoundsException (e.g. a PubMed author with an
+                    // empty <ForeName>). Normalize blanks to null, which the constructor
+                    // handles. lastName is null-guarded above and never substringed.
+                    AuthorName authorName = new AuthorName(blankToNull(firstName), blankToNull(middleName), lastName);
 
                     ReCiterAuthor reCiterAuthor = new ReCiterAuthor(authorName, affiliation);
                     reCiterAuthor.setRank(i++);
@@ -221,9 +226,13 @@ public class ArticleTranslator {
 
         // Translating Keywords.
         ReCiterArticleKeywords articleKeywords = new ReCiterArticleKeywords();
-        if (keywordList != null) {
+        if (keywordList != null && keywordList.getKeywordlist() != null) {
             for (MedlineCitationKeyword keyword : keywordList.getKeywordlist()) {
-                articleKeywords.addKeyword(keyword.getKeyword());
+                // A keyword list can contain null entries (observed in PubMed data) —
+                // skip them, and defensively skip entries whose keyword text is null.
+                if (keyword != null && keyword.getKeyword() != null) {
+                    articleKeywords.addKeyword(keyword.getKeyword());
+                }
             }
         }
 
@@ -533,6 +542,19 @@ public class ArticleTranslator {
         return reCiterArticle;
     }
     
+    /**
+     * Normalizes a blank-or-whitespace name part to null so that AuthorName's
+     * constructor (which substrings any non-null value to derive the initial)
+     * cannot throw StringIndexOutOfBoundsException on it.
+     * Package-private for testing.
+     */
+    static String blankToNull(String namePart) {
+        if (namePart == null || namePart.trim().isEmpty()) {
+            return null;
+        }
+        return namePart;
+    }
+
     /**
      * Phase 1: Determine canonical publication type from PubMed publication types.
      *

--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -1287,6 +1287,7 @@ public class ReCiterController {
     private EngineParameters initializeEngineParameters(String uid, Double totalStandardizedArticleScore, RetrievalRefreshFlag retrievalRefreshFlag, Integer fullSweepMaxAgeDays) {
         // find identity
         Identity identity = identityService.findByUid(uid);
+        dropMalformedAlternateNames(identity);
         ESearchResult eSearchResults = null;
 	        // find search results for this identity
 	        //To Avoid 404 errors when multi threading
@@ -1418,5 +1419,27 @@ public class ReCiterController {
             parameters.setTotalStandardzizedArticleScore(totalStandardizedArticleScore); // Configuring the totalScore in multiple of 10's in application.properties file
         }
         return parameters;
+    }
+
+    /**
+     * An alternate name with a null firstName or lastName (they exist in the Identity
+     * table, e.g. kns2002) NPEs downstream consumers that dereference name parts
+     * (AuthorNameSanitizationUtils, GenderProbability, name-matching strategies).
+     * Drop them once at the load boundary instead of guarding every consumer.
+     * The filtered list lives only in this request; nothing writes it back.
+     * Package-private for testing.
+     */
+    static void dropMalformedAlternateNames(Identity identity) {
+        if (identity == null || identity.getAlternateNames() == null) {
+            return;
+        }
+        List<reciter.model.identity.AuthorName> usable = identity.getAlternateNames().stream()
+                .filter(n -> n != null && n.getFirstName() != null && n.getLastName() != null)
+                .collect(Collectors.toList());
+        if (usable.size() != identity.getAlternateNames().size()) {
+            log.warn("uid: {} has {} malformed alternate name(s) (null firstName or lastName); dropping for this run",
+                    identity.getUid(), identity.getAlternateNames().size() - usable.size());
+            identity.setAlternateNames(usable);
+        }
     }
 }

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -982,7 +982,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 	 * @param identity
 	 * @return
 	 */
-	private void identityAuthorNames(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames) {
+	void identityAuthorNames(Identity identity, Map<IdentityNameType, Set<AuthorName>> identityNames) {
 		Set<AuthorName> identityAuthorNames  = new HashSet<AuthorName>();
 		Set<AuthorName> identityDerivedNames = new HashSet<AuthorName>();
 		AuthorName identityPrimaryName = identity.getPrimaryName();
@@ -1009,6 +1009,12 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		
 		if(identity.getAlternateNames() != null) {
 			for(AuthorName authorName: identity.getAlternateNames()) {
+				// An alternate name deserialized from the Identity table can carry a null
+				// firstName or lastName, which every dereference below would NPE on — skip it.
+				if(authorName == null || authorName.getFirstName() == null || authorName.getLastName() == null) {
+					slf4jLogger.warn("uid: {} has a malformed alternate name (null firstName or lastName); skipping it", identity.getUid());
+					continue;
+				}
 				authorName.setFirstName(ReCiterStringUtil.deAccent(authorName.getFirstName().replaceAll("[\"()]", "")));
 				authorName.setLastName(ReCiterStringUtil.deAccent(authorName.getLastName().replaceAll("(,Jr|, Jr|, MD PhD|,MD PhD|, MD-PhD|,MD-PhD|, PhD|,PhD|, MD|,MD|, III|,III|, II|,II|, Sr|,Sr|Jr|MD PhD|MD-PhD|PhD|MD|III|II|Sr)$", "")));
 				if(authorName.getMiddleName() != null) {

--- a/src/test/java/reciter/algorithm/util/ArticleTranslatorTest.java
+++ b/src/test/java/reciter/algorithm/util/ArticleTranslatorTest.java
@@ -1,42 +1,52 @@
 package reciter.algorithm.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import reciter.engine.StrategyParameters;
 import reciter.model.article.ReCiterArticle;
+import reciter.model.article.ReCiterArticleKeywords;
+import reciter.model.pubmed.MedlineCitationArticleAuthor;
 import reciter.model.pubmed.MedlineCitationCommentsCorrections;
+import reciter.model.pubmed.MedlineCitationKeyword;
+import reciter.model.pubmed.MedlineCitationKeywordList;
 import reciter.model.pubmed.PubMedArticle;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ArticleTranslatorTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private PubMedArticle pubmedArticle;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        when(pubmedArticle.getPubmeddata()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getJournal()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getPublicationtypelist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getPublicationAbstract()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getAuthorlist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getKeywordlist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getMeshheadinglist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getArticledate()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getGrantlist()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getPagination()).thenReturn(null);
-        when(pubmedArticle.getMedlinecitation().getArticle().getElocationid()).thenReturn(null);
+        // lenient: not every test drives translate() through every branch, and some
+        // tests override individual stubs with real data.
+        lenient().when(pubmedArticle.getPubmeddata()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getJournal()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getPublicationtypelist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getPublicationAbstract()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getAuthorlist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getKeywordlist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getMeshheadinglist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getArticledate()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getGrantlist()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getPagination()).thenReturn(null);
+        lenient().when(pubmedArticle.getMedlinecitation().getArticle().getElocationid()).thenReturn(null);
     }
 
     @Test
@@ -60,5 +70,66 @@ public class ArticleTranslatorTest {
         assertEquals(1, result.getCommentsCorrectionsPmids().size());
         assertTrue(result.getCommentsCorrectionsPmids().contains(32648546L));
         assertEquals("ErratumFor", result.getCommentsCorrectionsRefTypes().get(32648546L));
+    }
+
+    @Test
+    public void translateToleratesBlankAuthorNamePartsAndKeepsAuthors() {
+        // AuthorName's constructor substrings any non-null firstName/middleName for its
+        // initial, so a blank one used to crash translate with
+        // StringIndexOutOfBoundsException (observed for pstuebge, kcm9013, xim9010).
+        MedlineCitationArticleAuthor blankForeName = new MedlineCitationArticleAuthor();
+        blankForeName.setLastname("Stuebgen");
+        blankForeName.setForename("");
+
+        MedlineCitationArticleAuthor whitespaceInitials = new MedlineCitationArticleAuthor();
+        whitespaceInitials.setLastname("Meyer");
+        whitespaceInitials.setInitials(" "); // no forename, so initials become the firstName
+
+        MedlineCitationArticleAuthor normal = new MedlineCitationArticleAuthor();
+        normal.setLastname("Bracken");
+        normal.setForename("Clay");
+
+        when(pubmedArticle.getMedlinecitation().getArticle().getAuthorlist())
+                .thenReturn(Arrays.asList(blankForeName, whitespaceInitials, normal));
+
+        StrategyParameters strategyParameters = new StrategyParameters();
+        strategyParameters.setNameExcludedSuffixes("Jr,MD PhD,MD-PhD,PhD,MD,III,II,Sr");
+
+        ReCiterArticle result = ArticleTranslator.translate(pubmedArticle, null, "Wang Y, Wang J", strategyParameters);
+
+        assertEquals(3, result.getArticleCoAuthors().getAuthors().size());
+        assertTrue(result.getArticleCoAuthors().getAuthors().stream()
+                .anyMatch(author -> "Clay".equals(author.getAuthorName().getFirstName())));
+    }
+
+    @Test
+    public void translateSkipsNullKeywordEntriesAndKeepsRealOnes() {
+        MedlineCitationKeyword realKeyword = new MedlineCitationKeyword();
+        realKeyword.setKeyword("neurology");
+
+        MedlineCitationKeyword nullTextKeyword = new MedlineCitationKeyword(); // getKeyword() == null
+
+        MedlineCitationKeywordList keywordList = new MedlineCitationKeywordList();
+        keywordList.setKeywordlist(Arrays.asList(null, realKeyword, nullTextKeyword));
+
+        when(pubmedArticle.getMedlinecitation().getKeywordlist()).thenReturn(keywordList);
+
+        ReCiterArticle result = ArticleTranslator.translate(pubmedArticle, null, "", null);
+
+        List<String> keywords = result.getArticleKeywords().getKeywords().stream()
+                .map(ReCiterArticleKeywords.Keyword::getKeyword)
+                .collect(Collectors.toList());
+        assertEquals(Arrays.asList("neurology"), keywords);
+    }
+
+    @Test
+    public void blankToNullNormalizesBlankAndWhitespaceNameParts() {
+        // Covers the middleName path of the AuthorName construction guard: translate
+        // itself cannot carry a non-null middleName today (the forename split is
+        // commented out), so the normalization is exercised directly.
+        assertNull(ArticleTranslator.blankToNull(null));
+        assertNull(ArticleTranslator.blankToNull(""));
+        assertNull(ArticleTranslator.blankToNull("   "));
+        assertEquals("Clay", ArticleTranslator.blankToNull("Clay"));
     }
 }

--- a/src/test/java/reciter/controller/ReCiterControllerTest.java
+++ b/src/test/java/reciter/controller/ReCiterControllerTest.java
@@ -1502,4 +1502,38 @@ public class ReCiterControllerTest {
 		verify(analysisService, times(1)).findByUid(testUid.trim());
 	}
 
+
+	@Test
+	public void testDropMalformedAlternateNamesFiltersNullNameParts() {
+		Identity identity = new Identity();
+		identity.setUid("kns2002");
+		reciter.model.identity.AuthorName good = new reciter.model.identity.AuthorName("Kristina", "Nori", "Shigyo");
+		reciter.model.identity.AuthorName noFirst = new reciter.model.identity.AuthorName();
+		noFirst.setLastName("Shigyo");
+		identity.setAlternateNames(new ArrayList<>(Arrays.asList(noFirst, good, null)));
+
+		ReCiterController.dropMalformedAlternateNames(identity);
+
+		assertEquals(1, identity.getAlternateNames().size());
+		assertEquals("Shigyo", identity.getAlternateNames().get(0).getLastName());
+		assertEquals("Kristina", identity.getAlternateNames().get(0).getFirstName());
+	}
+
+	@Test
+	public void testDropMalformedAlternateNamesLeavesValidNamesAndNullsAlone() {
+		Identity identity = new Identity();
+		identity.setUid("abc1001");
+		List<reciter.model.identity.AuthorName> names = new ArrayList<>(Arrays.asList(
+				new reciter.model.identity.AuthorName("Jane", null, "Doe")));
+		identity.setAlternateNames(names);
+
+		ReCiterController.dropMalformedAlternateNames(identity);
+		assertEquals(names, identity.getAlternateNames());
+
+		identity.setAlternateNames(null);
+		ReCiterController.dropMalformedAlternateNames(identity);
+		assertNull(identity.getAlternateNames());
+
+		ReCiterController.dropMalformedAlternateNames(null);
+	}
 }

--- a/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import reciter.api.parameters.RetrievalRefreshFlag;
 import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
+import reciter.xml.retriever.engine.AliasReCiterRetrievalEngine.IdentityNameType;
 
 /**
  * Covers the blank-middleName hazard in deriveAdditionalName (an Identity primaryName
@@ -78,6 +82,32 @@ public class AliasReCiterRetrievalEngineTest {
 		// AuthorName(_, null, _) stores middleName as "".
 		Set<AuthorName> derived = engine.deriveAdditionalName(new AuthorName("W", "Clay", "Bracken"));
 		assertEquals(Set.of("Clay||Bracken"), flattened(derived));
+	}
+
+	@Test
+	public void malformedAlternateNamesAreSkippedWithoutThrowing() {
+		// The kns2002 shape: an alternate name deserialized from the Identity table with a
+		// null firstName. identityAuthorNames used to NPE on the first dereference; it must
+		// skip the malformed entries and still produce the rest.
+		Identity identity = new Identity();
+		identity.setUid("kns2002");
+		identity.setPrimaryName(new AuthorName("Katherine", null, "Smith"));
+
+		AuthorName nullFirstName = new AuthorName(); // constructor would turn null into ""
+		nullFirstName.setLastName("Smith");
+		AuthorName nullLastName = new AuthorName();
+		nullLastName.setFirstName("Kate");
+		AuthorName valid = new AuthorName("Kate", null, "Smith");
+		identity.setAlternateNames(Arrays.asList(nullFirstName, nullLastName, valid));
+
+		Map<IdentityNameType, Set<AuthorName>> identityNames = new HashMap<>();
+		engine.identityAuthorNames(identity, identityNames);
+
+		Set<AuthorName> original = identityNames.get(IdentityNameType.ORIGINAL);
+		assertEquals(2, original.size()); // primary + the valid alternate; malformed skipped
+		assertTrue(original.stream().anyMatch(n -> "Katherine".equals(n.getFirstName())));
+		assertTrue(original.stream().anyMatch(n -> "Kate".equals(n.getFirstName())));
+		assertTrue(original.stream().noneMatch(n -> n.getFirstName() == null || n.getLastName() == null));
 	}
 
 	@Test


### PR DESCRIPTION
Clean cherry-pick of #715 (merged to `development` as `2caa6b1e`) onto the Corretto17 prod line. **Stacked on #714** — merge #714 first; this PR's base will retarget to `MigrationFromJDk11ToAWSCorretto17` automatically when it does.

Three data-robustness guards for crashes observed live on reciter-dev (uids `pstuebge`, `kcm9013`, `xim9010`, `kns2002` — all 500 on the feature-generator until this lands):

1. `ArticleTranslator`: blank first/middle names in PubMed article author data normalized to null before `AuthorName` construction (the constructor substrings any non-null value → `StringIndexOutOfBoundsException`). Model-level root fix is ReCiter-Identity-Model #14 (v3.0.3); this guard doesn't wait on the release.
2. `ArticleTranslator`: null entries in an article's keyword list are skipped.
3. `AliasReCiterRetrievalEngine.identityAuthorNames`: alternate names with null firstName/lastName are skipped with a warn naming the uid.

Each guard was verified red-then-green against the exact production exception. **243/243 tests pass on this branch.** Also converts `ArticleTranslatorTest` from JUnit 4 to JUnit 5 — it had never actually executed (no vintage engine on Spring Boot 3.4); several other JUnit 4 test classes remain silently skipped and deserve a separate issue.