### PR TITLE
Stop labelling a first-name prefix match as full-exact (#746)

### DIFF
--- a/src/main/java/reciter/algorithm/evidence/targetauthor/name/strategy/ScoreByNameStrategy.java
+++ b/src/main/java/reciter/algorithm/evidence/targetauthor/name/strategy/ScoreByNameStrategy.java
@@ -270,7 +270,45 @@ public class ScoreByNameStrategy extends AbstractTargetAuthorStrategy {
 		}
 	}
 	
-	/** This function matches and scores first name and middle name where middle name is null in identity 
+	/**
+	 * Label a first-name match in which the registered (identity) first name is a
+	 * left-anchored prefix of the article first name, rather than equal to it.
+	 *
+	 * <p>Before issue #746 both callers of this helper reported {@code full-exact}, so a
+	 * byline of "Shuofei" was indistinguishable from a genuine exact match against a
+	 * registered "Shuo". The compensating {@code identitySubstringOfArticle-firstName}
+	 * modifier lives in a different feature, so nothing downstream could tell the two
+	 * apart. Two honest buckets replace it:</p>
+	 * <ul>
+	 *   <li>{@code inferredInitials-prefix} when the registered first name sanitized down
+	 *       to a single letter ('M.' &rarr; M matching "Mayra"). That is an initial match;
+	 *       {@code inferredInitials-exact} (0.441) is the semantically correct score, but
+	 *       moving it there is a numeric change and is deliberately deferred.</li>
+	 *   <li>{@code full-prefix} otherwise (Paul &rarr; PaulJames, Shuo &rarr; Shuofei).</li>
+	 * </ul>
+	 *
+	 * <p>Both scores default to the previous {@code full-exact} value (1.852) so this
+	 * relabel moves no model input. Retuning either is a one-line properties change that
+	 * requires a retrain plus an evaluation sweep, because the type string is itself
+	 * consumed as a numeric feature ({@code nameMatchTypeOrdinal}) by the scoring Lambda.</p>
+	 *
+	 * <p>This helper only assigns the first-name type and score. Callers keep full control
+	 * of the middle-name type/score and the modifier, which are unchanged.</p>
+	 *
+	 * @param identityAuthor the sanitized identity name whose first name matched
+	 * @param authorNameEvidence evidence object to populate
+	 */
+	private void assignFirstNamePrefixEvidence(AuthorName identityAuthor, AuthorNameEvidence authorNameEvidence) {
+		if(identityAuthor.getFirstName() != null && identityAuthor.getFirstName().length() == 1) {
+			authorNameEvidence.setNameMatchFirstType("inferredInitials-prefix");
+			authorNameEvidence.setNameMatchFirstScore(ReCiterArticleScorer.strategyParameters.getNameMatchFirstTypeInferredInitialsPrefixScore());
+		} else {
+			authorNameEvidence.setNameMatchFirstType("full-prefix");
+			authorNameEvidence.setNameMatchFirstScore(ReCiterArticleScorer.strategyParameters.getNameMatchFirstTypeFullPrefixScore());
+		}
+	}
+
+	/** This function matches and scores first name and middle name where middle name is null in identity
 	 * All of the matching that follows should be evaluated as a series of ifElse statements (once we get a match, we stop). The goal is to match as early on in the process as possible.
 	 * 	Matching should be case insensitive, however, we will pull out some characters below based on case.
 	*/
