### PR TITLE
Run the 16 JUnit 4 test classes that were silently never executed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,15 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
+		<!-- Surefire selects the JUnit Platform provider, which cannot discover JUnit 4
+		     tests on its own. Without the vintage engine the 16 test classes still on
+		     org.junit.Test compile but never run, and report as neither passed nor
+		     skipped. See #721. -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/test/java/reciter/ApplicationContextSmokeTest.java
+++ b/src/test/java/reciter/ApplicationContextSmokeTest.java
@@ -110,7 +110,9 @@ public class ApplicationContextSmokeTest {
      */
     @Test
     public void springdocApiDocsAreGenerated() throws Exception {
-        mockMvc.perform(get("/v3/api-docs/reciter"))
+        // springdoc.api-docs.path is /reciter/v3/api-docs, so the "reciter" group document
+        // is served at {api-docs.path}/{group}, i.e. the group name is reciter-group.
+        mockMvc.perform(get("/reciter/v3/api-docs/reciter-group"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("\"openapi\"")))
                 .andExpect(content().string(containsString("/reciter/ping")))


### PR DESCRIPTION
Fixes #721.

## Problem

`junit:junit` is on the classpath but `junit-vintage-engine` is not, and the pom configures no surefire provider — so Spring Boot's surefire selects `JUnitPlatformProvider`, which cannot discover JUnit 4 tests. The 16 test classes still on `org.junit.Test` compiled and were then skipped **without appearing as skipped**: `Tests run: 252, Failures: 0, Errors: 0, Skipped: 0` / BUILD SUCCESS, with 106 methods reporting as neither passed nor failed.

## Fix

Add the vintage engine (test scope, version managed by the Spring Boot parent). Suite goes **252 → 358**.

## That surfaced a real, pre-existing failure

`ApplicationContextSmokeTest.springdocApiDocsAreGenerated` had never run since it was written, and was wrong on both counts:

- it requested `/v3/api-docs/reciter`
- `springdoc.api-docs.path` is `/reciter/v3/api-docs` (application.properties:407)
- `SwaggerConfig` names the group **`reciter-group`**, not `reciter`

So the document is served at `/reciter/v3/api-docs/reciter-group`. Corrected, and it now actually verifies the springfox→springdoc migration it was written to cover rather than 404ing unnoticed.

## Why this matters beyond the count

The dark set covered code paths that changed recently: `GenderProbabilityTest`, `AuthorNameSanitizationUtilsTest`, `ReCiterStringUtilTest`, `TargetAuthorSelectionTest`, `GoldStandardRetrievalStrategyTest`, `SecondInitialRetrievalStrategyTest` — the downstream consumers of the malformed-name guards in #715/#717 and the strategies running inside the retrieval worker from #712. A regression in any of those shipped green.

## Notes

- `SecurityFilterChainIntegrationTest` still reports 0 tests locally; it `Assume`-skips without `ADMIN_API_KEY` / `CONSUMER_API_KEY`, which CodeBuild sets. Expect 4 more in CI.
- Converting the 16 classes to JUnit 5 and dropping `junit:junit` is the durable end state; left as separate work so this restores the coverage now without a 16-file churn.

Suite **358, 0 failures**.