### PR TITLE
Port the #714/#716 review guards back to development

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -1302,7 +1302,7 @@ public class ReCiterController {
                 // unbudgeted full sweeps, and folding them into the escalation count would
                 // make the client's "budget is holding" signal a false one.
                 RetrievalEscalationTracker.markAutoUpgraded();
-                if (retrievalResponse.getStatusCode().isError()) {
+                if (retrievalResponse == null || retrievalResponse.getStatusCode().isError()) {
                     // The retrieval FAILED (a crashed worker, not a successful run that found
                     // nothing): scoring the empty candidate set now would overwrite the prior
                     // Analysis row with a zero-feature result. Bail out to the caller's 404.
@@ -1313,7 +1313,7 @@ public class ReCiterController {
                 eSearchResults = eSearchResultService.findByUid(uid);
             } else if(eSearchResults != null && (retrievalRefreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS || retrievalRefreshFlag == RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS)) {
             	ResponseEntity retrievalResponse = retrieveArticlesByUid(uid, retrievalRefreshFlag, fullSweepMaxAgeDays);
-            	if (retrievalResponse.getStatusCode().isError()) {
+            	if (retrievalResponse == null || retrievalResponse.getStatusCode().isError()) {
             		log.error("Retrieval failed for uid={} (status={}); skipping feature generation",
             				uid, retrievalResponse.getStatusCode());
             		return null;

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -177,7 +177,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		return true;
 	}
 	
-	/** Package-private, not private, so a test can override it to simulate strategy behaviour. */
+	/** Package-private, not private, so tests can override it to simulate a worker Error
+	 *  or a swallowed strategy failure. */
 	Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) throws IOException {
 		slf4jLogger.info("Coming into retrieveData section without date range****");
 		Set<Long> uniquePmids = new HashSet<>();
@@ -1066,36 +1067,51 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		if(middleName != null && middleName.trim().isEmpty()) {
 			middleName = null;
 		}
-		if(identityName.getLastName().contains(" ") || identityName.getLastName().contains(".")) {
-			String[] possibleLastName = identityName.getLastName().split("\\s+|-", 2);
-			if(possibleLastName[0].length() >=4
+		// A malformed Identity can carry a null first or last name (see #715/#717), and an
+		// unchecked throw here dies inside a retrieval worker — the swallowed-crash shape
+		// this PR exists to stop. Read each once, guard each once.
+		String lastName = identityName.getLastName();
+		String firstName = identityName.getFirstName();
+		if(lastName != null && !lastName.trim().isEmpty()
+				&& (lastName.contains(" ") || lastName.contains("."))) {
+			// The pattern splits on whitespace and hyphens, never on a period, so a
+			// period-without-space surname ("St.John") enters this branch but splits into a
+			// single element. Require both halves before indexing either one.
+			String[] possibleLastName = lastName.split("\\s+|-", 2);
+			if(possibleLastName.length > 1
+					&&
+					possibleLastName[0].length() >=4
 					&&
 					possibleLastName[1].length() >=4) {
 
-				AuthorName authorName1 = new AuthorName(identityName.getFirstName(), middleName, possibleLastName[0].trim());
-				AuthorName authorName2 = new AuthorName(identityName.getFirstName(), middleName, possibleLastName[1].trim());
+				AuthorName authorName1 = new AuthorName(firstName, middleName, possibleLastName[0].trim());
+				AuthorName authorName2 = new AuthorName(firstName, middleName, possibleLastName[1].trim());
 				derivedAuthorNames.add(authorName1);
 				derivedAuthorNames.add(authorName2);
 			}
 		}
-		if(identityName.getFirstName().contains(" ") || identityName.getFirstName().contains(".")) {
-			if(identityName.getFirstName().length() ==2 && identityName.getFirstName().trim().endsWith(".") && middleName != null) {
-				AuthorName authorName1 = new AuthorName(middleName, null, identityName.getLastName());//W.[firstName] Clay[middleName] Bracken[lastName]
+		if(firstName != null && (firstName.contains(" ") || firstName.contains("."))) {
+			// Measure the trimmed value: "W. " is the same initial as "W.", which an
+			// untrimmed length check silently skips. A genuine one-letter first name has
+			// neither a space nor a period, so it never reaches this branch at all.
+			String trimmedFirstName = firstName.trim();
+			if(trimmedFirstName.length() ==2 && trimmedFirstName.endsWith(".") && middleName != null) {
+				AuthorName authorName1 = new AuthorName(middleName, null, lastName);//W.[firstName] Clay[middleName] Bracken[lastName]
 				derivedAuthorNames.add(authorName1);
 			}
-			if(identityName.getFirstName().length() >=3 && Character.isWhitespace(identityName.getFirstName().charAt(1))) {
+			if(firstName.length() >=3 && Character.isWhitespace(firstName.charAt(1))) {
 				//String[] possibleFirstName = identityName.getFirstName().split("\\s+", 2);
-				AuthorName authorName1 = new AuthorName(Character.toString(identityName.getFirstName().charAt(2)), middleName, identityName.getLastName());//W Clay[firstName] Bracken[lastName]
+				AuthorName authorName1 = new AuthorName(Character.toString(firstName.charAt(2)), middleName, lastName);//W Clay[firstName] Bracken[lastName]
 				derivedAuthorNames.add(authorName1);
 			}	
-			if(identityName.getFirstName().length() >=4 && Character.isWhitespace(identityName.getFirstName().charAt(1)) && identityName.getFirstName().charAt(2) == '.') {
+			if(firstName.length() >=4 && Character.isWhitespace(firstName.charAt(1)) && firstName.charAt(2) == '.') {
 				//String[] possibleFirstName = identityName.getFirstName().split(".\\s+", 2);
-				AuthorName authorName1 = new AuthorName(Character.toString(identityName.getFirstName().charAt(3)), middleName, identityName.getLastName());//W. Clay[firstName] Bracken[lastName]
+				AuthorName authorName1 = new AuthorName(Character.toString(firstName.charAt(3)), middleName, lastName);//W. Clay[firstName] Bracken[lastName]
 				derivedAuthorNames.add(authorName1);
 			}
 		}
-		if(identityName.getFirstName().length() ==1 && middleName != null) {//Case for W[firstName] Clay[middleName] Bracken[lastName]
-			AuthorName authorName1 = new AuthorName(middleName, null, identityName.getLastName());
+		if(firstName != null && firstName.length() ==1 && middleName != null) {//Case for W[firstName] Clay[middleName] Bracken[lastName]
+			AuthorName authorName1 = new AuthorName(middleName, null, lastName);
 			derivedAuthorNames.add(authorName1);
 		}
 		

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -1064,7 +1064,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		// blank one (an Identity primaryName can carry middleName "") must behave exactly
 		// like null — both as a constructor argument and as a first-name substitute below.
 		String middleName = identityName.getMiddleName();
-		if(middleName != null && middleName.trim().isEmpty()) {
+		if(middleName != null && middleName.isBlank()) {
 			middleName = null;
 		}
 		// A malformed Identity can carry a null first or last name (see #715/#717), and an
@@ -1072,7 +1072,7 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		// this PR exists to stop. Read each once, guard each once.
 		String lastName = identityName.getLastName();
 		String firstName = identityName.getFirstName();
-		if(lastName != null && !lastName.trim().isEmpty()
+		if(lastName != null && !lastName.isBlank()
 				&& (lastName.contains(" ") || lastName.contains("."))) {
 			// The pattern splits on whitespace and hyphens, never on a period, so a
 			// period-without-space surname ("St.John") enters this branch but splits into a

--- a/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
@@ -39,6 +39,22 @@ public class AliasReCiterRetrievalEngineTest {
 		return name;
 	}
 
+	/**
+	 * The no-arg constructor leaves firstName/lastName null, which is exactly the shape
+	 * DynamoDB deserialization produces for a malformed Identity (#715/#717). The setters
+	 * reject null, so this is the only way to build that state.
+	 */
+	private static AuthorName rawName(String firstName, String lastName) {
+		AuthorName name = new AuthorName();
+		if (firstName != null) {
+			name.setFirstName(firstName);
+		}
+		if (lastName != null) {
+			name.setLastName(lastName);
+		}
+		return name;
+	}
+
 	private static Set<String> flattened(Set<AuthorName> names) {
 		return names.stream()
 				.map(n -> n.getFirstName() + "|" + n.getMiddleName() + "|" + n.getLastName())
@@ -168,6 +184,76 @@ public class AliasReCiterRetrievalEngineTest {
 		identity.setUid("prs4005");
 
 		assertTrue(emptyButCleanEngine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
+	}
+
+	@Test
+	public void periodWithoutSpaceSurnameDerivesNothingInsteadOfThrowing() {
+		// "St.John" satisfies contains(".") but the split pattern matches whitespace and
+		// hyphens only, so it returns ONE element — indexing [1] threw
+		// ArrayIndexOutOfBoundsException inside the retrieval worker.
+		assertTrue(engine.deriveAdditionalName(new AuthorName("Manuel", null, "St.John")).isEmpty());
+		assertTrue(engine.deriveAdditionalName(new AuthorName("Manuel", null, "O.Brien")).isEmpty());
+	}
+
+	@Test
+	public void periodWithSpaceSurnameStillDerivesBothHalves() {
+		// The regression guard for the fix above: a period AND a space still splits.
+		Set<AuthorName> derived = engine.deriveAdditionalName(new AuthorName("Manuel", null, "Della. Robbia"));
+
+		assertEquals(Set.of("Della.", "Robbia"),
+				derived.stream().map(AuthorName::getLastName).collect(Collectors.toSet()));
+	}
+
+	@Test
+	public void blankAndNullLastNamesDeriveNothingInsteadOfThrowing() {
+		assertTrue(engine.deriveAdditionalName(rawName("Manuel", "")).isEmpty());
+		assertTrue(engine.deriveAdditionalName(rawName("Manuel", " ")).isEmpty());
+		assertTrue(engine.deriveAdditionalName(rawName("Manuel", null)).isEmpty());
+	}
+
+	@Test
+	public void nullFirstNameDerivesWithoutThrowing() {
+		// Null firstName must not NPE on contains(); the surname half still derives.
+		Set<AuthorName> derived = engine.deriveAdditionalName(
+				rawName(null, "Hidalgo Medina"));
+
+		assertEquals(Set.of("Hidalgo", "Medina"),
+				derived.stream().map(AuthorName::getLastName).collect(Collectors.toSet()));
+	}
+
+	@Test
+	public void trailingWhitespaceInitialIsTreatedAsAnInitial() {
+		// "W. " is the same initial as "W."; the untrimmed length()==2 check skipped it.
+		assertEquals(Set.of("Clay||Bracken"),
+				flattened(engine.deriveAdditionalName(new AuthorName("W. ", "Clay", "Bracken"))));
+		assertEquals(flattened(engine.deriveAdditionalName(new AuthorName("W.", "Clay", "Bracken"))),
+				flattened(engine.deriveAdditionalName(new AuthorName("W. ", "Clay", "Bracken"))));
+	}
+
+	@Test
+	public void genuineOneLetterFirstNameIsUnaffectedByTheTrimNormalization() {
+		// A real one-letter first name carries neither a space nor a period, so it never
+		// reaches the initial-detection branch: it derives only via the length()==1 case.
+		assertEquals(Set.of("Clay||Bracken"),
+				flattened(engine.deriveAdditionalName(new AuthorName("W", "Clay", "Bracken"))));
+		assertTrue(engine.deriveAdditionalName(new AuthorName("W", null, "Bracken")).isEmpty());
+	}
+
+	@Test
+	public void errorFromRetrievalWorkerIsRecordedBeforeItIsRethrown() throws IOException {
+		// An Error is recorded and rethrown; returning false proves the uid reached
+		// failedUids before the rethrow left the catch block.
+		AliasReCiterRetrievalEngine erroringEngine = new AliasReCiterRetrievalEngine() {
+			@Override
+			Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) {
+				throw new StackOverflowError("simulated worker Error");
+			}
+		};
+		Identity identity = new Identity();
+		identity.setUid("mah4006");
+
+		assertFalse(erroringEngine.retrieveArticlesByDateRange(Collections.singletonList(identity),
 				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
 	}
 }


### PR DESCRIPTION
`development` is currently **behind production** on a crash fix.

The review round on #714/#716 produced two commits (`d1b65e9b`, `b7dabdcc`) that landed only on `MigrationFromJDk11ToAWSCorretto17` and are now live in prod (image `640…53e1dc94`). `development` never received them, so anyone working off dev is missing guards that prod has.

## What comes across

- **`possibleLastName.length > 1` before indexing.** The condition admits a period but the pattern splits on `\s+|-`, never on a period, so `St.John` / `O.Brien` enter the branch, split into a single element, and throw `ArrayIndexOutOfBoundsException` on `[1]` — inside the retrieval worker, i.e. the zero-feature-Analysis-with-200 shape. Found by @mrj4001 in review. Note `> 0` is insufficient: line 1052 reads `[1]`.
- Null/blank guards on `getLastName()` and `getFirstName()` before `contains()`, and on the `length()==1` case.
- Trim before the `length()==2` initial check so `"W. "` is treated like `"W."`. A genuine one-letter first name has neither a space nor a period, so it never enters that branch; pinned by a test.
- `retrievalResponse == null ||` before `getStatusCode()` at both gates.
- `isBlank()` rather than `trim().isEmpty()` throughout, per review preference.
- The seven tests that came with them.

## Conflict resolution

Two conflicts, both purely additive, resolved as unions:

- `retrieveData`'s package-private javadoc — #722 widened it for a swallowed-failure test, the port widened it for an Error test. Merged into one comment covering both.
- `AliasReCiterRetrievalEngineTest` — both changesets appended tests. Kept all of them; the class now has 16.

## Verification

Both changesets coexist and are individually present after the merge (`possibleLastName.length > 1`, `retrievalResponse == null` ×2, `isBlank()` ×2, `RetrievalErrorTracker.hadError()` ×2).

Full suite **367, 0 failures** — 358 from #723's vintage engine plus the ported tests.