### PR TITLE
Drop malformed alternate names at the identity load boundary

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -1287,6 +1287,7 @@ public class ReCiterController {
     private EngineParameters initializeEngineParameters(String uid, Double totalStandardizedArticleScore, RetrievalRefreshFlag retrievalRefreshFlag, Integer fullSweepMaxAgeDays) {
         // find identity
         Identity identity = identityService.findByUid(uid);
+        dropMalformedAlternateNames(identity);
         ESearchResult eSearchResults = null;
 	        // find search results for this identity
 	        //To Avoid 404 errors when multi threading
@@ -1418,5 +1419,27 @@ public class ReCiterController {
             parameters.setTotalStandardzizedArticleScore(totalStandardizedArticleScore); // Configuring the totalScore in multiple of 10's in application.properties file
         }
         return parameters;
+    }
+
+    /**
+     * An alternate name with a null firstName or lastName (they exist in the Identity
+     * table, e.g. kns2002) NPEs downstream consumers that dereference name parts
+     * (AuthorNameSanitizationUtils, GenderProbability, name-matching strategies).
+     * Drop them once at the load boundary instead of guarding every consumer.
+     * The filtered list lives only in this request; nothing writes it back.
+     * Package-private for testing.
+     */
+    static void dropMalformedAlternateNames(Identity identity) {
+        if (identity == null || identity.getAlternateNames() == null) {
+            return;
+        }
+        List<reciter.model.identity.AuthorName> usable = identity.getAlternateNames().stream()
+                .filter(n -> n != null && n.getFirstName() != null && n.getLastName() != null)
+                .collect(Collectors.toList());
+        if (usable.size() != identity.getAlternateNames().size()) {
+            log.warn("uid: {} has {} malformed alternate name(s) (null firstName or lastName); dropping for this run",
+                    identity.getUid(), identity.getAlternateNames().size() - usable.size());
+            identity.setAlternateNames(usable);
+        }
     }
 }

--- a/src/test/java/reciter/controller/ReCiterControllerTest.java
+++ b/src/test/java/reciter/controller/ReCiterControllerTest.java
@@ -1502,4 +1502,38 @@ public class ReCiterControllerTest {
 		verify(analysisService, times(1)).findByUid(testUid.trim());
 	}
 
+
+	@Test
+	public void testDropMalformedAlternateNamesFiltersNullNameParts() {
+		Identity identity = new Identity();
+		identity.setUid("kns2002");
+		reciter.model.identity.AuthorName good = new reciter.model.identity.AuthorName("Kristina", "Nori", "Shigyo");
+		reciter.model.identity.AuthorName noFirst = new reciter.model.identity.AuthorName();
+		noFirst.setLastName("Shigyo");
+		identity.setAlternateNames(new ArrayList<>(Arrays.asList(noFirst, good, null)));
+
+		ReCiterController.dropMalformedAlternateNames(identity);
+
+		assertEquals(1, identity.getAlternateNames().size());
+		assertEquals("Shigyo", identity.getAlternateNames().get(0).getLastName());
+		assertEquals("Kristina", identity.getAlternateNames().get(0).getFirstName());
+	}
+
+	@Test
+	public void testDropMalformedAlternateNamesLeavesValidNamesAndNullsAlone() {
+		Identity identity = new Identity();
+		identity.setUid("abc1001");
+		List<reciter.model.identity.AuthorName> names = new ArrayList<>(Arrays.asList(
+				new reciter.model.identity.AuthorName("Jane", null, "Doe")));
+		identity.setAlternateNames(names);
+
+		ReCiterController.dropMalformedAlternateNames(identity);
+		assertEquals(names, identity.getAlternateNames());
+
+		identity.setAlternateNames(null);
+		ReCiterController.dropMalformedAlternateNames(identity);
+		assertNull(identity.getAlternateNames());
+
+		ReCiterController.dropMalformedAlternateNames(null);
+	}
 }


### PR DESCRIPTION
Completes the kns2002 chain from #715's smoke test. The engine-side skip let retrieval succeed, but the request then died one consumer later: `GenderProbability.getGenderIdentityProbability:73` NPEs on the same null-firstName alternate name (`{firstName: null, lastName: "Shigyo"}` in the Identity table), reached via `initializeEngineParameters:1395` — and `AuthorNameSanitizationUtils` and the name-matching strategies dereference the same fields further along.

Rather than guarding each consumer, this filters unusable alternate names (null firstName or lastName) once where `initializeEngineParameters` loads the identity, with a warn naming the uid and count. The filtered list lives only in the request — nothing writes it back to DynamoDB. A name without a first or last name can't participate in matching anyway.

**256/256 tests pass** (254 baseline + 2 new unit tests on the filter: malformed entries dropped while valid ones survive; valid-only, null list, and null identity are untouched).

Smoke test after deploy: `kns2002` should finally go 500 → real results (the other three uids from the #715 round — pstuebge, kcm9013, xim9010 — are already verified fixed on image `635.…2caa6b1e`).