### PR TITLE
Bump reciter-identity-model to 3.0.3 (prod line)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
 		<dependency>
 			<groupId>edu.cornell.weill.reciter</groupId>
 			<artifactId>reciter-identity-model</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>edu.cornell.weill.reciter</groupId>


### PR DESCRIPTION
Same one-line bump as #718, for the Corretto17 line: picks up ReCiter-Identity-Model #14 (3.0.3, published to Central today) — the `AuthorName` constructor treats blank first/middle names like null instead of throwing.

Verified the published repo1 jar with the assertion harness (5/5) before bumping; full suite on this branch: **242/242 pass**.

Note: merging this deploys to `reciter-prod` via the `ReCiter_V2` pipeline, so sequence it however you prefer relative to #714/#716 — it's independent of them (pom-only; no conflicts either way), and safe on its own since 3.0.3 is behavior-identical for well-formed names.