### PR TITLE
Treat swallowed PubMed failures on a full sweep as a failed retrieval

### DIFF
--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -120,6 +120,20 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				if(this.refreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS) {
 					slf4jLogger.info("Starting full retrieval for uid=[" + identity.getUid() + "].");
 					retrieveData(identity, this.refreshFlag);
+					// The strategies SWALLOW a PubMed tool 500 / NCBI 429: AbstractRetrievalStrategy
+					// and PubMedArticleRetriever catch, mark the thread-local tracker, and return
+					// empty rather than throwing. Nothing reaches the catch below, so a tool-wide
+					// outage looks to the gate like a clean run that simply found nothing. On THIS
+					// path retrieveArticlesByUid has already deleted the prior ESearchResult, so
+					// scoring that empty candidate set overwrites the Analysis row with zero
+					// features and answers 200 — the May 3-4 shape (#720). Record it as a failure.
+					// The incremental path needs no equivalent: #691 rolls its watermark back and
+					// leaves the prior ESearchResult in place.
+					if (RetrievalErrorTracker.hadError()) {
+						slf4jLogger.error("Retrieval for uid=[" + identity.getUid()
+								+ "] finished with swallowed PubMed failures; treating the run as failed.");
+						failedUids.add(identity.getUid());
+					}
 				} else if(this.refreshFlag == RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS) {
 					slf4jLogger.info("Starting date range retrieval for uid=[" + identity.getUid() + "] startDate=["
 						+ startDate + "] endDate=[" + endDate + "].");
@@ -163,7 +177,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		return true;
 	}
 	
-	private Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) throws IOException {
+	/** Package-private, not private, so a test can override it to simulate strategy behaviour. */
+	Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) throws IOException {
 		slf4jLogger.info("Coming into retrieveData section without date range****");
 		Set<Long> uniquePmids = new HashSet<>();
 

--- a/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import reciter.api.parameters.RetrievalRefreshFlag;
 import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
+import reciter.xml.retriever.pubmed.RetrievalErrorTracker;
 import reciter.xml.retriever.engine.AliasReCiterRetrievalEngine.IdentityNameType;
 
 /**
@@ -131,5 +132,42 @@ public class AliasReCiterRetrievalEngineTest {
 
 		assertTrue(engine.retrieveArticlesByDateRange(Collections.singletonList(identity),
 				new Date(), new Date(), RetrievalRefreshFlag.FALSE));
+	}
+
+	@Test
+	public void swallowedPubMedFailureOnFullSweepIsReportedAsFailure() throws IOException {
+		// The strategies do not throw on a PubMed tool 500 / NCBI 429; they mark the
+		// thread-local tracker and return empty. Without the tracker check the run looks
+		// clean and the caller scores an empty candidate set over a populated Analysis row.
+		AliasReCiterRetrievalEngine swallowingEngine = new AliasReCiterRetrievalEngine() {
+			@Override
+			Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) {
+				RetrievalErrorTracker.markError();
+				return Collections.emptySet();
+			}
+		};
+		Identity identity = new Identity();
+		identity.setUid("prs4005");
+
+		assertFalse(swallowingEngine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
+	}
+
+	@Test
+	public void cleanFullSweepFindingNothingStillReportsSuccess() throws IOException {
+		// The gate must stay "a retrieval failed", never "nothing was retrieved": a person
+		// with genuinely no articles has to keep returning 200.
+		AliasReCiterRetrievalEngine emptyButCleanEngine = new AliasReCiterRetrievalEngine() {
+			@Override
+			Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) {
+				RetrievalErrorTracker.reset();
+				return Collections.emptySet();
+			}
+		};
+		Identity identity = new Identity();
+		identity.setUid("prs4005");
+
+		assertTrue(emptyButCleanEngine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
 	}
 }


### PR DESCRIPTION
Fixes #720.

## Problem

#712 records a retrieval worker's `Throwable` and fails the run, but the two dominant real-world failures never throw:

- `AbstractRetrievalStrategy.getNumberOfResults` catches a PubMed tool 500 / NCBI 429, calls `RetrievalErrorTracker.markError()`, and **returns 0**.
- `PubMedArticleRetriever` does the same and returns an empty list.

The worker completes normally, `failedUids` stays empty, and the gate reports success. `RetrievalErrorTracker` is a worker-thread `ThreadLocal` that the gate never consults.

On the `ALL_PUBLICATIONS` path `retrieveArticlesByUid` has already deleted the prior `ESearchResult`, so the empty candidate set is scored and written over the person's Analysis row as `reCiterArticleFeatures: 0` with a large `inGoldStandardButNotRetrieved` list, returned as **HTTP 200** — the May 3-4 signature, on every full sweep taken during a PubMed outage.

## Fix

Check the tracker after a full sweep and record the uid, so the existing false-return gate fires and the controller answers 500/404 with the prior Analysis row untouched.

## Deliberately scoped to ALL_PUBLICATIONS

The incremental path already has its own protection from #691: the watermark rolls back on error and the prior `ESearchResult` stays in place. Failing those requests too would spike nightly 404s for no correctness gain.

## Operational note

Full sweeps taken during PubMed flakiness now surface as failures instead of silently writing an empty result. That is the intended direction, consistent with #691/#712, and the prior Analysis row survives either way.

## Verification

- `retrieveData` is package-private so the tests can simulate a swallowed failure.
- `swallowedPubMedFailureOnFullSweepIsReportedAsFailure` — marks the tracker, returns empty, expects false.
- `cleanFullSweepFindingNothingStillReportsSuccess` — the gate stays "a retrieval failed", never "nothing was retrieved", so a person with genuinely no articles still gets 200.
- Mutation-checked: replacing the new condition with `false` fails the first test (`expected: <false> but was: <true>`).
- Full suite **258, 0 failures**.

Not included: the second candidate fix from #720, leaving the prior `ESearchResult` in place instead of deleting it at `ReCiterController:448`. That is defence in depth and a larger behavioural change; worth doing separately if you want belt and braces.