### PR TITLE
Close the swallowed-failure half of the zero-feature Analysis bug; run the dark JUnit 4 tests (prod port)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,15 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
+		<!-- Surefire selects the JUnit Platform provider, which cannot discover JUnit 4
+		     tests on its own. Without the vintage engine the 16 test classes still on
+		     org.junit.Test compile but never run, and report as neither passed nor
+		     skipped. See #721. -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -120,6 +120,20 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 				if(this.refreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS) {
 					slf4jLogger.info("Starting full retrieval for uid=[" + identity.getUid() + "].");
 					retrieveData(identity, this.refreshFlag);
+					// The strategies SWALLOW a PubMed tool 500 / NCBI 429: AbstractRetrievalStrategy
+					// and PubMedArticleRetriever catch, mark the thread-local tracker, and return
+					// empty rather than throwing. Nothing reaches the catch below, so a tool-wide
+					// outage looks to the gate like a clean run that simply found nothing. On THIS
+					// path retrieveArticlesByUid has already deleted the prior ESearchResult, so
+					// scoring that empty candidate set overwrites the Analysis row with zero
+					// features and answers 200 — the May 3-4 shape (#720). Record it as a failure.
+					// The incremental path needs no equivalent: #691 rolls its watermark back and
+					// leaves the prior ESearchResult in place.
+					if (RetrievalErrorTracker.hadError()) {
+						slf4jLogger.error("Retrieval for uid=[" + identity.getUid()
+								+ "] finished with swallowed PubMed failures; treating the run as failed.");
+						failedUids.add(identity.getUid());
+					}
 				} else if(this.refreshFlag == RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS) {
 					slf4jLogger.info("Starting date range retrieval for uid=[" + identity.getUid() + "] startDate=["
 						+ startDate + "] endDate=[" + endDate + "].");
@@ -163,7 +177,8 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 		return true;
 	}
 	
