### PR TITLE
Never shrink a retrieval record on a run that hit PubMed failures (#737)

### DIFF
--- a/src/main/java/reciter/controller/ReCiterController.java
+++ b/src/main/java/reciter/controller/ReCiterController.java
@@ -444,6 +444,7 @@ public class ReCiterController {
             } else if(refreshFlag == RetrievalRefreshFlag.ALL_PUBLICATIONS
             		||
             		eSearchResult == null){
+                ESearchResult priorESearchResult = eSearchResult;
                 if (eSearchResult != null)
                     eSearchResultService.delete(uid.trim());
 
@@ -455,12 +456,14 @@ public class ReCiterController {
                     // false = a retrieval worker crashed (a successful run that found nothing
                     // still returns true), so the candidate set must not be treated as complete.
                     if (!aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(identities, Date.valueOf(startDate), Date.valueOf(endDate), RetrievalRefreshFlag.ALL_PUBLICATIONS)) {
+                        restoreESearchResultAfterFailedSweep(uid.trim(), priorESearchResult);
                         stopWatch.stop();
                         log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
                         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("The uid supplied failed to retrieve articles");
                     }
                 } catch (IOException e) {
                     log.error("Failed to retrieve articles."+ e);
+                    restoreESearchResultAfterFailedSweep(uid.trim(), priorESearchResult);
                     stopWatch.stop();
                     log.info(stopWatch.getId() + " took " + stopWatch.getTotalTimeSeconds() + "s");
                     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("The uid supplied failed to retrieve articles");
@@ -553,6 +556,31 @@ public class ReCiterController {
     /** Convenience overload for callers that do not opt into full-sweep escalation. */
     public ResponseEntity retrieveArticlesByUid(String uid, RetrievalRefreshFlag refreshFlag) {
         return retrieveArticlesByUid(uid, refreshFlag, null);
+    }
+
+    /**
+     * Restore the ESearchResult record this uid had before an ALL_PUBLICATIONS sweep
+     * that then failed (#737). The engine has already upserted partial per-strategy
+     * entries into DynamoDB before this method's caller learns the sweep failed (the
+     * #720 gate fires only after retrieveArticlesByDateRange returns) — leaving those
+     * entries in place means the next cache-only or incremental run rebuilds the
+     * Analysis candidate set from the partial data. With no prior record (a first-ever
+     * retrieval), deleting instead of restoring leaves the uid with no ESearchResult at
+     * all, so the next run auto-upgrades to a full sweep (initializeEngineParameters
+     * :1296-1299) rather than being treated as ONLY_NEWLY_ADDED against a partial base.
+     */
+    private void restoreESearchResultAfterFailedSweep(String uid, ESearchResult prior) {
+        try {
+            if (prior != null) {
+                eSearchResultService.save(prior);
+                log.warn("uid=[{}] full sweep failed; restored the pre-sweep ESearchResult so partial per-strategy entries written before the failure don't shrink the next run's Analysis (#737)", uid);
+            } else {
+                eSearchResultService.delete(uid);
+                log.warn("uid=[{}] full sweep failed with no prior ESearchResult; deleted the partial one so the next run auto-upgrades to a full sweep (#737)", uid);
+            }
+        } catch (Exception e) {
+            log.error("uid=[{}] failed to restore ESearchResult after a failed full sweep (#737): {}", uid, e.getMessage(), e);
+        }
     }
 
     /**

--- a/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngine.java
@@ -171,7 +171,20 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 				eSearchPmids.removeIf(existing -> existing != null
 						&& existing.getRetrievalStrategyName() != null
 						&& existing.getRetrievalStrategyName().equalsIgnoreCase(newStrategyName));
-				eSearchPmids.add(upsertedStrategyEntry(existingEntry, eSearchPmid));
+				// #737: a run that hit PubMed failures for this uid must not let a partial
+				// batch shrink the stored strategy entry — union instead of replace.
+				boolean runHadFailures = reciter.xml.retriever.pubmed.RetrievalErrorTracker.hadError();
+				ESearchPmid upserted = upsertedStrategyEntry(existingEntry, eSearchPmid, runHadFailures);
+				if (runHadFailures && existingEntry != null
+						&& existingEntry.getPmids() != null && eSearchPmid.getPmids() != null) {
+					int storedCount = upserted.getPmids() == null ? 0 : upserted.getPmids().size();
+					int incomingCount = eSearchPmid.getPmids().size();
+					if (storedCount > incomingCount) {
+						log.warn("uid=[{}] strategy [{}]: run hit PubMed failures; kept {} prior pmids the run did not return (incoming {}, stored {})",
+								uid, newStrategyName, storedCount - incomingCount, incomingCount, storedCount);
+					}
+				}
+				eSearchPmids.add(upserted);
 			}
 			if(!eSearchPmids.isEmpty()) {
 				eSearchResultService.save(new ESearchResult(uid, Instant.now(), eSearchPmids, queryType));
@@ -185,27 +198,76 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 
 	/**
 	 * The strategy entry to store when a retrieval upserts over an existing one.
-	 * Normally the incoming entry replaces the old one wholesale — but an incremental
-	 * run must not downgrade an entry's {@code lookupType} from ALL_PUBLICATIONS
-	 * (#696/E13): {@code ArticleSizeStrategy} filters entries on that marker to compute
-	 * {@code articleCountScore}, so erasing it perturbs scoring, and the escalation
-	 * fallback infers last-full-sweep from the same marker's {@code retrievalDate}.
+	 * Normally the incoming entry replaces the old one wholesale, but two situations
+	 * refuse that replacement and merge pmids instead:
 	 *
-	 * <p>When the downgrade is refused, the stored entry keeps the ALL_PUBLICATIONS
-	 * marker AND the full sweep's retrievalDate — bumping the date on an incremental
-	 * run would make the person look freshly swept and suppress a due escalation —
-	 * while the pmid lists are merged, so the full-sweep article count is preserved and
-	 * newly discovered articles still register. Pure so the rule is unit-testable.
+	 * <p>(1) An incremental run must not downgrade an entry's {@code lookupType} from
+	 * ALL_PUBLICATIONS (#696/E13): {@code ArticleSizeStrategy} filters entries on that
+	 * marker to compute {@code articleCountScore}, so erasing it perturbs scoring, and
+	 * the escalation fallback infers last-full-sweep from the same marker's
+	 * {@code retrievalDate}. The stored entry keeps the ALL_PUBLICATIONS marker AND the
+	 * full sweep's retrievalDate — bumping the date would make the person look freshly
+	 * swept and suppress a due escalation — while the pmid lists are merged. This rule
+	 * applies regardless of {@code runHadFailures}.
+	 *
+	 * <p>(2) A run that hit PubMed failures for this uid (#737) must not let a partial
+	 * batch shrink the stored entry: on 2026-09-01 3 of 8 GoldStandardRetrievalStrategy
+	 * batches for rharrington failed with NCBI connection resets, and the wholesale
+	 * replace this method previously always performed shrank the strategy entry from
+	 * 794 to 394 pmids — which shrank the Analysis candidate set with it, and cache-only
+	 * re-analysis could not heal it since the candidate set is rebuilt from this stored
+	 * entry. When {@code runHadFailures} is true the pmids are unioned (existing first,
+	 * then incoming's not-yet-seen), the lookupType is escalated to ALL_PUBLICATIONS if
+	 * either side already carries it (otherwise incoming's), and retrievalDate is
+	 * incoming's — a failed run should still look attempted, unlike case (1)'s refused
+	 * sweep. When a strategy returns zero pmids the caller never builds an incoming
+	 * entry at all, so a total failure leaves the existing entry untouched (:137, :158);
+	 * only a partial batch reaches this union path.
+	 *
+	 * <p>Outside both cases (clean run, no ALL_PUBLICATIONS downgrade at stake) the
+	 * incoming entry replaces the old one wholesale, unchanged from prior behavior.
+	 * Pure so both rules are unit-testable — no {@code RetrievalErrorTracker} read here.
 	 */
-	static ESearchPmid upsertedStrategyEntry(ESearchPmid existing, ESearchPmid incoming) {
-		if (existing == null || incoming == null
-				|| existing.getLookupType() != ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS
-				|| incoming.getLookupType() == ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS) {
+	static ESearchPmid upsertedStrategyEntry(ESearchPmid existing, ESearchPmid incoming, boolean runHadFailures) {
+		if (existing == null || incoming == null) {
 			return incoming;
 		}
+		boolean existingIsAll = existing.getLookupType() == ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS;
+		boolean incomingIsAll = incoming.getLookupType() == ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS;
+
+		if (existingIsAll && !incomingIsAll) {
+			// Rule b: refused ALL_PUBLICATIONS downgrade — merge, keep existing's date.
+			List<Long> mergedPmids = mergePmids(existing.getPmids(), incoming.getPmids());
+			log.info("Refusing lookupType downgrade for strategy {} : keeping ALL_PUBLICATIONS marker "
+					+ "(sweep date {}), merged pmids {} -> {}", incoming.getRetrievalStrategyName(),
+					existing.getRetrievalDate(),
+					incoming.getPmids() == null ? 0 : incoming.getPmids().size(), mergedPmids.size());
+			return new ESearchPmid(mergedPmids, incoming.getRetrievalStrategyName(),
+					existing.getRetrievalDate(), ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+		}
+
+		if (runHadFailures) {
+			// Rule c (#737): failed run — union, keep incoming's date.
+			List<Long> mergedPmids = mergePmids(existing.getPmids(), incoming.getPmids());
+			ESearchPmid.RetrievalRefreshFlag lookupType = (existingIsAll || incomingIsAll)
+					? ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS
+					: incoming.getLookupType();
+			return new ESearchPmid(mergedPmids, incoming.getRetrievalStrategyName(),
+					incoming.getRetrievalDate(), lookupType);
+		}
+
+		// Rule d: clean run, no ALL_PUBLICATIONS downgrade at stake — replace wholesale.
+		return incoming;
+	}
+
+	/**
+	 * Union of two pmid lists, existing's entries first in their original order, then
+	 * incoming's not-yet-seen entries in their original order. Nulls are skipped.
+	 */
+	private static List<Long> mergePmids(List<Long> existingPmids, List<Long> incomingPmids) {
 		List<Long> mergedPmids = new ArrayList<>();
 		Set<Long> seen = new HashSet<>();
-		for (List<Long> pmidList : Arrays.asList(existing.getPmids(), incoming.getPmids())) {
+		for (List<Long> pmidList : Arrays.asList(existingPmids, incomingPmids)) {
 			if (pmidList == null) {
 				continue;
 			}
@@ -215,12 +277,7 @@ public abstract class AbstractReCiterRetrievalEngine implements ReCiterRetrieval
 				}
 			}
 		}
-		log.info("Refusing lookupType downgrade for strategy {} : keeping ALL_PUBLICATIONS marker "
-				+ "(sweep date {}), merged pmids {} -> {}", incoming.getRetrievalStrategyName(),
-				existing.getRetrievalDate(),
-				incoming.getPmids() == null ? 0 : incoming.getPmids().size(), mergedPmids.size());
-		return new ESearchPmid(mergedPmids, incoming.getRetrievalStrategyName(),
-				existing.getRetrievalDate(), ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+		return mergedPmids;
 	}
 
 	/**

--- a/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
+++ b/src/main/java/reciter/xml/retriever/engine/AliasReCiterRetrievalEngine.java
@@ -127,8 +127,11 @@ public class AliasReCiterRetrievalEngine extends AbstractReCiterRetrievalEngine 
 					// path retrieveArticlesByUid has already deleted the prior ESearchResult, so
 					// scoring that empty candidate set overwrites the Analysis row with zero
 					// features and answers 200 — the May 3-4 shape (#720). Record it as a failure.
-					// The incremental path needs no equivalent: #691 rolls its watermark back and
-					// leaves the prior ESearchResult in place.
+					// The incremental path is protected differently: the engine's per-strategy
+					// union when a run hit failures (#737, upsertedStrategyEntry) stops a
+					// partial batch from shrinking the stored ESearchResult entry, and #691's
+					// watermark rollback keeps the next incremental run from treating the gap
+					// as already covered.
 					if (RetrievalErrorTracker.hadError()) {
 						slf4jLogger.error("Retrieval for uid=[" + identity.getUid()
 								+ "] finished with swallowed PubMed failures; treating the run as failed.");

--- a/src/test/java/reciter/controller/ReCiterControllerTest.java
+++ b/src/test/java/reciter/controller/ReCiterControllerTest.java
@@ -638,6 +638,59 @@ public class ReCiterControllerTest {
 	}
 
 	@Test
+	public void testRetrieveArticlesByUidRefreshAllPublicationsFailedSweepRestoresPrior() throws IOException {
+		// #737 case (g): a failed full sweep with a prior ESearchResult on record must
+		// restore it, so partial per-strategy entries the engine already wrote don't
+		// shrink the next run's Analysis candidate set.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(testESearchResult);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				any(RetrievalRefreshFlag.class))).thenReturn(false);
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		verify(eSearchResultService, times(1)).delete(testUid.trim());
+		verify(eSearchResultService, times(1)).save(testESearchResult);
+	}
+
+	@Test
+	public void testRetrieveArticlesByUidRefreshAllPublicationsFailedSweepNoPriorDeletes() throws IOException {
+		// #737 case (h): with no prior ESearchResult (first-ever retrieval), a failed
+		// sweep deletes the partial one instead of restoring, so the next run
+		// auto-upgrades to a full sweep rather than looking like a covered uid.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(null);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				any(RetrievalRefreshFlag.class))).thenReturn(false);
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		verify(eSearchResultService, times(1)).delete(testUid.trim());
+		verify(eSearchResultService, never()).save(any(ESearchResult.class));
+	}
+
+	@Test
+	public void testRetrieveArticlesByUidRefreshAllPublicationsSuccessNeverRestores() throws IOException {
+		// #737 case (i): a successful full sweep never touches restore — only the
+		// initial pre-sweep delete happens.
+		when(identityService.findByUid(testUid)).thenReturn(identity);
+		when(eSearchResultService.findByUid(testUid.trim())).thenReturn(testESearchResult);
+		when(aliasReCiterRetrievalEngine.retrieveArticlesByDateRange(anyList(), any(Date.class), any(Date.class),
+				any(RetrievalRefreshFlag.class))).thenReturn(true);
+
+		ResponseEntity<?> response = reCiterController.retrieveArticlesByUid(testUid,
+				RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		verify(eSearchResultService, times(1)).delete(testUid.trim());
+		verify(eSearchResultService, never()).save(any(ESearchResult.class));
+	}
+
+	@Test
 	public void testRetrieveArticlesByUidOnlyNewPublications() throws IOException {
 		// Arrange
 		when(identityService.findByUid(testUid)).thenReturn(identity);

--- a/src/test/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngineTest.java
+++ b/src/test/java/reciter/xml/retriever/engine/AbstractReCiterRetrievalEngineTest.java
@@ -7,9 +7,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -17,23 +20,25 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import reciter.api.parameters.RetrievalRefreshFlag;
 import reciter.database.dynamodb.model.ESearchPmid;
 import reciter.database.dynamodb.model.ESearchResult;
+import reciter.database.dynamodb.model.QueryType;
 import reciter.model.identity.Identity;
 import reciter.model.pubmed.MedlineCitation;
 import reciter.model.pubmed.MedlineCitationPMID;
 import reciter.model.pubmed.PubMedArticle;
 import reciter.service.ESearchResultService;
+import reciter.service.PubMedService;
 import reciter.xml.retriever.pubmed.RetrievalErrorTracker;
 
 /**
  * Covers the known-pmid persistence skip (#695): with a floored lookback window the
  * same span is re-retrieved nightly, so incremental runs must not re-write articles
- * the uid's ESearchResult already records. Also covers the two #696 engine rules:
- * the lookupType downgrade guard on strategy-entry upserts and the clean-completion
- * gate on the lastFullSweep stamp.
+ * the uid's ESearchResult already records. Also covers the #696 lookupType downgrade
+ * guard and clean-completion gate, and the #737 no-shrink-on-failure union rule.
  */
 public class AbstractReCiterRetrievalEngineTest {
 
@@ -104,7 +109,7 @@ public class AbstractReCiterRetrievalEngineTest {
 		assertEquals(Collections.singletonList(7L), pmidsOf(toPersist));
 	}
 
-	// ---- lookupType downgrade guard (#696 / E13) ----
+	// ---- lookupType downgrade guard (#696 / E13) and #737 no-shrink-on-failure union ----
 
 	private static final Instant SWEEP_DATE = Instant.parse("2026-05-15T00:00:00Z");
 	private static final Instant TONIGHT = Instant.parse("2026-08-03T00:00:00Z");
@@ -115,13 +120,16 @@ public class AbstractReCiterRetrievalEngineTest {
 		// ALL_PUBLICATIONS, and the escalation fallback infers last-full-sweep from
 		// the same entries. The stored entry must therefore keep the marker AND the
 		// sweep's retrievalDate (a bumped date would fake a fresh sweep and suppress
-		// a due escalation), while merging in the incremental run's new pmids.
+		// a due escalation), while merging in the incremental run's new pmids. This
+		// rule applies on a clean run (runHadFailures=false, asserted here) and is
+		// independently re-asserted for both boolean values in
+		// downgradeGuardIgnoresRunHadFailuresInEitherDirection (#737 case e).
 		ESearchPmid existing = new ESearchPmid(Arrays.asList(1L, 2L, 3L), "EmailRetrievalStrategy",
 				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
 		ESearchPmid incoming = new ESearchPmid(Arrays.asList(3L, 4L), "EmailRetrievalStrategy",
 				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
 
-		ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming);
+		ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, false);
 
 		assertEquals(ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS, stored.getLookupType());
 		assertEquals(SWEEP_DATE, stored.getRetrievalDate());
@@ -135,7 +143,7 @@ public class AbstractReCiterRetrievalEngineTest {
 		ESearchPmid incoming = new ESearchPmid(Arrays.asList(2L, 5L), "EmailRetrievalStrategy",
 				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
 
-		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming));
+		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, false));
 	}
 
 	@Test
@@ -145,14 +153,16 @@ public class AbstractReCiterRetrievalEngineTest {
 		ESearchPmid incoming = new ESearchPmid(Arrays.asList(2L), "EmailRetrievalStrategy",
 				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
 
-		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming));
+		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, false));
 	}
 
 	@Test
 	public void firstEntryForAStrategyIsStoredAsIs() {
+		// Also #737 case (c): a null existing entry always returns incoming, even
+		// when the run had failures.
 		ESearchPmid incoming = new ESearchPmid(Arrays.asList(2L), "EmailRetrievalStrategy",
 				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
-		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(null, incoming));
+		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(null, incoming, true));
 	}
 
 	@Test
@@ -162,9 +172,129 @@ public class AbstractReCiterRetrievalEngineTest {
 		ESearchPmid incoming = new ESearchPmid(Arrays.asList(4L), "EmailRetrievalStrategy",
 				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
 
-		ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming);
+		ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, false);
 		assertEquals(ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS, stored.getLookupType());
 		assertEquals(Arrays.asList(4L), stored.getPmids());
+	}
+
+	@Test
+	public void failedRunUnionsPmidsWhenNeitherSideIsAllPublications() {
+		// #737 case (a): a partial GoldStandardRetrievalStrategy batch during a run that
+		// hit PubMed failures must not shrink the ONLY_NEWLY_ADDED entry — union in the
+		// prior pmids the run did not return, keep incoming's lookupType and date.
+		ESearchPmid existing = new ESearchPmid(Arrays.asList(1L, 2L, 3L, 4L, 5L), "GoldStandardRetrievalStrategy",
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(1L, 2L, 3L), "GoldStandardRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, true);
+
+		assertEquals(Arrays.asList(1L, 2L, 3L, 4L, 5L), stored.getPmids());
+		assertEquals(ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS, stored.getLookupType());
+		assertEquals(TONIGHT, stored.getRetrievalDate());
+	}
+
+	@Test
+	public void cleanRunReplacesTheEntryWholesaleEvenWithFewerIncomingPmids() {
+		// #737 case (b): same inputs as the case-(a) test above, but a clean run keeps
+		// the pre-#737 wholesale-replace behavior — incoming returned as is.
+		ESearchPmid existing = new ESearchPmid(Arrays.asList(1L, 2L, 3L, 4L, 5L), "GoldStandardRetrievalStrategy",
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(1L, 2L, 3L), "GoldStandardRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		assertSame(incoming, AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, false));
+	}
+
+	@Test
+	public void failedRunUnionsBothAllPublicationsEntries() {
+		// #737 case (d): both sides already carry the ALL_PUBLICATIONS marker, so this
+		// is not the downgrade-guard path (that requires incoming to NOT be ALL) — it is
+		// the failed-run union, which keeps the ALL marker and takes incoming's date.
+		ESearchPmid existing = new ESearchPmid(Arrays.asList(1L, 2L, 3L, 4L, 5L), "EmailRetrievalStrategy",
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(1L, 2L), "EmailRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+
+		ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, true);
+
+		assertEquals(Arrays.asList(1L, 2L, 3L, 4L, 5L), stored.getPmids());
+		assertEquals(ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS, stored.getLookupType());
+		assertEquals(TONIGHT, stored.getRetrievalDate());
+	}
+
+	@Test
+	public void downgradeGuardIgnoresRunHadFailuresInEitherDirection() {
+		// #737 case (e), regression of #696/E13: the ALL_PUBLICATIONS downgrade guard
+		// (rule b) takes precedence over the failed-run union (rule c) regardless of
+		// runHadFailures — both true and false keep the ALL marker and the EXISTING
+		// entry's retrievalDate, merging in the new pmid either way.
+		ESearchPmid existing = new ESearchPmid(Arrays.asList(1L, 2L, 3L, 4L, 5L), "EmailRetrievalStrategy",
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS);
+		ESearchPmid incoming = new ESearchPmid(Arrays.asList(6L), "EmailRetrievalStrategy",
+				TONIGHT, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		for (boolean runHadFailures : Arrays.asList(true, false)) {
+			ESearchPmid stored = AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, runHadFailures);
+			assertEquals(ESearchPmid.RetrievalRefreshFlag.ALL_PUBLICATIONS, stored.getLookupType());
+			assertEquals(SWEEP_DATE, stored.getRetrievalDate());
+			assertEquals(Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L), stored.getPmids());
+		}
+	}
+
+	// ---- #737 end-to-end: savePubMedArticles reads RetrievalErrorTracker.hadError() ----
+
+	private static ESearchPmid gsEntryOf(ESearchResult result, String strategyName) {
+		return result.getESearchPmids().stream()
+				.filter(e -> e != null && strategyName.equalsIgnoreCase(e.getRetrievalStrategyName()))
+				.findFirst().orElse(null);
+	}
+
+	@Test
+	public void savePubMedArticlesKeepsPriorPmidsOnlyWhenTheRunHadFailures() {
+		// #737 case (f): the rharrington shape — a GoldStandardRetrievalStrategy entry
+		// with 5 prior pmids, a run that only came back with 3 of them. When the run hit
+		// PubMed failures the stored entry must keep all 5; on a clean re-run with the
+		// same partial batch, it replaces wholesale down to 3 as before.
+		ESearchResultService eSearchResultService = mock(ESearchResultService.class);
+		PubMedService pubMedService = mock(PubMedService.class);
+		String uid = "rharrington";
+		String strategyName = "GoldStandardRetrievalStrategy";
+
+		ESearchPmid gsEntry = new ESearchPmid(new ArrayList<>(Arrays.asList(1L, 2L, 3L, 4L, 5L)), strategyName,
+				SWEEP_DATE, ESearchPmid.RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+		ESearchResult existingResult = new ESearchResult(uid, SWEEP_DATE,
+				new ArrayList<>(Arrays.asList(gsEntry)), QueryType.LENIENT_LOOKUP);
+		when(eSearchResultService.findByUid(uid)).thenReturn(existingResult);
+
+		AbstractReCiterRetrievalEngine engine = engineWith(eSearchResultService);
+		engine.pubMedService = pubMedService;
+
+		List<PubMedArticle> retrieved = Arrays.asList(article(1L), article(2L), article(3L));
+
+		RetrievalErrorTracker.reset();
+		RetrievalErrorTracker.markError();
+		engine.savePubMedArticles(retrieved, uid, strategyName, Collections.emptyList(),
+				QueryType.LENIENT_LOOKUP, RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		// Capture and snapshot immediately: savePubMedArticles mutates the
+		// ESearchResult's pmid list in place, and the mock's findByUid keeps
+		// returning that same mutable object, so a captured reference read after
+		// the second call below would reflect the second call's state instead of
+		// the first's.
+		ArgumentCaptor<ESearchResult> firstSave = ArgumentCaptor.forClass(ESearchResult.class);
+		verify(eSearchResultService, times(1)).save(firstSave.capture());
+		List<Long> afterFailedRunPmids = new ArrayList<>(gsEntryOf(firstSave.getValue(), strategyName).getPmids());
+		assertEquals(5, afterFailedRunPmids.size());
+
+		RetrievalErrorTracker.reset();
+		engine.savePubMedArticles(retrieved, uid, strategyName, Collections.emptyList(),
+				QueryType.LENIENT_LOOKUP, RetrievalRefreshFlag.ONLY_NEWLY_ADDED_PUBLICATIONS);
+
+		ArgumentCaptor<ESearchResult> secondSave = ArgumentCaptor.forClass(ESearchResult.class);
+		verify(eSearchResultService, times(2)).save(secondSave.capture());
+		ESearchPmid afterCleanRun = gsEntryOf(secondSave.getValue(), strategyName);
+		assertEquals(3, afterCleanRun.getPmids().size());
 	}
 
 	// ---- Clean-completion gate on the lastFullSweep stamp (#696) ----


### PR DESCRIPTION
Ports PR #738 from `development` to the live prod line. Straight cherry-pick of `f162e6a5` — it applied with **no conflicts**, and the resulting diff is identical to the source commit (5 files, +305/-34).

## Why prod needs it

The failure #737 describes happened *in prod*, on 2026-09-01: `reciter-pubmed-prod` returned failures for 3 of 8 `GoldStandardRetrievalStrategy` batches for one person (NCBI connection resets). The engine logged the #689 watermark rollback but still stored the partial GoldStandard entry (394 of 794 pmids) in `ESearchResult`, and the controller then rebuilt the Analysis with 374 accepted articles instead of 763. Because the Analysis candidate set is exactly the union of the `ESearchResult` strategy entries, a shrunken entry shrinks the Analysis — and cache-only re-analysis cannot heal it. The #720 gate does not cover this: on a full sweep the controller deletes the record before retrieval, so a 500 with no Analysis write still leaves the partial entries behind for the next run.

The guard is currently on `development` only, which deploys to `reciter-dev`. Prod (image `647…ac7caf88`) is unprotected.

## Change (unchanged from #738)

- `AbstractReCiterRetrievalEngine.upsertedStrategyEntry(existing, incoming, runHadFailures)` — when the run hit PubMed failures (`RetrievalErrorTracker.hadError()`, read in `savePubMedArticles` on the same thread the strategies ran on), never replace an existing strategy entry with a smaller one.
- `ReCiterController` — restore the prior record when a full sweep fails.
- `AliasReCiterRetrievalEngine` — pass the failure flag through.

## Checks run

- `mvn -B test` on this branch, JDK 17: **Tests run: 379, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS**. Includes #738's own regression tests (`AbstractReCiterRetrievalEngineTest` +150, `ReCiterControllerTest` +53).
- Diff verified identical to `f162e6a5` by `git diff --stat` comparison.
- NOT run: any deployed-environment or live-retrieval check. This has not been exercised against a real PubMed failure in prod.

Merging is a freeze decision.