### PR TITLE
Bump reciter-identity-model to 3.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
 		<dependency>
 			<groupId>edu.cornell.weill.reciter</groupId>
 			<artifactId>reciter-identity-model</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>edu.cornell.weill.reciter</groupId>


### PR DESCRIPTION
Picks up ReCiter-Identity-Model #14 (published to Central today): the `AuthorName` constructor now treats blank first/middle names like null instead of throwing `StringIndexOutOfBoundsException`. Constructor-level companion to the call-site guards already merged in #712/#715/#717 — it protects any `AuthorName` construction site those didn't touch.

Verified the published jar directly before bumping: downloaded from repo1 and ran the assertion harness (blank/whitespace names → null path, mah4006 case, normal names unchanged) — 5/5. Full ReCiter suite on this branch: **256/256 pass**.