@@ -327,15 +365,20 @@ public class ScoreByNameStrategy extends AbstractTargetAuthorStrategy {
 					articleAuthorName.getFirstName().toLowerCase().startsWith(identityAuthor.getFirstName().toLowerCase())) { 
 				//Attempt match where identity.firstName is a left-anchored substring of article.firstName
 				//Example: Paul (identity.firstName) = PaulJames (article.firstName)
-				authorNameEvidence.setNameMatchFirstType("full-exact");
-				authorNameEvidence.setNameMatchFirstScore(ReCiterArticleScorer.strategyParameters.getNameMatchFirstTypeFullExactScore());
+				//This is NOT an exact match. The same predicate also fires for
+				//Shuo (identity.firstName) = Shuofei (article.firstName), a different given
+				//name, and for a registered name that sanitized down to a single initial:
+				//'M.' -> M (identity.firstName) = Mayra (article.firstName). See issue #746.
+				//The predicate is untouched; only the reported type is split, so exactly the
+				//same articles reach exactly the same score.
+				assignFirstNamePrefixEvidence(identityAuthor, authorNameEvidence);
 				authorNameEvidence.setNameMatchMiddleType("identityNull-MatchNotAttempted");
 				authorNameEvidence.setNameMatchMiddleScore(ReCiterArticleScorer.strategyParameters.getNameMatchMiddleTypeIdentityNullMatchNotAttemptedScore());
 				authorNameEvidence.setNameMatchModifier("identitySubstringOfArticle-firstName");
 				authorNameEvidence.setNameMatchModifierScore(ReCiterArticleScorer.strategyParameters.getNameMatchModifierIdentitySubstringOfArticleFirstnameScore());
-			} else if(identityAuthor.getFirstName() != null 
-					&& 
-					identityAuthor.getFirstName().toLowerCase().startsWith(articleAuthorName.getFirstName().toLowerCase())) { 
+			} else if(identityAuthor.getFirstName() != null
+					&&
+					identityAuthor.getFirstName().toLowerCase().startsWith(articleAuthorName.getFirstName().toLowerCase())) {
 				//Attempt match where article.firstName is a left-anchored substring of identity.firstName
 				//Example: Paul (identity.firstName) = P (article.firstName)
 				authorNameEvidence.setNameMatchFirstType("inferredInitials-exact");
@@ -624,26 +667,31 @@ public class ScoreByNameStrategy extends AbstractTargetAuthorStrategy {
 					articleAuthorName.getFirstName().toLowerCase().matches(identityAuthor.getFirstName().toLowerCase() + "(.*)")) {
 				//Attempt match where identity.firstName + "%" = article.firstName
 				//Example: Robert (identity.firstName) = RobertR (article.firstName)
-				authorNameEvidence.setNameMatchFirstType("full-exact");
-				authorNameEvidence.setNameMatchFirstScore(ReCiterArticleScorer.strategyParameters.getNameMatchFirstTypeFullExactScore());
+				//Same over-claim as the substring branch in scoreFirstNameMiddleNameNull:
+				//this is a prefix, not an exact match. See issue #746.
+				assignFirstNamePrefixEvidence(identityAuthor, authorNameEvidence);
 				authorNameEvidence.setNameMatchMiddleType("noMatch");
 				authorNameEvidence.setNameMatchMiddleScore(ReCiterArticleScorer.strategyParameters.getNameMatchMiddleTypeNoMatchScore());
 				authorNameEvidence.setNameMatchModifier("identitySubstringOfArticle-firstName");
 				authorNameEvidence.setNameMatchModifierScore(ReCiterArticleScorer.strategyParameters.getNameMatchModifierIdentitySubstringOfArticleFirstnameScore());
-			} else if(identityAuthor.getFirstName() != null 
-					&& 
-					articleAuthorName.getFirstName() != null  
-					&& 
+			} else if(identityAuthor.getFirstName() != null
+					&&
+					articleAuthorName.getFirstName() != null
+					&&
 					articleAuthorName.getFirstName().toLowerCase().matches("(.*)" + identityAuthor.getFirstName().toLowerCase())) {
 				//Attempt match where "%" + identity.firstName = article.firstName
 				//Example: Cary (identity.firstName) = MCary (article.firstName)
-				authorNameEvidence.setNameMatchFirstType("full-exact");
-				authorNameEvidence.setNameMatchFirstScore(ReCiterArticleScorer.strategyParameters.getNameMatchFirstTypeFullExactScore());
+				//A right-anchored suffix is not an exact match either. See issue #746.
+				//Unlike the prefix direction this bucket is NOT split by identity name
+				//length: a trailing single letter is a coincidence, not an inferred
+				//initial, so there is no initials bucket it could honestly move to.
+				authorNameEvidence.setNameMatchFirstType("full-suffix");
+				authorNameEvidence.setNameMatchFirstScore(ReCiterArticleScorer.strategyParameters.getNameMatchFirstTypeFullSuffixScore());
 				authorNameEvidence.setNameMatchMiddleType("noMatch");
 				authorNameEvidence.setNameMatchMiddleScore(ReCiterArticleScorer.strategyParameters.getNameMatchMiddleTypeNoMatchScore());
 				authorNameEvidence.setNameMatchModifier("identitySubstringOfArticle-firstName");
 				authorNameEvidence.setNameMatchModifierScore(ReCiterArticleScorer.strategyParameters.getNameMatchModifierIdentitySubstringOfArticleFirstnameScore());
-			} else if(identityAuthor.getFirstName() != null 
+			} else if(identityAuthor.getFirstName() != null
 					&& 
 					identityAuthor.getMiddleName() != null 
 					&& 

--- a/src/main/java/reciter/engine/StrategyParameters.java
+++ b/src/main/java/reciter/engine/StrategyParameters.java
@@ -91,6 +91,35 @@ public class StrategyParameters {
     @Value("${nameMatchFirstType.inferredInitials-exact}")
     private double nameMatchFirstTypeInferredInitialsExactScore;
 
+    /**
+     * Score for a registered first name of two or more characters that is a
+     * left-anchored prefix of the article first name (Paul -> PaulJames, but
+     * also Shuo -> Shuofei). Before issue #746 these rows were labelled
+     * "full-exact"; the label is now honest but the score deliberately defaults
+     * to the same value so relabelling changes no model input. Retuning this
+     * number is a separate, retrain-gated change.
+     */
+    @Value("${nameMatchFirstType.full-prefix:1.852}")
+    private double nameMatchFirstTypeFullPrefixScore;
+
+    /**
+     * Score for a registered first name of two or more characters that is a
+     * right-anchored suffix of the article first name (Cary -> MCary). Same
+     * relabel-only contract as {@code full-prefix}.
+     */
+    @Value("${nameMatchFirstType.full-suffix:1.852}")
+    private double nameMatchFirstTypeFullSuffixScore;
+
+    /**
+     * Score for a registered first name that sanitizes down to a SINGLE letter
+     * and merely begins the article first name ('M.' -> M, matching "Mayra").
+     * Semantically this is an initial match and belongs in the
+     * inferredInitials-exact bucket (0.441), but the default preserves the
+     * pre-#746 value so the relabel ships without moving a model feature.
+     */
+    @Value("${nameMatchFirstType.inferredInitials-prefix:1.852}")
+    private double nameMatchFirstTypeInferredInitialsPrefixScore;
+
     @Value("${nameMatchFirstType.full-fuzzy}")
     private double nameMatchFirstTypeFullFuzzyScore;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -171,6 +171,21 @@ strategy.education.year.discrepancy=true
 
 nameMatchFirstType.full-exact=1.852
 nameMatchFirstType.inferredInitials-exact=0.441
+# Issue #746. Three buckets split out of full-exact so the diagnostic string
+# stops claiming an exact match it never made. Each DEFAULTS TO THE full-exact
+# VALUE (1.852) so the relabel alone moves no model input; retuning any of them
+# is a separate change that needs a model retrain plus an evaluation sweep,
+# because nameMatchFirstScore is a numeric feature in both deployed models AND
+# the type string itself feeds nameMatchTypeOrdinal in the scoring Lambda.
+#   full-prefix             registered first name (>=2 chars) begins the byline
+#                           first name: Paul->PaulJames, but also Shuo->Shuofei
+#   full-suffix             registered first name (>=2 chars) ends it: Cary->MCary
+#   inferredInitials-prefix registered first name is a SINGLE letter that begins
+#                           the byline first name: 'M.'->Mayra. Semantically an
+#                           initial match; the honest score is 0.441, deferred.
+nameMatchFirstType.full-prefix=1.852
+nameMatchFirstType.full-suffix=1.852
+nameMatchFirstType.inferredInitials-prefix=1.852
 nameMatchFirstType.full-fuzzy=-0.75
 nameMatchFirstType.noMatch=-1.941
 nameMatchFirstType.full-conflictingAllButInitials=-2.646

--- a/src/test/java/reciter/algorithm/evidence/targetauthor/name/strategy/ScoreByNameStrategyFirstNamePrefixTest.java
+++ b/src/test/java/reciter/algorithm/evidence/targetauthor/name/strategy/ScoreByNameStrategyFirstNamePrefixTest.java
@@ -1,0 +1,286 @@
+package reciter.algorithm.evidence.targetauthor.name.strategy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import reciter.algorithm.cluster.article.scorer.ReCiterArticleScorer;
+import reciter.engine.StrategyParameters;
+import reciter.engine.analysis.evidence.AuthorNameEvidence;
+import reciter.model.article.ReCiterAuthor;
+import reciter.model.identity.AuthorName;
+
+/**
+ * Regression tests for issue #746: the first-name matcher labelled a left-anchored
+ * PREFIX match as {@code full-exact}, so a byline of "Shuofei" was reported as an exact
+ * match against a registered "Shuo".
+ *
+ * <p>The two scoring entry points are private, so they are driven by reflection with a
+ * hand-built {@link StrategyParameters}; that keeps the test on the pure name-matching
+ * cascade with no Spring context, no DynamoDB and no retrieval stack.</p>
+ *
+ * <p>Every case asserts the emitted SCORE as well as the type string. The relabel is
+ * required to be numerically inert: {@code nameMatchFirstScore} is a model feature in
+ * both deployed pipelines, so a changed number here would silently shift a feature
+ * distribution the 72/47-feature models were trained on.</p>
+ */
+public class ScoreByNameStrategyFirstNamePrefixTest {
+
+	/** Values taken from src/main/resources/application.properties. */
+	private static final double FULL_EXACT = 1.852;
+	private static final double INFERRED_INITIALS_EXACT = 0.441;
+	private static final double FULL_FUZZY = -0.75;
+	private static final double NO_MATCH = -1.941;
+	private static final double CONFLICTING_ALL_BUT_INITIALS = -2.646;
+	private static final double CONFLICTING_ENTIRELY = -3.087;
+	private static final double MIDDLE_IDENTITY_NULL = 0.794;
+	private static final double MIDDLE_NO_MATCH = -0.794;
+	private static final double MODIFIER_IDENTITY_SUBSTRING_OF_ARTICLE_FIRST = -1.608;
+
+	private ScoreByNameStrategy strategy;
+	private Method scoreFirstNameMiddleNameNull;
+	private Method scoreFirstNameMiddleName;
+
+	@Before
+	public void setUp() throws Exception {
+		StrategyParameters params = new StrategyParameters();
+		// Read by the ScoreByNameStrategy field initializer.
+		params.setNameExcludedSuffixes("Jr,Jr.,MD PhD,MD-PhD,PhD,MD,III,III.,II,II.,Sr,Sr.");
+
+		params.setNameMatchFirstTypeFullExactScore(FULL_EXACT);
+		params.setNameMatchFirstTypeInferredInitialsExactScore(INFERRED_INITIALS_EXACT);
+		params.setNameMatchFirstTypeFullFuzzyScore(FULL_FUZZY);
+		params.setNameMatchFirstTypeNoMatchScore(NO_MATCH);
+		params.setNameMatchFirstTypeFullConflictingAllButInitialsScore(CONFLICTING_ALL_BUT_INITIALS);
+		params.setNameMatchFirstTypeFullConflictingEntirelyScore(CONFLICTING_ENTIRELY);
+		// #746 buckets, defaulted to the full-exact value exactly as shipped.
+		params.setNameMatchFirstTypeFullPrefixScore(FULL_EXACT);
+		params.setNameMatchFirstTypeFullSuffixScore(FULL_EXACT);
+		params.setNameMatchFirstTypeInferredInitialsPrefixScore(FULL_EXACT);
+
+		params.setNameMatchMiddleTypeIdentityNullMatchNotAttemptedScore(MIDDLE_IDENTITY_NULL);
+		params.setNameMatchMiddleTypeNoMatchScore(MIDDLE_NO_MATCH);
+		params.setNameMatchModifierIdentitySubstringOfArticleFirstnameScore(
+				MODIFIER_IDENTITY_SUBSTRING_OF_ARTICLE_FIRST);
+
+		ReCiterArticleScorer.strategyParameters = params;
+
+		strategy = new ScoreByNameStrategy();
+		scoreFirstNameMiddleNameNull = ScoreByNameStrategy.class.getDeclaredMethod(
+				"scoreFirstNameMiddleNameNull", AuthorName.class, AuthorName.class,
+				Map.class, AuthorNameEvidence.class);
+		scoreFirstNameMiddleNameNull.setAccessible(true);
+		scoreFirstNameMiddleName = ScoreByNameStrategy.class.getDeclaredMethod(
+				"scoreFirstNameMiddleName", AuthorName.class, AuthorName.class,
+				Map.class, AuthorNameEvidence.class);
+		scoreFirstNameMiddleName.setAccessible(true);
+	}
+
+	// ---- helpers -----------------------------------------------------------
+
+	/**
+	 * Builds a name the way AuthorNameSanitizationUtils leaves one: periods, spaces and
+	 * dashes already stripped, initials derived from the surviving characters.
+	 */
+	private static AuthorName name(String first, String middle, String last) {
+		AuthorName n = new AuthorName();
+		n.setFirstName(first);
+		n.setMiddleName(middle);
+		n.setLastName(last);
+		if (first != null && !first.isEmpty()) {
+			n.setFirstInitial(first.substring(0, 1));
+		}
+		if (middle != null && !middle.isEmpty()) {
+			n.setMiddleInitial(middle.substring(0, 1));
+		}
+		return n;
+	}
+
+	private static Map<ReCiterAuthor, ReCiterAuthor> articleAuthor(AuthorName articleName) {
+		ReCiterAuthor author = new ReCiterAuthor(articleName, null);
+		author.setTargetAuthor(true);
+		Map<ReCiterAuthor, ReCiterAuthor> map = new LinkedHashMap<>();
+		map.put(author, author);
+		return map;
+	}
+
+	/** Runs the middle-name-is-null cascade (scoreFirstNameMiddleNameNull). */
+	private AuthorNameEvidence scoreMiddleNull(String identityFirst, String identityLast,
+			String articleFirst, String articleLast) throws Exception {
+		AuthorName identity = name(identityFirst, null, identityLast);
+		AuthorNameEvidence evidence = new AuthorNameEvidence();
+		scoreFirstNameMiddleNameNull.invoke(strategy, identity, identity,
+				articleAuthor(name(articleFirst, null, articleLast)), evidence);
+		return evidence;
+	}
+
+	/** Runs the middle-name-present cascade (scoreFirstNameMiddleName). */
+	private AuthorNameEvidence scoreWithMiddle(String identityFirst, String identityMiddle,
+			String identityLast, String articleFirst, String articleLast) throws Exception {
+		AuthorName identity = name(identityFirst, identityMiddle, identityLast);
+		AuthorNameEvidence evidence = new AuthorNameEvidence();
+		scoreFirstNameMiddleName.invoke(strategy, identity, identity,
+				articleAuthor(name(articleFirst, null, articleLast)), evidence);
+		return evidence;
+	}
+
+	private static void assertFirst(AuthorNameEvidence e, String type, double score) {
+		assertEquals("nameMatchFirstType", type, e.getNameMatchFirstType());
+		assertEquals("nameMatchFirstScore", score, e.getNameMatchFirstScore(), 1e-9);
+	}
+
+	// ---- the defect --------------------------------------------------------
+
+	/**
+	 * The reported case. "Shuo" is a registered first name; "Shuofei" is a different
+	 * given name that happens to begin with it. Before #746 this was reported as
+	 * full-exact, indistinguishable from a real exact match.
+	 */
+	@Test
+	public void shuoAgainstShuofeiIsAPrefixNotAnExactMatch() throws Exception {
+		AuthorNameEvidence e = scoreMiddleNull("Shuo", "Chen", "Shuofei", "Chen");
+		assertFirst(e, "full-prefix", FULL_EXACT);
+		assertEquals("identitySubstringOfArticle-firstName", e.getNameMatchModifier());
+		assertEquals(MODIFIER_IDENTITY_SUBSTRING_OF_ARTICLE_FIRST,
+				e.getNameMatchModifierScore(), 1e-9);
+	}
+
+	/** The branch's intended case (a glued first+middle byline) must still match. */
+	@Test
+	public void paulAgainstPaulJamesStillMatchesAsAPrefix() throws Exception {
+		AuthorNameEvidence e = scoreMiddleNull("Paul", "Albert", "PaulJames", "Albert");
+		assertFirst(e, "full-prefix", FULL_EXACT);
+		assertEquals("identityNull-MatchNotAttempted", e.getNameMatchMiddleType());
+		assertEquals("identitySubstringOfArticle-firstName", e.getNameMatchModifier());
+	}
+
+	/**
+	 * The single-letter class: a registered name that sanitized down to one letter
+	 * ('M.' -> "M") merely BEGINS the byline. That is an initial match, not an exact
+	 * one, and it gets its own bucket rather than falling through to a negative one.
+	 */
+	@Test
+	public void singleLetterRegisteredNameAgainstFullBylineIsAnInferredInitial() throws Exception {
+		AuthorNameEvidence e = scoreMiddleNull("M", "Rivera", "Mayra", "Rivera");
+		assertFirst(e, "inferredInitials-prefix", FULL_EXACT);
+		assertEquals("identitySubstringOfArticle-firstName", e.getNameMatchModifier());
+	}
+
+	/**
+	 * Guard for the fall-through trap: if the prefix branch had simply been guarded on
+	 * length >= 2, "M" vs "Mayra" would have skipped the three-character and Levenshtein
+	 * branches and landed on full-conflictingAllButInitials (-2.646) -- worse than the
+	 * status quo, and a numeric change.
+	 */
+	@Test
+	public void singleLetterClassDoesNotFallThroughToAConflictBucket() throws Exception {
+		AuthorNameEvidence e = scoreMiddleNull("M", "Rivera", "Mayra", "Rivera");
+		assertTrue("must not land in a negative bucket", e.getNameMatchFirstScore() > 0);
+		assertEquals(FULL_EXACT, e.getNameMatchFirstScore(), 1e-9);
+	}
+
+	// ---- directions and buckets that must NOT change ------------------------
+
+	/** The reverse direction was already correct and stays correct. */
+	@Test
+	public void articleInitialAgainstFullRegisteredNameStaysInferredInitialsExact() throws Exception {
+		AuthorNameEvidence e = scoreMiddleNull("Paul", "Albert", "P", "Albert");
+		assertFirst(e, "inferredInitials-exact", INFERRED_INITIALS_EXACT);
+		assertNull("reverse direction sets no modifier", e.getNameMatchModifier());
+	}
+
+	/** A genuine exact match is still full-exact. */
+	@Test
+	public void exactFirstNameStaysFullExact() throws Exception {
+		AuthorNameEvidence e = scoreMiddleNull("Paul", "Albert", "Paul", "Albert");
+		assertFirst(e, "full-exact", FULL_EXACT);
+		assertNull(e.getNameMatchModifier());
+	}
+
+	/** A non-match is still the terminal conflict bucket. */
+	@Test
+	public void unrelatedFirstNamesStayFullConflictingEntirely() throws Exception {
+		AuthorNameEvidence e = scoreMiddleNull("Pascale", "Albert", "Curtis", "Albert");
+		assertFirst(e, "full-conflictingEntirely", CONFLICTING_ENTIRELY);
+	}
+
+	/** Same initial, different name: unchanged. */
+	@Test
+	public void sameInitialDifferentNameStaysConflictingAllButInitials() throws Exception {
+		AuthorNameEvidence e = scoreMiddleNull("Paul", "Albert", "Peter", "Albert");
+		assertFirst(e, "full-conflictingAllButInitials", CONFLICTING_ALL_BUT_INITIALS);
+	}
+
+	// ---- the middle-name-present cascade -----------------------------------
+
+	/** The regex prefix branch (identity.firstName + "%") shares the defect. */
+	@Test
+	public void regexPrefixBranchReportsFullPrefix() throws Exception {
+		AuthorNameEvidence e = scoreWithMiddle("Robert", "Q", "Smith", "RobertR", "Smith");
+		assertFirst(e, "full-prefix", FULL_EXACT);
+		assertEquals("noMatch", e.getNameMatchMiddleType());
+		assertEquals("identitySubstringOfArticle-firstName", e.getNameMatchModifier());
+	}
+
+	/** The regex prefix branch also carries the single-letter class. */
+	@Test
+	public void regexPrefixBranchSplitsTheSingleLetterClass() throws Exception {
+		AuthorNameEvidence e = scoreWithMiddle("M", "Q", "Smith", "Mayra", "Smith");
+		assertFirst(e, "inferredInitials-prefix", FULL_EXACT);
+	}
+
+	/** The regex suffix branch ("%" + identity.firstName) gets its own honest label. */
+	@Test
+	public void regexSuffixBranchReportsFullSuffix() throws Exception {
+		AuthorNameEvidence e = scoreWithMiddle("Cary", "Q", "Smith", "MCary", "Smith");
+		assertFirst(e, "full-suffix", FULL_EXACT);
+		assertEquals("noMatch", e.getNameMatchMiddleType());
+		assertEquals("identitySubstringOfArticle-firstName", e.getNameMatchModifier());
+	}
+
+	/** An exact first name in the middle-present cascade is untouched. */
+	@Test
+	public void exactFirstNameWithMiddlePresentStaysFullExact() throws Exception {
+		AuthorNameEvidence e = scoreWithMiddle("Paul", "J", "Smith", "Paul", "Jones");
+		assertFirst(e, "full-exact", FULL_EXACT);
+	}
+
+	// ---- the numeric contract ----------------------------------------------
+
+	/**
+	 * The shipped defaults must keep the three new buckets numerically identical to
+	 * full-exact. Retuning any of them changes nameMatchFirstScore, a feature in both
+	 * deployed models, and also nameMatchTypeOrdinal in the scoring Lambda -- neither
+	 * can move without a retrain. If someone edits a value, this test is the tripwire.
+	 */
+	@Test
+	public void newBucketsShipAtTheFullExactValue() throws Exception {
+		Properties props = new Properties();
+		try (InputStream in = getClass().getClassLoader()
+				.getResourceAsStream("application.properties")) {
+			assertNotNull("application.properties must be on the test classpath", in);
+			props.load(in);
+		}
+		String fullExact = props.getProperty("nameMatchFirstType.full-exact");
+		assertNotNull(fullExact);
+		for (String key : new String[] { "nameMatchFirstType.full-prefix",
+				"nameMatchFirstType.full-suffix",
+				"nameMatchFirstType.inferredInitials-prefix" }) {
+			String value = props.getProperty(key);
+			assertNotNull(key + " must be declared", value);
+			assertEquals(key + " must still equal nameMatchFirstType.full-exact; "
+					+ "changing it requires a model retrain (issue #746)",
+					Double.parseDouble(fullExact), Double.parseDouble(value), 1e-9);
+		}
+	}
+}


### PR DESCRIPTION
Addresses #746. **Relabels only — the retune is deferred, so this does not close the issue.**

**Blocked on wcmc-its/ReCiter---Scoring#25.** That must be merged and deployed to the same environment first; see "The premise in #746 is wrong" below. Do not merge this one alone.

## The defect

`ScoreByNameStrategy` set `nameMatchFirstType = "full-exact"` on three branches that only ever established a prefix or suffix relationship:

| where | predicate | example the comment gives | example it also fires on |
|---|---|---|---|
| `scoreFirstNameMiddleNameNull` :325 | `article.first.startsWith(identity.first)` | Paul -> PaulJames | **Shuo -> Shuofei**, `'M.'` -> Mayra |
| `scoreFirstNameMiddleName` :620 | `article.first.matches(identity.first + "(.*)")` | Robert -> RobertR | same |
| `scoreFirstNameMiddleName` :633 | `article.first.matches("(.*)" + identity.first)` | Cary -> MCary | Kim matched by a registered `M` |

Each branch does set a compensating `nameMatchModifier = identitySubstringOfArticle-firstName` (-1.608), but that lands in a **different** feature. `nameMatchFirstType` and `nameMatchFirstScore` were byte-for-byte identical to a genuine exact match, so no consumer — the scoring input, `person_article`, Publication Manager, a human reading the evidence — could tell "Shuo" matching "Shuofei" from "Shuo" matching "Shuo".

Note the asymmetry that made this obvious: the very next branch (:336), article-name-is-a-prefix-of-identity-name (`Paul` -> `P`), already reports `inferredInitials-exact` (0.441). Only the reverse direction over-claimed.

## The premise in #746 is wrong, and it matters

#746 states that changing the type string is model-safe because `nameMatchFirstType` is diagnostic and not a member of the 72/47 feature lists. It is not safe. `ReCiter---Scoring/app/preprocessing.py` maps the string into `nameMatchTypeOrdinal`, which **is** in both lists, via a lookup ending in `.fillna(2.0)` — so an unmapped label does not raise, it silently becomes 2.0 (the `noMatch` ordinal) instead of 5.0.

Measured on 365 live S3 scoring inputs (48,337 article-rows) against the models in the deployed prod Lambda image `master-68.2026-03-18.20.54.55.ff52638e`:

| shipped | rows whose final score changed | max abs delta |
|---|---|---|
| this PR alone | **34** (23 feedback + 11 identity-only) | **18.02 pts** (`yoy4001`/37152781, 52.500 -> 34.483) |
| this PR + Scoring#25 | **0** | **0.000000000000000** |

This is the same trap that stopped #747. Merge order is not optional.

## What this PR does

Three honest buckets, each with its own property **defaulting to the current `full-exact` value of 1.852**:

```properties
nameMatchFirstType.full-prefix=1.852
nameMatchFirstType.full-suffix=1.852
nameMatchFirstType.inferredInitials-prefix=1.852
```

- **`full-prefix`** — registered first name of >= 2 chars begins the byline first name. Covers both the intended glued-name case (Paul -> PaulJames) and the false one (Shuo -> Shuofei); those are indistinguishable from name strings alone, which is exactly why the score is left alone pending evaluation.
- **`full-suffix`** — registered first name of >= 2 chars ends it (Cary -> MCary). Not split by length: a trailing single letter is a coincidence, not an inferred initial, so there is no initials bucket it could honestly move to.
- **`inferredInitials-prefix`** — registered first name is a **single letter** that begins the byline first name (`'M.'` sanitizes to `M`, matching "Mayra"). This is #746's 5,282-row / 62-person class. It is semantically an initial match and its correct score is `inferredInitials-exact` (0.441), but moving it there is a numeric change and is deferred.

No predicate is touched. Each branch keeps its exact condition and its middle-name type/score and modifier; only the first-name type/score assignment is split, via a new `assignFirstNamePrefixEvidence` helper shared by the two prefix branches.

### Why the single-letter class gets its own branch, not a length guard

#746 warns about this and the warning is correct. Guarding the prefix branch on `length >= 2` and letting `M` / `Mayra` fall through lands it here (traced through `scoreFirstNameMiddleNameNull`):

| next branch | predicate | fires for M/Mayra? |
|---|---|---|
| :336 | `identity.first.startsWith(article.first)` | `"m".startsWith("mayra")` — no |
| :345 | both names >= 3 chars, first 3 equal | identity is 1 char — no |
| :358 | identity >= 4 chars, Levenshtein == 1 | no |
| :368 | `firstInitial` equal | **yes -> `full-conflictingAllButInitials`, -2.646** |

So the "cheap" fix would have moved 5,282 rows from +1.852 to -2.646 — worse than the status quo, and a numeric change requiring a retrain. A dedicated branch keeps the score where it is and still tells the truth in the label.

## Verification

**Numeric inertness, exhaustively enumerated.** An 11,520-case sweep of both first-name cascades (30 registered first names x 6 middle-name variants x 32 byline first names x 2 surnames), run against the pre-change source and against this branch, then diffed:

```
enumerated cases: 11520
rows where ANY emitted score differs: 0
rows where nameMatchMiddleType or nameMatchModifier differs: 0
```

| before -> after | cases | nameMatchFirstScore | nameMatchMiddleScore | nameMatchModifierScore |
|---|---|---|---|---|
| `full-exact` -> `full-prefix` | 536 | 1.852 -> 1.852 | 0.794 -> 0.794 | -1.608 -> -1.608 |
| `full-exact` -> `inferredInitials-prefix` | 160 | 1.852 -> 1.852 | 0.794 -> 0.794 | -1.608 -> -1.608 |
| `full-exact` -> `full-suffix` | 80 | 1.852 -> 1.852 | -0.794 -> -0.794 | -1.608 -> -1.608 |

Every other case is unchanged in both label and score. `nameMatchFirstScore`, `nameMatchMiddleScore`, `nameMatchLastScore`, `nameMatchModifierScore` and `nameScoreTotal` are identical in all 11,520.

That table also enumerates the answer to "which code paths could emit a different number": the three rows above are the only paths whose output changes at all, and all three change the string only. The remaining `full-exact` emitters (:213, :288, :303, :418, :431, :446, :459, :505, :521, :536, :549 for the first name) are untouched.

**End-to-end, on the deployed models.** 224 feedback + 141 identity-only real S3 inputs replayed with the six joblib files from `ReCiter---Scoring@ff52638e` (feedback scaler `n_features_in_ = 72`, xgboost `[3, 2, 0]`), every `full-exact` row rewritten to each new label in turn, `data/name_frequency.json` loaded:

```
 feedback:  224 people,  33538 article-rows,   7977 rows relabelled -> rows with ANY score change: 0, max |delta| = 0.000000000000000
 identity:  141 people,  14799 article-rows,   1382 rows relabelled -> rows with ANY score change: 0, max |delta| = 0.000000000000000
TOTAL: 48337 article-rows, 0 changed
```

**Tests.** New `ScoreByNameStrategyFirstNamePrefixTest`, 13 cases: Shuo/Shuofei, Paul/PaulJames, `M`/Mayra (plus an explicit assertion it does not land in a negative bucket), Paul/`P` (reverse direction stays `inferredInitials-exact`), Paul/Paul (stays `full-exact`), Paul/Peter, Pascale/Curtis, the regex prefix and suffix branches, and a contract test that reads `application.properties` and fails if any of the three new keys stops equalling `nameMatchFirstType.full-exact`.

```
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0 -- ScoreByNameStrategyFirstNamePrefixTest
[INFO] Tests run: 384, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Mutation-checked: reverting the three branches to `full-exact` while keeping the tests fails exactly 6 of the 13, so they are load-bearing rather than tautological. `ApplicationContextSmokeTest` passes, which exercises the new `@Value` bindings against the real properties file.

Commands run, all exit 0: `mvn -o -q -DskipTests compile`, `mvn -o -Dtest=ScoreByNameStrategyFirstNamePrefixTest test`, `mvn -o test`, under `JAVA_HOME=/opt/homebrew/opt/openjdk@17` (17.0.18).

**Downstream consumers of the literal.** Searched for anything branching on `"full-exact"` for the first name:

| consumer | reads it? | verdict |
|---|---|---|
| `ScoreByNameStrategy:82` | null-check only; the `equalsIgnoreCase("full-exact")` at :108 is on `nameMatchMiddleType`, untouched | safe |
| `ReCiterArticleScorer:370` | copies the string into the scoring-input JSON | pass-through |
| `ReCiter---Scoring/app/preprocessing.py` | **maps it to `nameMatchTypeOrdinal`, a numeric feature** | **handled by Scoring#25** |
| ReCiterDB `dataTransformer.py:284`, `updateReciterDB.py:283` | column passthrough into `person_article.nameMatchFirstType` (`varchar(128)`) | safe, no branching |
| Publication Manager `src/db/models/PersonArticle.ts` | Sequelize column definition only | safe, no branching |
| ReCiter-Institutional-Client | no occurrence | safe |

## Not done / owed

- **The retune is not in this PR.** Every new bucket ships at 1.852. Moving `inferredInitials-prefix` to 0.441 (the semantically correct value), and deciding whether `full-prefix` deserves less than a true exact match, needs a retrain plus an evaluation sweep. That is why this does not say `Closes #746` — please leave the issue open, narrowed to the retune. The properties and the tripwire assertion in Scoring#25 are the whole mechanism for doing it as a one-line change later.
- **Owed port to `origin/development`**, together with the same `dev_v2` change in the scoring repo. `development` is behind this branch, so the port is not automatic.
- **Not verified:** no deploy, no `feature-generator` call against `reciter-dev` or `reciter-prod`, no Lambda invocation from either branch. Everything above is local compile, local tests, and offline replay against the deployed model artifacts.
- **An empty registered first name** (a name that sanitizes to `""`) still matches every byline via `startsWith("")` and now reports `full-prefix`. That is unchanged behaviour and a separate bug; it is out of scope here because any different routing would be a numeric change.

## Merge order

1. wcmc-its/ReCiter---Scoring#25 -> `master`, deploy `reciter-scoring-prod`, confirm scores unchanged for a known uid.
2. This PR -> `MigrationFromJDk11ToAWSCorretto17`.
3. Port both to `development` / `dev_v2`.