-	/** Package-private, not private, so a test can override it to simulate a worker Error. */
+	/** Package-private, not private, so tests can override it to simulate a worker Error
+	 *  or a swallowed strategy failure. */
 	Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) throws IOException {
 		slf4jLogger.info("Coming into retrieveData section without date range****");
 		Set<Long> uniquePmids = new HashSet<>();

--- a/src/test/java/reciter/ApplicationContextSmokeTest.java
+++ b/src/test/java/reciter/ApplicationContextSmokeTest.java
@@ -110,7 +110,9 @@ public class ApplicationContextSmokeTest {
      */
     @Test
     public void springdocApiDocsAreGenerated() throws Exception {
-        mockMvc.perform(get("/v3/api-docs/reciter"))
+        // springdoc.api-docs.path is /reciter/v3/api-docs, so the "reciter" group document
+        // is served at {api-docs.path}/{group}, i.e. the group name is reciter-group.
+        mockMvc.perform(get("/reciter/v3/api-docs/reciter-group"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("\"openapi\"")))
                 .andExpect(content().string(containsString("/reciter/ping")))

--- a/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngineTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import reciter.api.parameters.RetrievalRefreshFlag;
 import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
+import reciter.xml.retriever.pubmed.RetrievalErrorTracker;
+import reciter.xml.retriever.engine.AliasReCiterRetrievalEngine.IdentityNameType;
 
 /**
  * Covers the blank-middleName hazard in deriveAdditionalName (an Identity primaryName
@@ -186,6 +188,43 @@ public class AliasReCiterRetrievalEngineTest {
 		identity.setUid("mah4006");
 
 		assertFalse(erroringEngine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
+	}
+
+	@Test
+	public void swallowedPubMedFailureOnFullSweepIsReportedAsFailure() throws IOException {
+		// The strategies do not throw on a PubMed tool 500 / NCBI 429; they mark the
+		// thread-local tracker and return empty. Without the tracker check the run looks
+		// clean and the caller scores an empty candidate set over a populated Analysis row.
+		AliasReCiterRetrievalEngine swallowingEngine = new AliasReCiterRetrievalEngine() {
+			@Override
+			Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) {
+				RetrievalErrorTracker.markError();
+				return Collections.emptySet();
+			}
+		};
+		Identity identity = new Identity();
+		identity.setUid("prs4005");
+
+		assertFalse(swallowingEngine.retrieveArticlesByDateRange(Collections.singletonList(identity),
+				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
+	}
+
+	@Test
+	public void cleanFullSweepFindingNothingStillReportsSuccess() throws IOException {
+		// The gate must stay "a retrieval failed", never "nothing was retrieved": a person
+		// with genuinely no articles has to keep returning 200.
+		AliasReCiterRetrievalEngine emptyButCleanEngine = new AliasReCiterRetrievalEngine() {
+			@Override
+			Set<Long> retrieveData(Identity identity, RetrievalRefreshFlag refreshFlag) {
+				RetrievalErrorTracker.reset();
+				return Collections.emptySet();
+			}
+		};
+		Identity identity = new Identity();
+		identity.setUid("prs4005");
+
+		assertTrue(emptyButCleanEngine.retrieveArticlesByDateRange(Collections.singletonList(identity),
 				new Date(), new Date(), RetrievalRefreshFlag.ALL_PUBLICATIONS));
 	}
 }


### PR DESCRIPTION
Port to the Corretto17 prod line of two changes merged to `development` earlier today: **#722** (fixes #720) and **#723** (fixes #721). Both were reviewed and verified on `development` first; `reciter-dev` is running them now as image `642.2026-08-21.19.31.20.9a0c6be3`.

> ⚠️ Merging this branch **deploys production** via the `ReCiter_V2` pipeline. Not out-of-band — verified today when #714/#716/#719 rolled prod to `640…53e1dc94` within five minutes of merge.

## 1. Swallowed PubMed failures still corrupted Analysis (#720)

#712 records a retrieval worker's `Throwable` and fails the run — but the two dominant real-world failures never throw. `AbstractRetrievalStrategy.getNumberOfResults` and `PubMedArticleRetriever` both catch a PubMed tool 500 / NCBI 429, call `RetrievalErrorTracker.markError()`, and return empty. The worker completes normally, `failedUids` stays empty, and the gate reports success.

On the `ALL_PUBLICATIONS` path `retrieveArticlesByUid` has already deleted the prior `ESearchResult`, so the empty candidate set gets scored and written over the person's Analysis row as `reCiterArticleFeatures: 0` with a large `inGoldStandardButNotRetrieved` list, returned as **HTTP 200** — the May 3-4 signature, on every full sweep taken during a PubMed outage.

`RetrievalErrorTracker` is a worker-thread `ThreadLocal` the gate never consulted. It does now.

**Scoped to `ALL_PUBLICATIONS` deliberately.** The incremental path already has #691's protection: the watermark rolls back on error and the prior `ESearchResult` stays in place. Failing those requests too would spike nightly 404s for no correctness gain.

**Operational note:** full sweeps taken during PubMed flakiness now surface as failures rather than silently writing an empty result. Same deliberate direction as #691/#712, and the prior Analysis row survives either way.

## 2. 16 JUnit 4 test classes never executed (#721)

`junit:junit` is on the classpath but `junit-vintage-engine` is not, and the pom sets no surefire provider — so surefire picks `JUnitPlatformProvider`, which cannot discover JUnit 4 tests. Sixteen classes compiled and were skipped **without reporting as skipped**.

Adding the vintage engine (test scope) surfaced a genuinely red test: `ApplicationContextSmokeTest.springdocApiDocsAreGenerated` had never run since it was written and was wrong twice over — it requested `/v3/api-docs/reciter`, but `springdoc.api-docs.path` is `/reciter/v3/api-docs` and `SwaggerConfig` names the group `reciter-group`. Corrected to `/reciter/v3/api-docs/reciter-group`; it now actually verifies the springfox→springdoc migration it was written for.

This matters here specifically: the dark set covers the consumers of the guards this line just shipped — `GenderProbabilityTest`, `AuthorNameSanitizationUtilsTest`, `ReCiterStringUtilTest`, `TargetAuthorSelectionTest`, `GoldStandardRetrievalStrategyTest`, `SecondInitialRetrievalStrategyTest`. A regression in any of them was shipping green.

## Conflict resolution

Two conflicts against this line, both purely additive, resolved as unions:

- `retrieveData`'s package-private javadoc — #714's review round widened it for an Error test, #722 widened it for a swallowed-failure test. One comment now covers both.
- `AliasReCiterRetrievalEngineTest` — both changesets appended tests. All kept; the class holds 15.

## Verification on this branch

- Full suite **363, 0 failures, 0 errors, 0 skipped** (JDK 17, `mvn test`). 48 surefire reports, up from 30.
- Confirmed the formerly-dark classes now execute here, not just on dev: `ApplicationContextSmokeTest` 2, `GenderProbabilityTest` 2, `AuthorNameSanitizationUtilsTest` 4, `TargetAuthorSelectionTest` 17 — all green.
- On `development` the same vintage change took the suite 252 → 358.
- `#722`'s gate is mutation-checked: forcing the new condition to `false` fails `swallowedPubMedFailureOnFullSweepIsReportedAsFailure` with `expected: <false> but was: <true>`.
- `SecurityFilterChainIntegrationTest` reports 0 locally; it `Assume`-skips without `ADMIN_API_KEY` / `CONSUMER_API_KEY`, which CodeBuild sets. Expect ~4 more in CI.

## Not included

The second candidate fix from #720 — leaving the prior `ESearchResult` in place instead of deleting it at `ReCiterController:448`. That is defence in depth and a larger behavioural change; worth doing separately if you want belt and braces.