### PR TITLE
Guard informed absence against registered but uncurated bylines (off by default)

### DIFF
--- a/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/targetauthorname/strategy/TargetAuthorNameFeedbackStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/feedback/targetauthorname/strategy/TargetAuthorNameFeedbackStrategy.java
@@ -13,10 +13,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import reciter.algorithm.evidence.feedback.targetauthor.AbstractTargetAuthorFeedbackStrategy;
+import reciter.engine.analysis.evidence.AuthorNameEvidence;
 import reciter.model.article.ReCiterArticle;
 import reciter.model.article.ReCiterArticleAuthors;
 import reciter.model.article.ReCiterArticleFeedbackScore;
 import reciter.model.article.ReCiterAuthor;
+import reciter.model.identity.AuthorName;
 import reciter.model.identity.Identity;
 
 public class TargetAuthorNameFeedbackStrategy extends AbstractTargetAuthorFeedbackStrategy {
@@ -27,6 +29,71 @@ public class TargetAuthorNameFeedbackStrategy extends AbstractTargetAuthorFeedba
 
 	private static final Pattern PATTERN1 = Pattern.compile("^[A-Z] [A-Z]$");
 	private static final Pattern PATTERN2 = Pattern.compile("^[A-Z] [A-Z][a-z]");
+
+	private static final String FULL_EXACT = "full-exact";
+
+	/**
+	 * Off by default. When enabled, a byline that full-exact matches a registered
+	 * Identity name with no curation history is treated as absence of evidence
+	 * (score 0.0) rather than evidence of absence (informed absence penalty).
+	 */
+	private boolean skipUncuratedRegisteredName = false;
+
+	public void setSkipUncuratedRegisteredName(boolean skipUncuratedRegisteredName) {
+		this.skipUncuratedRegisteredName = skipUncuratedRegisteredName;
+	}
+
+	/**
+	 * True when the byline being scored is a name the institution has already
+	 * REGISTERED for this person - primaryName or one of alternateNames - and
+	 * which simply has not been curated yet.
+	 *
+	 * <p>This reuses the name match ReCiter has already computed upstream in
+	 * ScoreByNameStrategy, which stores its verdict on the article as
+	 * AuthorNameEvidence.nameMatchFirstType; it is not re-derived here. The
+	 * registered-name list is then checked to confirm the byline is a name the
+	 * institution knows about rather than an incidental exact match.
+	 *
+	 * <p>A newly registered publishing name has zero accepted and zero rejected
+	 * articles for the same reason a brand new account has no history: nobody has
+	 * curated it yet. That is not the same signal as a genuinely unfamiliar
+	 * journal or coauthor set, which is why this guard is deliberately scoped to
+	 * the target author name only.
+	 */
+	private boolean isUncuratedRegisteredName(ReCiterArticle article, Identity identity, ReCiterAuthor author) {
+		if (article == null || identity == null || author == null || author.getAuthorName() == null) {
+			return false;
+		}
+		AuthorNameEvidence nameEvidence = article.getAuthorNameEvidence();
+		if (nameEvidence == null || !FULL_EXACT.equalsIgnoreCase(nameEvidence.getNameMatchFirstType())) {
+			return false;
+		}
+		String bylineFirstName = author.getAuthorName().getFirstName();
+		String bylineLastName = author.getAuthorName().getLastName();
+		if (bylineFirstName == null || bylineFirstName.trim().isEmpty()
+				|| bylineLastName == null || bylineLastName.trim().isEmpty()) {
+			return false;
+		}
+		if (isSameRegisteredName(identity.getPrimaryName(), bylineFirstName, bylineLastName)) {
+			return true;
+		}
+		if (identity.getAlternateNames() != null) {
+			for (AuthorName alternateName : identity.getAlternateNames()) {
+				if (isSameRegisteredName(alternateName, bylineFirstName, bylineLastName)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static boolean isSameRegisteredName(AuthorName registeredName, String bylineFirstName, String bylineLastName) {
+		if (registeredName == null || registeredName.getFirstName() == null || registeredName.getLastName() == null) {
+			return false;
+		}
+		return registeredName.getFirstName().trim().equalsIgnoreCase(bylineFirstName.trim())
+				&& registeredName.getLastName().trim().equalsIgnoreCase(bylineLastName.trim());
+	}
 
 	@Override
 	public double executeFeedbackStrategy(ReCiterArticle reCiterArticle, Identity identity) {
@@ -133,10 +200,21 @@ public class TargetAuthorNameFeedbackStrategy extends AbstractTargetAuthorFeedba
 								// accepted or rejected article, but the researcher has substantial
 								// acceptance history, apply a negative penalty instead of 0.0
 								if (countAccepted == 0 && countRejected == 0 && totalAccepted > 0) {
-									double penalty = computeInformedAbsencePenalty(totalAccepted);
-									scoreAll = penalty;
-									scoreWithout1Accepted = penalty;
-									scoreWithout1Rejected = penalty;
+									if (skipUncuratedRegisteredName
+											&& isUncuratedRegisteredName(article, identity, author)) {
+										// A registered publishing name that nobody has curated yet is
+										// absence of evidence, not evidence of absence. Leave the
+										// scores as computed (0.0) rather than penalising the person
+										// for the institution having just added the name.
+										slf4jLogger.debug(
+											"Informed absence skipped for registered but uncurated byline '{}' on article {}",
+											authorName, article.getArticleId());
+									} else {
+										double penalty = computeInformedAbsencePenalty(totalAccepted);
+										scoreAll = penalty;
+										scoreWithout1Accepted = penalty;
+										scoreWithout1Rejected = penalty;
+									}
 								}
 
 								double feedbackScore= determineFeedbackScore(article.getGoldStandard(),scoreWithout1Accepted, scoreWithout1Rejected, scoreAll);

--- a/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
+++ b/src/main/java/reciter/algorithm/feedback/article/scorer/ReciterFeedbackArticleScorer.java
@@ -145,6 +145,8 @@ public class ReciterFeedbackArticleScorer extends AbstractFeedbackArticleScorer 
 			strategyParameters.isInformedAbsenceEnabled(),
 			strategyParameters.getInformedAbsenceScale(),
 			strategyParameters.getInformedAbsenceTargetAuthorNameStrength());
+		targetAuthorNameStrategy.setSkipUncuratedRegisteredName(
+			strategyParameters.isInformedAbsenceSkipUncuratedRegisteredName());
 
 		// Configure informed absence for co-author name strategy
 		CoauthorNameFeedbackStrategy coAuthorNameStrategy = new CoauthorNameFeedbackStrategy();

--- a/src/main/java/reciter/engine/StrategyParameters.java
+++ b/src/main/java/reciter/engine/StrategyParameters.java
@@ -432,6 +432,17 @@ public class StrategyParameters {
 
     @Value("${strategy.feedback.informedAbsence.orcid.strength:0.3}")
     private double informedAbsenceOrcidStrength;
+
+    /**
+     * When true, TargetAuthorNameFeedbackStrategy will NOT apply the informed
+     * absence penalty to a byline that full-exact matches a registered
+     * Identity name (primaryName or an alternateName) which simply has no
+     * curation history yet. Default false: behaviour is unchanged until this
+     * is deliberately turned on, because turning it on shifts a feature
+     * distribution the deployed models were trained against.
+     */
+    @Value("${strategy.feedback.informedAbsence.targetAuthorName.skipUncuratedRegisteredName:false}")
+    private boolean informedAbsenceSkipUncuratedRegisteredName;
     
     @Value("${dynamodb.migrations.Analysis.schema.version}")
     private String analysisSchemaVersion;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -338,6 +338,13 @@ strategy.feedback.informedAbsence.organization.strength=0.5
 strategy.feedback.informedAbsence.email.strength=0.3
 strategy.feedback.informedAbsence.orcid.strength=0.3
 
+# Guard (default OFF): when true, targetAuthorName informed absence is NOT applied
+# to a byline that full-exact matches a registered Identity name (primaryName or an
+# alternateName) with no curation history yet -- e.g. a newly added publishing name.
+# Leave false unless the scoring models have been retrained: turning this on shifts
+# the feedbackScoreTargetAuthorName distribution the deployed models were fit on.
+strategy.feedback.informedAbsence.targetAuthorName.skipUncuratedRegisteredName=false
+
 
 #### Feedback scoring: S3 bucket ####
 


### PR DESCRIPTION
**Draft.** The guard is off by default and, on the measurement below, **does not on its own recover the articles it was designed to recover**. Opening it so the mechanism and the numbers are reviewable together, not because it is ready to turn on.

## The defect

`TargetAuthorNameFeedbackStrategy` keys its accept/reject map on the literal byline string produced by `formatAuthorName(firstName, lastName)`. When the institution registers a **new publishing name** for a person, that key is new, so `countAccepted = 0` and `countRejected = 0` while `totalAccepted` is large. The branch at `TargetAuthorNameFeedbackStrategy.java:135-140` then reads that as evidence of absence and applies the penalty from `AbstractTargetAuthorFeedbackStrategy.java:54-62`:

```
informedAbsenceStrength * -(1 / (1 + exp(-totalAccepted / informedAbsenceScale)) - 0.5)
```

Worked case, cwid `mis4060` (Mila Sun), PMID `42670968` (NEJM, Entrez 2026-08-31). Her Identity carries two registered names, `Shuo Sun` and `Mila Sun`. All 20 of her accepted articles are bylined `Shuo`. This paper is the only one of her 152 candidates bylined `Mila`. With `totalAccepted = 20` and the configured strengths, five features fire the penalty at once, and the live S3 feature vector reproduces the closed form to 16 significant digits:

| feature | strength | live S3 value | closed form |
|---|---|---|---|
| `feedbackScoreTargetAuthorName` | 1.0 | `-0.3807970779778823` | `-0.3807970779778823` |
| `feedbackScoreCoAuthorName` | 0.9 | `-0.34271737018009407` | `-0.3427173701800941` |
| `feedbackScoreJournal` | 0.7 | `-0.2665579545845176` | `-0.2665579545845176` |
| `feedbackScoreJournalSubField` | 0.7 | `-0.2665579545845176` | `-0.2665579545845176` |
| `feedbackScoreBibliographicCoupling` | 0.5 | `-0.19039853898894116` | `-0.1903985389889412` |

This is the penalty at full strength on five features simultaneously, not a learned signal. `nameMatchFirstType` on that row is `full-exact` — ReCiter's own name matcher agrees the byline is her.

## Blast radius (measured)

Prod `Identity` DynamoDB scan (35,067 rows, name attributes only) plus prod `reciterdb.person_article` bylines plus 224 live S3 feature vectors scored against the deployed model bytes.

**Identities with more than one registered first name** (26,578 WCM rows, excluding the `ucsf_`/`ucla_`/`fredhutch_`/etc. validation cohorts, none of which have alternates):

| distinct registered first names | identities | share |
|---|---|---|
| 1 | 25,476 | 95.85% |
| 2 | 1,018 | 3.83% |
| 3 | 76 | 0.29% |
| 4 | 7 | 0.03% |
| 5 | 1 | 0.00% |
| **2 or more** | **1,102** | **4.15%** |

**Of those 1,102, exposure to this specific failure** — accepted corpus concentrated on one byline first name, plus at least one registered name with zero curation history:

| | identities |
|---|---|
| no accepted corpus at all (penalty cannot fire, `totalAccepted = 0`) | 432 |
| accepted corpus **100%** on one byline name + a registered name with no history | **261** |
| 95–99% concentrated + a registered name with no history | 10 |
| genuinely spread, or no uncurated registered name | 399 |

**Realized, in the 224 live S3 feature vectors that exist for that exposed set:**

- **912** article rows where the byline is a registered-but-uncurated name **and** the penalty actually fired, across **46** cwids
- of those, **909** are `PENDING` with `nameMatchFirstType = full-exact`, across **45** cwids
- of those, **99** sit below the storage threshold with identity-only ≥ 50 — the exact `mis4060` shape — across **27** cwids

Those 99 are invisible today: `reciter.minimumStorageThreshold=30` drops them at `ReCiterFeatureGenerator.java:96`, so they never reach Analysis, `person_article`, or Publication Manager. 39 of the 99 have identity-only ≥ 90. Affected cwids include `aba2004`, `ket4008`, `yul2019`, `sjw9010`, `jap2040`, `gis2011`, `mha2008`, `dje4001`.

## What this guard actually buys — the part that matters

Counterfactual, re-scoring those 99 rows with the deployed 72/47 models and the penalty neutralised at inference time:

| arm | rows reaching fb ≥ 30 | mean fb delta |
|---|---|---|
| **A — guard `targetAuthorName` only (this PR's scope)** | **4 / 99 (4.0%)** | +2.41 |
| B — neutralise all five firing features (not proposed) | 55 / 99 (55.6%) | +41.30 |

For `mis4060` / `42670968` specifically: **4.24 → 5.97** under arm A, and **13.16** even under arm B. Both still far below 30. The article is not recovered either way.

Two reasons, both measured:

1. `targetAuthorName` carries **26.3%** of the penalty mass (strength 1.0 of 3.8 summed across the five firing features), not the "one fifth" that was the working assumption. Still only about a quarter.
2. The isotonic calibrator emits a short discrete ladder in the low range — the 99 hits occupy only the levels `0.0, 0.037, 0.14, 0.997, 1.053, 2.83, 4.237, 5.97, 9.524, 13.158, 23.913, 29.07`. Removing ~0.38 from one feature moves an article one rung, not across a 30-point gap.

So this guard is correct in principle and insufficient in practice. It removes a penalty that is demonstrably an artifact, but the residual low score comes from the model having been fit with this penalty in-distribution. **Recovering these 99 rows needs a retrain, or a different lever entirely** — a floor on `full-exact` primary-name matches, or routing through the identity-only safety net.

## Why off by default, and what turning it on costs

Turning the flag on shifts the `feedbackScoreTargetAuthorName` distribution that the deployed 72/47 models were trained against. It therefore requires a **retrain plus an eval sweep**, not a config change. With the flag `false` the scoring path is byte-identical to today.

The arm A / arm B numbers above are inference-time feature neutralisation, which is *not* the same as retraining — treat them as direction and rough magnitude, not as predicted post-retrain scores.

## Scope

`TargetAuthorNameFeedbackStrategy` only. The other nine strategies calling `computeInformedAbsencePenalty` are untouched deliberately: a genuinely unfamiliar journal or coauthor set really is new evidence about the article. A newly registered name is only new information about the registry.

The guard reuses the match ReCiter already computed — `AuthorNameEvidence.nameMatchFirstType == "full-exact"`, set upstream in `ScoreByNameStrategy` and already read at feedback time in `ReciterFeedbackArticleScorer.java:617` — and corroborates it against `Identity.primaryName` / `Identity.alternateNames`. Nothing is re-derived.

**Explicitly not proposed:** dropping or down-weighting the `Shuo` alternateName. It carries all 20 of her accepted articles; removing it would sever her entire curated corpus.

## Also noticed, not fixed here

`formatAuthorName` (lines 38-44) tests `PATTERN1` / `PATTERN2` and both branches `return firstName + " " + lastName`. The regex test is dead code. Left alone to keep this diff to the behavioural change.

## Verification performed

- `mvn -o -DskipTests compile` on Java 17 — exit 0. `javap` confirms `setSkipUncuratedRegisteredName`, `isSameRegisteredName`, and the Lombok-generated `isInformedAbsenceSkipUncuratedRegisteredName()` are in the compiled classes.
- Local scoring harness validated against production before use: it reproduces the prod Lambda's `4.237288475036621` / `0.9057` for `42670968` exactly, using model bytes verified md5-identical to `origin/master:app/models/*` of ReCiter---Scoring (the deployed Lambda image `master-68.2026-03-18.20.54.55.ff52638e`), with the `name_frequency.json` load asserted rather than assumed.

**Not verified:** no unit tests were added or run; the full test suite was not run; nothing was deployed or exercised on a cluster; the flag has never been enabled in any environment.

## Port still owed

Based on `MigrationFromJDk11ToAWSCorretto17`, the branch the `ReCiter_V2` pipeline actually deploys. `origin/development` is behind prod and still needs this ported.



## Correction after review — read this before promoting out of draft

**The guard's evidence check is article-level, not per-byline.** `isUncuratedRegisteredName` reads
`article.getAuthorNameEvidence()`, which `ScoreByNameStrategy:154` sets as ONE article-level object chosen by
`calculateHighestScore` across all authors. The guard runs inside
`listOfAuthors.stream().filter(author -> author.isTargetAuthor()).forEach(...)`, and
`TargetAuthorSelection:242/288` can mark more than one author as target. So the full-exact test asks an
article-level question inside a per-target-author loop. Any earlier wording in this PR describing the check as
applying "for the byline being scored" is stronger than what the code does. The registered-name equality check
is per-author and strict, so a false fire is narrow — but this must be fixed, or the text narrowed to what the
code checks, before the flag is turned on anywhere.

**This flag is not the lever.** By this PR's own arm-A counterfactual it lifts 4 of 99 affected rows above the
storage threshold, and it does not fix the case it was written for: PMID 42670968 goes 4.24 → 5.97 against a
threshold of 30. Even neutralising all five penalised features (arm B, not proposed here) reaches only 13.16 on
that row, though it does clear 55/99 overall. Recovery needs a retrain, or the prefix-match fix in #746, not
this flag alone.

Leaving this as a documented draft is a defensible outcome. It is here so the mechanism and the measurement are
on the record, not because it is ready to ship.
